### PR TITLE
Make blackscholes benchmark script a little bit more flexible.

### DIFF
--- a/examples/blackscholes.jl
+++ b/examples/blackscholes.jl
@@ -84,15 +84,22 @@ using Query
 # Pkg.checkout("Query")
 # Pkg.checkout("SimpleTraits")
 
-Nmax = 7
+Nmax = haskey(ENV, "GPUARRAYS_BENCH_NMAX") ? parse(Int, ENV["GPUARRAYS_BENCH_NMAX"]) : 7
+backends = haskey(ENV, "GPUARRAYS_BENCH_BACKENDS") ?
+             map(Symbol, split(ENV["GPUARRAYS_BENCH_BACKENDS"])) :
+             collect(supported_backends())
+
+info("Running benchmarks on $backends to a maximum N of $(10^Nmax)")
+NT = Base.Threads.nthreads()
+if :julia ∈ backends
+    info("Running benchmarks $NT threads.")
+end
 
 benchmarks = DataFrame([String, Int64, Trial, Float64], [:Backend, :N, :Trial, :minT], 0)
 
-NT = Base.Threads.nthreads()
-info("Running benchmarks number of threads: $NT")
-
 for n in 1:Nmax
     N = 10^n
+    info("Running benchmark for N=$N")
     sptprice   = Float32[42.0 for i = 1:N]
     initStrike = Float32[40.0 + (i / N) for i = 1:N]
     rate       = Float32[0.5 for i = 1:N]
@@ -100,30 +107,31 @@ for n in 1:Nmax
     spttime    = Float32[0.5 for i = 1:N]
     result     = similar(spttime)
     comparison = blackscholes.(sptprice, initStrike, rate, volatility, spttime)
-    perbackend() do backend # nice to go through all backends, but for benchmarks we might want to have this more explicit!
-        if true #backend == :julia
-            _sptprice = GPUArray(sptprice)
-            _initStrike = GPUArray(initStrike)
-            _rate = GPUArray(rate)
-            _volatility = GPUArray(volatility)
-            _time = GPUArray(spttime)
-            _result = GPUArray(result)
-            f = backend == :cudanative ? cu_blackscholes : blackscholes
-            b = @benchmark runbench($f, $_result, $_sptprice, $_initStrike, $_rate, $_volatility, $_time)
-            ctx_str = sprint() do io
-                show(io, GPUArrays.current_context())
-            end
-            push!(benchmarks, (ctx_str, N, b, minimum(b).time))
 
-            @assert Array(_result) ≈ comparison
-            # this is optional, but needed in a loop like this, which allocates a lot of GPUArrays
-            # for the future, we need a way to tell the Julia gc about GPU memory
-            free(_sptprice);free(_initStrike);free(_rate);free(_volatility);free(_time);free(_result);
+    for backend in backends
+        ctx = GPUArrays.init(backend)
+
+        _sptprice = GPUArray(sptprice)
+        _initStrike = GPUArray(initStrike)
+        _rate = GPUArray(rate)
+        _volatility = GPUArray(volatility)
+        _time = GPUArray(spttime)
+        _result = GPUArray(result)
+        f = backend == :cudanative ? cu_blackscholes : blackscholes
+        b = @benchmark runbench($f, $_result, $_sptprice, $_initStrike, $_rate, $_volatility, $_time)
+        ctx_str = sprint() do io
+            show(io, GPUArrays.current_context())
         end
+        push!(benchmarks, (ctx_str, N, b, minimum(b).time))
+
+        @assert Array(_result) ≈ comparison
+        # this is optional, but needed in a loop like this, which allocates a lot of GPUArrays
+        # for the future, we need a way to tell the Julia gc about GPU memory
+        free(_sptprice); free(_initStrike); free(_rate); free(_volatility); free(_time); free(_result);
     end
 end
 
-results = @from b in benchmarks begin
+benchmark_results = @from b in benchmarks begin
    @select {b.Backend, b.N, b.minT}
    @collect DataFrame
 end
@@ -133,18 +141,19 @@ results = cd(dirname(@__FILE__)) do
     # merge
     merged = if isfile(file)
         merged = readtable(file)
-        backends = unique(merged[:Backend])
-        benched_backends = unique(results[:Backend])
-        to_add = setdiff(benched_backends, backends)
-        for i in 1:size(results, 1)
-            row = results[i, :]
-            if row[:Backend][1] in to_add
-                append!(merged, row)
-            end
+        prev_backends = unique(merged[:Backend])
+        prev_Nmax = maximum(merged[:N])
+
+        results = @from r in benchmark_results begin
+          @where r.Backend ∉ prev_backends || # add new backends
+                 r.N > prev_Nmax # add new results from old backends
+          @select r
+          @collect DataFrame
         end
-        merged
+
+        vcat(merged, results)
     else
-        results
+        benchmark_results
     end
     writetable(file, merged)
     merged
@@ -167,7 +176,7 @@ for n in 1:Nmax
    for row in eachrow(df)
       b = row[:Backend]
       t = row[:minT]
-      @printf(io, "| %s | %6.2f μs|\n", b, t / 10^9)
+      @printf(io, "| %s | %6.2f μs|\n", b, t)
    end
    display(Markdown.parse(io))
    seekstart(io)

--- a/examples/blackscholes_results.csv
+++ b/examples/blackscholes_results.csv
@@ -69,3 +69,17 @@
 "JLContext","Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 1 threads",10000000,9.31366734e8
 "CUContext","Quadro M6000",10000000,1.092519e6
 "CLContext","Quadro M6000",10000000,8.763701e6
+"JLContext","Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 6 threads",10,1302.5
+"JLContext","Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 6 threads",100,2609.0
+"JLContext","Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 6 threads",1000,16734.0
+"JLContext","Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 6 threads",10000,160290.0
+"JLContext","Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 6 threads",100000,1.588639e6
+"JLContext","Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 6 threads",1000000,1.5933972e7
+"JLContext","Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 6 threads",10000000,1.60091522e8
+"JLContext","Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 12 threads",10,1458.1
+"JLContext","Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 12 threads",100,2531.3333333333335
+"JLContext","Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 12 threads",1000,12579.0
+"JLContext","Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 12 threads",10000,114749.0
+"JLContext","Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 12 threads",100000,1.145862e6
+"JLContext","Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 12 threads",1000000,1.1412315e7
+"JLContext","Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 12 threads",10000000,1.1496937e8

--- a/examples/blackscholes_results.csv
+++ b/examples/blackscholes_results.csv
@@ -83,3 +83,80 @@
 "JLContext","Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 12 threads",100000,1.145862e6
 "JLContext","Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 12 threads",1000000,1.1412315e7
 "JLContext","Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 12 threads",10000000,1.1496937e8
+"JLContext","POWER8NVL with 1 threads",10,2911.0
+"CUContext","Tesla P100-SXM2-16GB",10,146851.0
+"JLContext","POWER8NVL with 1 threads",100,22556.0
+"CUContext","Tesla P100-SXM2-16GB",100,151031.0
+"JLContext","POWER8NVL with 1 threads",1000,216984.0
+"CUContext","Tesla P100-SXM2-16GB",1000,153589.0
+"JLContext","POWER8NVL with 1 threads",10000,2.166235e6
+"CUContext","Tesla P100-SXM2-16GB",10000,155908.0
+"JLContext","POWER8NVL with 1 threads",100000,2.1644173e7
+"CUContext","Tesla P100-SXM2-16GB",100000,161750.0
+"JLContext","POWER8NVL with 1 threads",1000000,2.16533528e8
+"CUContext","Tesla P100-SXM2-16GB",1000000,225688.0
+"JLContext","POWER8NVL with 1 threads",10000000,2.168615985e9
+"CUContext","Tesla P100-SXM2-16GB",10000000,775973.0
+"JLContext","POWER8NVL with 8 threads",10,2766.1111111111113
+"JLContext","POWER8NVL with 8 threads",100,6901.0
+"JLContext","POWER8NVL with 8 threads",1000,31760.0
+"JLContext","POWER8NVL with 8 threads",10000,272565.0
+"JLContext","POWER8NVL with 8 threads",100000,2.706448e6
+"JLContext","POWER8NVL with 8 threads",1000000,2.7059363e7
+"JLContext","POWER8NVL with 8 threads",10000000,2.71267733e8
+"JLContext","POWER8NVL with 16 threads",10,4821.666666666667
+"JLContext","POWER8NVL with 16 threads",100,7380.666666666667
+"JLContext","POWER8NVL with 16 threads",1000,23334.0
+"JLContext","POWER8NVL with 16 threads",10000,140560.0
+"JLContext","POWER8NVL with 16 threads",100000,1.381327e6
+"JLContext","POWER8NVL with 16 threads",1000000,1.3886778e7
+"JLContext","POWER8NVL with 16 threads",10000000,1.38805447e8
+"JLContext","POWER8NVL with 32 threads",10,6179.5
+"JLContext","POWER8NVL with 32 threads",100,6722.75
+"JLContext","POWER8NVL with 32 threads",1000,13078.0
+"JLContext","POWER8NVL with 32 threads",10000,88196.0
+"JLContext","POWER8NVL with 32 threads",100000,841415.0
+"JLContext","POWER8NVL with 32 threads",1000000,8.349377e6
+"JLContext","POWER8NVL with 32 threads",10000000,8.35524e7
+"JLContext","POWER8NVL with 40 threads",10,6291.0
+"JLContext","POWER8NVL with 40 threads",100,6381.0
+"JLContext","POWER8NVL with 40 threads",1000,13152.0
+"JLContext","POWER8NVL with 40 threads",10000,98143.0
+"JLContext","POWER8NVL with 40 threads",100000,683085.0
+"JLContext","POWER8NVL with 40 threads",1000000,6.779449e6
+"JLContext","POWER8NVL with 40 threads",10000000,6.782938e7
+"JLContext","POWER8NVL with 10 threads",10,3239.0
+"JLContext","POWER8NVL with 10 threads",100,6809.0
+"JLContext","POWER8NVL with 10 threads",1000,24125.0
+"JLContext","POWER8NVL with 10 threads",10000,218574.0
+"JLContext","POWER8NVL with 10 threads",100000,2.163455e6
+"JLContext","POWER8NVL with 10 threads",1000000,2.1684779e7
+"JLContext","POWER8NVL with 10 threads",10000000,2.16296064e8
+"JLContext","POWER8NVL with 64 threads",10,9160.0
+"JLContext","POWER8NVL with 64 threads",100,9675.0
+"JLContext","POWER8NVL with 64 threads",1000,13416.0
+"JLContext","POWER8NVL with 64 threads",10000,70303.0
+"JLContext","POWER8NVL with 64 threads",100000,638642.0
+"JLContext","POWER8NVL with 64 threads",1000000,6.362315e6
+"JLContext","POWER8NVL with 64 threads",10000000,6.3557088e7
+"JLContext","POWER8NVL with 80 threads",10,10098.0
+"JLContext","POWER8NVL with 80 threads",100,10626.0
+"JLContext","POWER8NVL with 80 threads",1000,14485.0
+"JLContext","POWER8NVL with 80 threads",10000,60309.0
+"JLContext","POWER8NVL with 80 threads",100000,520739.0
+"JLContext","POWER8NVL with 80 threads",1000000,5.23202e6
+"JLContext","POWER8NVL with 80 threads",10000000,5.1988805e7
+"JLContext","POWER8NVL with 128 threads",10,15010.0
+"JLContext","POWER8NVL with 128 threads",100,16367.0
+"JLContext","POWER8NVL with 128 threads",1000,24104.0
+"JLContext","POWER8NVL with 128 threads",10000,57963.0
+"JLContext","POWER8NVL with 128 threads",100000,479096.0
+"JLContext","POWER8NVL with 128 threads",1000000,5.20785e6
+"JLContext","POWER8NVL with 128 threads",10000000,5.1994391e7
+"JLContext","POWER8NVL with 160 threads",10,19504.0
+"JLContext","POWER8NVL with 160 threads",100,19572.0
+"JLContext","POWER8NVL with 160 threads",1000,23395.0
+"JLContext","POWER8NVL with 160 threads",10000,59975.0
+"JLContext","POWER8NVL with 160 threads",100000,451527.0
+"JLContext","POWER8NVL with 160 threads",1000000,4.349085e6
+"JLContext","POWER8NVL with 160 threads",10000000,4.3031821e7

--- a/examples/blackscholes_results.csv
+++ b/examples/blackscholes_results.csv
@@ -1,50 +1,71 @@
-"Backend","N","minT"
-"JLContext i3-4130 CPU @ 3.40GHz 1 threads","10000000","1.00845e9"
-"JLContext i7-6700 CPU @ 3.40GHz 1 threads","10000000","8.77278e8"
-"CLContext: i7-6700 CPU @ 3.40GHz","10000000","2.09277e8"
-"JLContext i7-6700 CPU @ 3.40GHz 8 threads","10000000","1.98091e8"
-"JLContext i3-4130 CPU @ 3.40GHz 1 threads","1000000","9.8874e7"
-"JLContext i7-6700 CPU @ 3.40GHz 1 threads","1000000","8.65065e7"
-"CLContext: GeForce GTX 950","10000000","3.00884e7"
-"CLContext: i7-6700 CPU @ 3.40GHz","1000000","2.14519e7"
-"JLContext i7-6700 CPU @ 3.40GHz 8 threads","1000000","1.97513e7"
-"JLContext i3-4130 CPU @ 3.40GHz 1 threads","100000","9.6816e6"
-"JLContext i7-6700 CPU @ 3.40GHz 1 threads","100000","8.02837e6"
-"CUContext: GeForce GTX 950","10000000","3.20146e6"
-"CLContext: GeForce GTX 950","1000000","2.97208e6"
-"CLContext: i7-6700 CPU @ 3.40GHz","100000","1.87866e6"
-"JLContext i7-6700 CPU @ 3.40GHz 8 threads","100000","1.50104e6"
-"CLContext: FirePro w9100","10000000","1.27692e6"
-"JLContext i3-4130 CPU @ 3.40GHz 1 threads","10000","964394.0"
-"JLContext i7-6700 CPU @ 3.40GHz 1 threads","10000","791163.0"
-"CUContext: GeForce GTX 950","1000000","403145.0"
-"CLContext: GeForce GTX 950","100000","318044.0"
-"CLContext: i7-6700 CPU @ 3.40GHz","10000","198403.0"
-"CLContext: FirePro w9100","1000000","165117.0"
-"JLContext i7-6700 CPU @ 3.40GHz 8 threads","10000","150657.0"
-"CUContext: GeForce GTX 950","100000","126658.0"
-"CUContext: GeForce GTX 950","10000","97260.0"
-"JLContext i3-4130 CPU @ 3.40GHz 1 threads","1000","96744.0"
-"CUContext: GeForce GTX 950","1000","94860.0"
-"CUContext: GeForce GTX 950","100","93302.0"
-"CUContext: GeForce GTX 950","10","90711.0"
-"JLContext i7-6700 CPU @ 3.40GHz 1 threads","1000","79679.0"
-"CLContext: FirePro w9100","100000","57141.0"
-"CLContext: GeForce GTX 950","10000","51292.0"
-"CLContext: FirePro w9100","100","44096.0"
-"CLContext: FirePro w9100","10","43930.0"
-"CLContext: FirePro w9100","10000","43665.0"
-"CLContext: FirePro w9100","1000","43215.0"
-"CLContext: i7-6700 CPU @ 3.40GHz","1000","37261.0"
-"CLContext: GeForce GTX 950","10","35829.0"
-"CLContext: GeForce GTX 950","100","25228.0"
-"CLContext: GeForce GTX 950","1000","24657.0"
-"CLContext: i7-6700 CPU @ 3.40GHz","100","19228.0"
-"CLContext: i7-6700 CPU @ 3.40GHz","10","17357.0"
-"JLContext i7-6700 CPU @ 3.40GHz 8 threads","1000","16007.0"
-"JLContext i3-4130 CPU @ 3.40GHz 1 threads","100","10029.0"
-"JLContext i7-6700 CPU @ 3.40GHz 1 threads","100","8463.33"
-"JLContext i7-6700 CPU @ 3.40GHz 8 threads","100","2774.44"
-"JLContext i7-6700 CPU @ 3.40GHz 8 threads","10","1406.8"
-"JLContext i3-4130 CPU @ 3.40GHz 1 threads","10","1348.4"
-"JLContext i7-6700 CPU @ 3.40GHz 1 threads","10","1262.9"
+"Backend","Device","N","minT"
+"JLContext","i3-4130 CPU @ 3.40GHz 1 threads",10000000,1.00845e9
+"JLContext","i7-6700 CPU @ 3.40GHz 1 threads",10000000,8.77278e8
+"CLContext","i7-6700 CPU @ 3.40GHz",10000000,2.09277e8
+"JLContext","i7-6700 CPU @ 3.40GHz 8 threads",10000000,1.98091e8
+"JLContext","i3-4130 CPU @ 3.40GHz 1 threads",1000000,9.8874e7
+"JLContext","i7-6700 CPU @ 3.40GHz 1 threads",1000000,8.65065e7
+"CLContext","GeForce GTX 950",10000000,3.00884e7
+"CLContext","i7-6700 CPU @ 3.40GHz",1000000,2.14519e7
+"JLContext","i7-6700 CPU @ 3.40GHz 8 threads",1000000,1.97513e7
+"JLContext","i3-4130 CPU @ 3.40GHz 1 threads",100000,9.6816e6
+"JLContext","i7-6700 CPU @ 3.40GHz 1 threads",100000,8.02837e6
+"CUContext","GeForce GTX 950",10000000,3.20146e6
+"CLContext","GeForce GTX 950",1000000,2.97208e6
+"CLContext","i7-6700 CPU @ 3.40GHz",100000,1.87866e6
+"JLContext","i7-6700 CPU @ 3.40GHz 8 threads",100000,1.50104e6
+"CLContext","FirePro w9100",10000000,1.27692e6
+"JLContext","i3-4130 CPU @ 3.40GHz 1 threads",10000,964394.0
+"JLContext","i7-6700 CPU @ 3.40GHz 1 threads",10000,791163.0
+"CUContext","GeForce GTX 950",1000000,403145.0
+"CLContext","GeForce GTX 950",100000,318044.0
+"CLContext","i7-6700 CPU @ 3.40GHz",10000,198403.0
+"CLContext","FirePro w9100",1000000,165117.0
+"JLContext","i7-6700 CPU @ 3.40GHz 8 threads",10000,150657.0
+"CUContext","GeForce GTX 950",100000,126658.0
+"CUContext","GeForce GTX 950",10000,97260.0
+"JLContext","i3-4130 CPU @ 3.40GHz 1 threads",1000,96744.0
+"CUContext","GeForce GTX 950",1000,94860.0
+"CUContext","GeForce GTX 950",100,93302.0
+"CUContext","GeForce GTX 950",10,90711.0
+"JLContext","i7-6700 CPU @ 3.40GHz 1 threads",1000,79679.0
+"CLContext","FirePro w9100",100000,57141.0
+"CLContext","GeForce GTX 950",10000,51292.0
+"CLContext","FirePro w9100",100,44096.0
+"CLContext","FirePro w9100",10,43930.0
+"CLContext","FirePro w9100",10000,43665.0
+"CLContext","FirePro w9100",1000,43215.0
+"CLContext","i7-6700 CPU @ 3.40GHz",1000,37261.0
+"CLContext","GeForce GTX 950",10,35829.0
+"CLContext","GeForce GTX 950",100,25228.0
+"CLContext","GeForce GTX 950",1000,24657.0
+"CLContext","i7-6700 CPU @ 3.40GHz",100,19228.0
+"CLContext","i7-6700 CPU @ 3.40GHz",10,17357.0
+"JLContext","i7-6700 CPU @ 3.40GHz 8 threads",1000,16007.0
+"JLContext","i3-4130 CPU @ 3.40GHz 1 threads",100,10029.0
+"JLContext","i7-6700 CPU @ 3.40GHz 1 threads",100,8463.33
+"JLContext","i7-6700 CPU @ 3.40GHz 8 threads",100,2774.44
+"JLContext","i7-6700 CPU @ 3.40GHz 8 threads",10,1406.8
+"JLContext","i3-4130 CPU @ 3.40GHz 1 threads",10,1348.4
+"JLContext","i7-6700 CPU @ 3.40GHz 1 threads",10,1262.9
+"JLContext","Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 1 threads",10,1258.1
+"CUContext","Quadro M6000",10,94904.0
+"CLContext","Quadro M6000",10,37289.0
+"JLContext","Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 1 threads",100,9558.0
+"CUContext","Quadro M6000",100,98835.0
+"CLContext","Quadro M6000",100,27089.0
+"JLContext","Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 1 threads",1000,92447.0
+"CUContext","Quadro M6000",1000,99642.0
+"CLContext","Quadro M6000",1000,27419.0
+"JLContext","Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 1 threads",10000,924625.0
+"CUContext","Quadro M6000",10000,96989.0
+"CLContext","Quadro M6000",10000,32666.0
+"JLContext","Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 1 threads",100000,9.275064e6
+"CUContext","Quadro M6000",100000,112098.0
+"CLContext","Quadro M6000",100000,112540.0
+"JLContext","Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 1 threads",1000000,9.2940948e7
+"CUContext","Quadro M6000",1000000,202011.0
+"CLContext","Quadro M6000",1000000,903081.0
+"JLContext","Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 1 threads",10000000,9.31366734e8
+"CUContext","Quadro M6000",10000000,1.092519e6
+"CLContext","Quadro M6000",10000000,8.763701e6

--- a/examples/blackscholes_results.md
+++ b/examples/blackscholes_results.md
@@ -10,6 +10,8 @@
 | JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 1 threads |  1258.10 μs |
 | CUContext | Quadro M6000 |  94904.00 μs |
 | CLContext | Quadro M6000 |  37289.00 μs |
+| JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 6 threads |  1302.50 μs |
+| JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 12 threads |  1458.10 μs |
 
 
 | Backend | Device | Time (μs) for N = 10^2 |
@@ -24,6 +26,8 @@
 | JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 1 threads |  9558.00 μs |
 | CUContext | Quadro M6000 |  98835.00 μs |
 | CLContext | Quadro M6000 |  27089.00 μs |
+| JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 6 threads |  2609.00 μs |
+| JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 12 threads |  2531.33 μs |
 
 
 | Backend | Device | Time (μs) for N = 10^3 |
@@ -38,6 +42,8 @@
 | JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 1 threads |  92447.00 μs |
 | CUContext | Quadro M6000 |  99642.00 μs |
 | CLContext | Quadro M6000 |  27419.00 μs |
+| JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 6 threads |  16734.00 μs |
+| JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 12 threads |  12579.00 μs |
 
 
 | Backend | Device | Time (μs) for N = 10^4 |
@@ -52,6 +58,8 @@
 | JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 1 threads |  924625.00 μs |
 | CUContext | Quadro M6000 |  96989.00 μs |
 | CLContext | Quadro M6000 |  32666.00 μs |
+| JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 6 threads |  160290.00 μs |
+| JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 12 threads |  114749.00 μs |
 
 
 | Backend | Device | Time (μs) for N = 10^5 |
@@ -66,6 +74,8 @@
 | JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 1 threads |  9275064.00 μs |
 | CUContext | Quadro M6000 |  112098.00 μs |
 | CLContext | Quadro M6000 |  112540.00 μs |
+| JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 6 threads |  1588639.00 μs |
+| JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 12 threads |  1145862.00 μs |
 
 
 | Backend | Device | Time (μs) for N = 10^6 |
@@ -80,6 +90,8 @@
 | JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 1 threads |  92940948.00 μs |
 | CUContext | Quadro M6000 |  202011.00 μs |
 | CLContext | Quadro M6000 |  903081.00 μs |
+| JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 6 threads |  15933972.00 μs |
+| JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 12 threads |  11412315.00 μs |
 
 
 | Backend | Device | Time (μs) for N = 10^7 |
@@ -94,5 +106,7 @@
 | JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 1 threads |  931366734.00 μs |
 | CUContext | Quadro M6000 |  1092519.00 μs |
 | CLContext | Quadro M6000 |  8763701.00 μs |
+| JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 6 threads |  160091522.00 μs |
+| JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 12 threads |  114969370.00 μs |
 
 

--- a/examples/blackscholes_results.md
+++ b/examples/blackscholes_results.md
@@ -1,0 +1,98 @@
+| Backend | Device | Time (μs) for N = 10^1 |
+| ---- | ---- | ---- |
+| CUContext | GeForce GTX 950 |  90711.00 μs |
+| CLContext | FirePro w9100 |  43930.00 μs |
+| CLContext | GeForce GTX 950 |  35829.00 μs |
+| CLContext | i7-6700 CPU @ 3.40GHz |  17357.00 μs |
+| JLContext | i7-6700 CPU @ 3.40GHz 8 threads |  1406.80 μs |
+| JLContext | i3-4130 CPU @ 3.40GHz 1 threads |  1348.40 μs |
+| JLContext | i7-6700 CPU @ 3.40GHz 1 threads |  1262.90 μs |
+| JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 1 threads |  1258.10 μs |
+| CUContext | Quadro M6000 |  94904.00 μs |
+| CLContext | Quadro M6000 |  37289.00 μs |
+
+
+| Backend | Device | Time (μs) for N = 10^2 |
+| ---- | ---- | ---- |
+| CUContext | GeForce GTX 950 |  93302.00 μs |
+| CLContext | FirePro w9100 |  44096.00 μs |
+| CLContext | GeForce GTX 950 |  25228.00 μs |
+| CLContext | i7-6700 CPU @ 3.40GHz |  19228.00 μs |
+| JLContext | i3-4130 CPU @ 3.40GHz 1 threads |  10029.00 μs |
+| JLContext | i7-6700 CPU @ 3.40GHz 1 threads |  8463.33 μs |
+| JLContext | i7-6700 CPU @ 3.40GHz 8 threads |  2774.44 μs |
+| JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 1 threads |  9558.00 μs |
+| CUContext | Quadro M6000 |  98835.00 μs |
+| CLContext | Quadro M6000 |  27089.00 μs |
+
+
+| Backend | Device | Time (μs) for N = 10^3 |
+| ---- | ---- | ---- |
+| JLContext | i3-4130 CPU @ 3.40GHz 1 threads |  96744.00 μs |
+| CUContext | GeForce GTX 950 |  94860.00 μs |
+| JLContext | i7-6700 CPU @ 3.40GHz 1 threads |  79679.00 μs |
+| CLContext | FirePro w9100 |  43215.00 μs |
+| CLContext | i7-6700 CPU @ 3.40GHz |  37261.00 μs |
+| CLContext | GeForce GTX 950 |  24657.00 μs |
+| JLContext | i7-6700 CPU @ 3.40GHz 8 threads |  16007.00 μs |
+| JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 1 threads |  92447.00 μs |
+| CUContext | Quadro M6000 |  99642.00 μs |
+| CLContext | Quadro M6000 |  27419.00 μs |
+
+
+| Backend | Device | Time (μs) for N = 10^4 |
+| ---- | ---- | ---- |
+| JLContext | i3-4130 CPU @ 3.40GHz 1 threads |  964394.00 μs |
+| JLContext | i7-6700 CPU @ 3.40GHz 1 threads |  791163.00 μs |
+| CLContext | i7-6700 CPU @ 3.40GHz |  198403.00 μs |
+| JLContext | i7-6700 CPU @ 3.40GHz 8 threads |  150657.00 μs |
+| CUContext | GeForce GTX 950 |  97260.00 μs |
+| CLContext | GeForce GTX 950 |  51292.00 μs |
+| CLContext | FirePro w9100 |  43665.00 μs |
+| JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 1 threads |  924625.00 μs |
+| CUContext | Quadro M6000 |  96989.00 μs |
+| CLContext | Quadro M6000 |  32666.00 μs |
+
+
+| Backend | Device | Time (μs) for N = 10^5 |
+| ---- | ---- | ---- |
+| JLContext | i3-4130 CPU @ 3.40GHz 1 threads |  9681600.00 μs |
+| JLContext | i7-6700 CPU @ 3.40GHz 1 threads |  8028370.00 μs |
+| CLContext | i7-6700 CPU @ 3.40GHz |  1878660.00 μs |
+| JLContext | i7-6700 CPU @ 3.40GHz 8 threads |  1501040.00 μs |
+| CLContext | GeForce GTX 950 |  318044.00 μs |
+| CUContext | GeForce GTX 950 |  126658.00 μs |
+| CLContext | FirePro w9100 |  57141.00 μs |
+| JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 1 threads |  9275064.00 μs |
+| CUContext | Quadro M6000 |  112098.00 μs |
+| CLContext | Quadro M6000 |  112540.00 μs |
+
+
+| Backend | Device | Time (μs) for N = 10^6 |
+| ---- | ---- | ---- |
+| JLContext | i3-4130 CPU @ 3.40GHz 1 threads |  98874000.00 μs |
+| JLContext | i7-6700 CPU @ 3.40GHz 1 threads |  86506500.00 μs |
+| CLContext | i7-6700 CPU @ 3.40GHz |  21451900.00 μs |
+| JLContext | i7-6700 CPU @ 3.40GHz 8 threads |  19751300.00 μs |
+| CLContext | GeForce GTX 950 |  2972080.00 μs |
+| CUContext | GeForce GTX 950 |  403145.00 μs |
+| CLContext | FirePro w9100 |  165117.00 μs |
+| JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 1 threads |  92940948.00 μs |
+| CUContext | Quadro M6000 |  202011.00 μs |
+| CLContext | Quadro M6000 |  903081.00 μs |
+
+
+| Backend | Device | Time (μs) for N = 10^7 |
+| ---- | ---- | ---- |
+| JLContext | i3-4130 CPU @ 3.40GHz 1 threads |  1008450000.00 μs |
+| JLContext | i7-6700 CPU @ 3.40GHz 1 threads |  877278000.00 μs |
+| CLContext | i7-6700 CPU @ 3.40GHz |  209277000.00 μs |
+| JLContext | i7-6700 CPU @ 3.40GHz 8 threads |  198091000.00 μs |
+| CLContext | GeForce GTX 950 |  30088400.00 μs |
+| CUContext | GeForce GTX 950 |  3201460.00 μs |
+| CLContext | FirePro w9100 |  1276920.00 μs |
+| JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 1 threads |  931366734.00 μs |
+| CUContext | Quadro M6000 |  1092519.00 μs |
+| CLContext | Quadro M6000 |  8763701.00 μs |
+
+

--- a/examples/blackscholes_results.md
+++ b/examples/blackscholes_results.md
@@ -12,6 +12,17 @@
 | CLContext | Quadro M6000 |  37289.00 μs |
 | JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 6 threads |  1302.50 μs |
 | JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 12 threads |  1458.10 μs |
+| JLContext | POWER8NVL with 1 threads |  2911.00 μs |
+| CUContext | Tesla P100-SXM2-16GB |  146851.00 μs |
+| JLContext | POWER8NVL with 8 threads |  2766.11 μs |
+| JLContext | POWER8NVL with 16 threads |  4821.67 μs |
+| JLContext | POWER8NVL with 32 threads |  6179.50 μs |
+| JLContext | POWER8NVL with 40 threads |  6291.00 μs |
+| JLContext | POWER8NVL with 10 threads |  3239.00 μs |
+| JLContext | POWER8NVL with 64 threads |  9160.00 μs |
+| JLContext | POWER8NVL with 80 threads |  10098.00 μs |
+| JLContext | POWER8NVL with 128 threads |  15010.00 μs |
+| JLContext | POWER8NVL with 160 threads |  19504.00 μs |
 
 
 | Backend | Device | Time (μs) for N = 10^2 |
@@ -28,6 +39,17 @@
 | CLContext | Quadro M6000 |  27089.00 μs |
 | JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 6 threads |  2609.00 μs |
 | JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 12 threads |  2531.33 μs |
+| JLContext | POWER8NVL with 1 threads |  22556.00 μs |
+| CUContext | Tesla P100-SXM2-16GB |  151031.00 μs |
+| JLContext | POWER8NVL with 8 threads |  6901.00 μs |
+| JLContext | POWER8NVL with 16 threads |  7380.67 μs |
+| JLContext | POWER8NVL with 32 threads |  6722.75 μs |
+| JLContext | POWER8NVL with 40 threads |  6381.00 μs |
+| JLContext | POWER8NVL with 10 threads |  6809.00 μs |
+| JLContext | POWER8NVL with 64 threads |  9675.00 μs |
+| JLContext | POWER8NVL with 80 threads |  10626.00 μs |
+| JLContext | POWER8NVL with 128 threads |  16367.00 μs |
+| JLContext | POWER8NVL with 160 threads |  19572.00 μs |
 
 
 | Backend | Device | Time (μs) for N = 10^3 |
@@ -44,6 +66,17 @@
 | CLContext | Quadro M6000 |  27419.00 μs |
 | JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 6 threads |  16734.00 μs |
 | JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 12 threads |  12579.00 μs |
+| JLContext | POWER8NVL with 1 threads |  216984.00 μs |
+| CUContext | Tesla P100-SXM2-16GB |  153589.00 μs |
+| JLContext | POWER8NVL with 8 threads |  31760.00 μs |
+| JLContext | POWER8NVL with 16 threads |  23334.00 μs |
+| JLContext | POWER8NVL with 32 threads |  13078.00 μs |
+| JLContext | POWER8NVL with 40 threads |  13152.00 μs |
+| JLContext | POWER8NVL with 10 threads |  24125.00 μs |
+| JLContext | POWER8NVL with 64 threads |  13416.00 μs |
+| JLContext | POWER8NVL with 80 threads |  14485.00 μs |
+| JLContext | POWER8NVL with 128 threads |  24104.00 μs |
+| JLContext | POWER8NVL with 160 threads |  23395.00 μs |
 
 
 | Backend | Device | Time (μs) for N = 10^4 |
@@ -60,6 +93,17 @@
 | CLContext | Quadro M6000 |  32666.00 μs |
 | JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 6 threads |  160290.00 μs |
 | JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 12 threads |  114749.00 μs |
+| JLContext | POWER8NVL with 1 threads |  2166235.00 μs |
+| CUContext | Tesla P100-SXM2-16GB |  155908.00 μs |
+| JLContext | POWER8NVL with 8 threads |  272565.00 μs |
+| JLContext | POWER8NVL with 16 threads |  140560.00 μs |
+| JLContext | POWER8NVL with 32 threads |  88196.00 μs |
+| JLContext | POWER8NVL with 40 threads |  98143.00 μs |
+| JLContext | POWER8NVL with 10 threads |  218574.00 μs |
+| JLContext | POWER8NVL with 64 threads |  70303.00 μs |
+| JLContext | POWER8NVL with 80 threads |  60309.00 μs |
+| JLContext | POWER8NVL with 128 threads |  57963.00 μs |
+| JLContext | POWER8NVL with 160 threads |  59975.00 μs |
 
 
 | Backend | Device | Time (μs) for N = 10^5 |
@@ -76,6 +120,17 @@
 | CLContext | Quadro M6000 |  112540.00 μs |
 | JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 6 threads |  1588639.00 μs |
 | JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 12 threads |  1145862.00 μs |
+| JLContext | POWER8NVL with 1 threads |  21644173.00 μs |
+| CUContext | Tesla P100-SXM2-16GB |  161750.00 μs |
+| JLContext | POWER8NVL with 8 threads |  2706448.00 μs |
+| JLContext | POWER8NVL with 16 threads |  1381327.00 μs |
+| JLContext | POWER8NVL with 32 threads |  841415.00 μs |
+| JLContext | POWER8NVL with 40 threads |  683085.00 μs |
+| JLContext | POWER8NVL with 10 threads |  2163455.00 μs |
+| JLContext | POWER8NVL with 64 threads |  638642.00 μs |
+| JLContext | POWER8NVL with 80 threads |  520739.00 μs |
+| JLContext | POWER8NVL with 128 threads |  479096.00 μs |
+| JLContext | POWER8NVL with 160 threads |  451527.00 μs |
 
 
 | Backend | Device | Time (μs) for N = 10^6 |
@@ -92,6 +147,17 @@
 | CLContext | Quadro M6000 |  903081.00 μs |
 | JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 6 threads |  15933972.00 μs |
 | JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 12 threads |  11412315.00 μs |
+| JLContext | POWER8NVL with 1 threads |  216533528.00 μs |
+| CUContext | Tesla P100-SXM2-16GB |  225688.00 μs |
+| JLContext | POWER8NVL with 8 threads |  27059363.00 μs |
+| JLContext | POWER8NVL with 16 threads |  13886778.00 μs |
+| JLContext | POWER8NVL with 32 threads |  8349377.00 μs |
+| JLContext | POWER8NVL with 40 threads |  6779449.00 μs |
+| JLContext | POWER8NVL with 10 threads |  21684779.00 μs |
+| JLContext | POWER8NVL with 64 threads |  6362315.00 μs |
+| JLContext | POWER8NVL with 80 threads |  5232020.00 μs |
+| JLContext | POWER8NVL with 128 threads |  5207850.00 μs |
+| JLContext | POWER8NVL with 160 threads |  4349085.00 μs |
 
 
 | Backend | Device | Time (μs) for N = 10^7 |
@@ -108,5 +174,16 @@
 | CLContext | Quadro M6000 |  8763701.00 μs |
 | JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 6 threads |  160091522.00 μs |
 | JLContext | Intel(R) Xeon(R) CPU E5-2643 v3 @ 3.40GHz with 12 threads |  114969370.00 μs |
+| JLContext | POWER8NVL with 1 threads |  2168615985.00 μs |
+| CUContext | Tesla P100-SXM2-16GB |  775973.00 μs |
+| JLContext | POWER8NVL with 8 threads |  271267733.00 μs |
+| JLContext | POWER8NVL with 16 threads |  138805447.00 μs |
+| JLContext | POWER8NVL with 32 threads |  83552400.00 μs |
+| JLContext | POWER8NVL with 40 threads |  67829380.00 μs |
+| JLContext | POWER8NVL with 10 threads |  216296064.00 μs |
+| JLContext | POWER8NVL with 64 threads |  63557088.00 μs |
+| JLContext | POWER8NVL with 80 threads |  51988805.00 μs |
+| JLContext | POWER8NVL with 128 threads |  51994391.00 μs |
+| JLContext | POWER8NVL with 160 threads |  43031821.00 μs |
 
 

--- a/src/backends/cudanative/cudanative.jl
+++ b/src/backends/cudanative/cudanative.jl
@@ -22,7 +22,7 @@ immutable CUContext <: Context
     device::CUDAdrv.CuDevice
 end
 
-Base.show(io::IO, ctx::CUContext) = print(io, "CUContext")
+Base.show(io::IO, ctx::CUContext) = print(io, "CUContext: ", CUDAdrv.name(ctx.device))
 
 function any_context()
     dev = CUDAdrv.CuDevice(0)

--- a/src/backends/julia/julia.jl
+++ b/src/backends/julia/julia.jl
@@ -70,7 +70,7 @@ Base.size{T, N}(x::JLArray{T, N}) = size(buffer(x))
 
 function Base.show(io::IO, ctx::JLContext)
     cpu = Sys.cpu_info()
-    print(io, "JLContext $(cpu[1].model) with $(ctx.nthreads) threads")
+    print(io, "JLContext: $(cpu[1].model) with $(ctx.nthreads) threads")
 end
 ##############################################
 # Implement BLAS interface


### PR DESCRIPTION
This allows you to do:

```
for i in 1 8 10 40 64 80 128 160; 
   do JULIA_NUM_THREADS=$i GPUARRAYS_BENCH_BACKENDS="julia" julia blackscholes.jl; 
done
```

And only benchmark one backend. 