### PR TITLE
fix blackscholes.jl script

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,7 @@
 julia 0.5
 StaticArrays
 Compat 0.19.0
+ColorTypes
 
 Transpiler 0.0.1
 Sugar 0.0.3

--- a/examples/blackscholes.jl
+++ b/examples/blackscholes.jl
@@ -65,7 +65,8 @@ end
 
 # add BenchmarkTools with Pkg.add("BenchmarkTools")
 using BenchmarkTools
-benchmarks = Dict()
+import BenchmarkTools: Trial
+benchmarks = Dict{Symbol, Vector{Trial}}()
 for n in 1:7
     N = 10^n
     sptprice   = Float32[42.0 for i = 1:N]
@@ -84,7 +85,7 @@ for n in 1:7
         _result = GPUArray(result)
         f = backend == :cudanative ? cu_blackscholes : blackscholes
         b = @benchmark runbench($f, $_result, $_sptprice, $_initStrike, $_rate, $_volatility, $_time)
-        benches = get!(benchmarks, backend, [])
+        benches = get!(benchmarks, backend, Trial[])
         push!(benches, b)
         @assert Array(_result) ≈ comparison
         # this is optional, but needed in a loop like this, which allocates a lot of GPUArrays
@@ -95,8 +96,7 @@ end
 # Plot results:
 # Pkg.add("Plots")
 using Plots
-benchmarks = benchy
-labels = String.(keys(benchmarks))
+labels = (String(k) for k in keys(benchmarks))
 times = map(values(benchmarks)) do v
     map(x-> minimum(x).time, v)
 end

--- a/examples/blackscholes.jl
+++ b/examples/blackscholes.jl
@@ -1,4 +1,13 @@
 # you might need to add SpecialFunctions with Pkg.add("SpecialFunctions")
+
+if Pkg.installed("BenchmarkTools") == nothing ||
+   Pkg.installed("Query") == nothing ||
+   Pkg.installed("CUDAnative") == nothing ||
+   Pkg.installed("DataFrames") == nothing
+
+   error("Please install BenchmarkTools, Query, CUDAnative and DataFrames")
+end
+
 using GPUArrays, SpecialFunctions
 using GPUArrays: perbackend, synchronize, free
 
@@ -62,8 +71,6 @@ function runbench(f, out, a, b, c, d, e)
 end
 
 
-
-# add BenchmarkTools with Pkg.add("BenchmarkTools")
 using BenchmarkTools
 import BenchmarkTools: Trial
 using DataFrames
@@ -135,21 +142,20 @@ end
 
 # Plot results:
 @static if VERSION < v"0.6.0-dev" &&
-           Pkg.installed("Plots") != ""
+           Pkg.installed("Plots") != nothing
+   using Plots
 
-using Plots
+   df7 = filterResults(results, 7)
+   labels = df7[:Backend]
+   times = df7[:minT]
 
-df7 = filterResults(results, 7)
-labels = df7[:Backend]
-times = df7[:minT]
-
-p2 = plot(
-   times,
-   m = (5, 0.8, :circle, stroke(0)),
-   line = 1.5,
-   labels = reshape(labels, (1, length(label))),
-   title = "blackscholes",
-   xaxis = ("10^N"),
-   yaxis = ("Time in Seconds")
-)
+   p2 = plot(
+      times,
+      m = (5, 0.8, :circle, stroke(0)),
+      line = 1.5,
+      labels = reshape(labels, (1, length(label))),
+      title = "blackscholes",
+      xaxis = ("10^N"),
+      yaxis = ("Time in Seconds")
+   )
 end


### PR DESCRIPTION
Results:

`JULIA_NUM_THREADS=12 ./julia ~/.julia/v0.6/GPUArrays/examples/blackscholes.jl `

| Backend | Time in Seconds N = 10^7 |
| ---- | ---- |
| cudanative | 1.094576e6 |
| opencl | 8.769266e6 |
| 12x julia | 1.25552062e8 |
| 6x julia |  1.72999036e8|
| 1x julia |  9.98053842e8 |

CPU:  Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz
GPU: Nvidia M6000

```
odin:~> lscpu
Architecture:          x86_64
CPU op-mode(s):        32-bit, 64-bit
Byte Order:            Little Endian
CPU(s):                12
On-line CPU(s) list:   0-11
Thread(s) per core:    2
Core(s) per socket:    6
Socket(s):             1
NUMA node(s):          1
...
CPU max MHz:           3700.0000
CPU min MHz:           1200.0000
...
L1d cache:             32K
L1i cache:             32K
L2 cache:              256K
L3 cache:              20480K
```

Which OpenCL device is GPU Arrays picking per default?