### PR TITLE
Fix broken ref for `compile_lib` (CUDAnative)

### DIFF
--- a/src/backends/cudanative/cudanative.jl
+++ b/src/backends/cudanative/cudanative.jl
@@ -108,7 +108,7 @@ immutable CUFunction{T}
     kernel::T
 end
 # TODO find a future for the kernel string compilation part
-compile_lib = Pkg.dir("CUDAdrv", "examples", "compilation", "library.jl")
+compile_lib = Pkg.dir("CUDArt", "examples", "compilation", "library.jl")
 has_nvcc = try
     success(`nvcc --version`)
 catch


### PR DESCRIPTION
Should fix #29 although I don't actually understand what's going on in general with `compile_lib` and the CUDAdrv/CUDArt compilation example.