### PR TITLE
Allows specifying device when initializing OpenCL

### DIFF
--- a/src/backends/opencl/opencl.jl
+++ b/src/backends/opencl/opencl.jl
@@ -23,7 +23,7 @@ immutable CLContext <: Context
     device::cl.Device
     context::cl.Context
     queue::cl.CmdQueue
-    function CLContext(device_type = nothing)
+    function CLContext(device_type = nothing; device_idx = 1)
         device = if device_type == nothing
             devlist = cl.devices(:gpu)
             dev = if isempty(devlist)
@@ -31,10 +31,10 @@ immutable CLContext <: Context
                 if isempty(devlist)
                     error("no device found to be supporting opencl")
                 else
-                    first(devlist)
+                    devlist[device_idx]
                 end
             else
-                first(devlist)
+                devlist[device_idx]
             end
             dev
         else
@@ -43,7 +43,7 @@ immutable CLContext <: Context
             if isempty(devlist)
                 error("Can't find OpenCL device for $device_type")
             end
-            first(devlist)
+            devlist[device_idx]
         end
         ctx = cl.Context(device)
         queue = cl.CmdQueue(ctx)
@@ -59,10 +59,11 @@ global init, all_contexts, current_context
 let contexts = CLContext[]
     all_contexts() = copy(contexts)::Vector{CLContext}
     current_context() = last(contexts)::CLContext
-    function init(;device_type = nothing, ctx = nothing)
-        context = if ctx == nothing
-            if isempty(contexts)
-                CLContext(device_type)
+    function init(;device_type = nothing, ctx = nothing, device_idx = nothing)
+      context = if ctx == nothing
+            if isempty(contexts) || device_type != nothing || device_idx != nothing
+                idx = if device_idx == nothing ; 1 else device_idx end
+                CLContext(device_type; device_idx = idx)
             else
                 current_context()
             end


### PR DESCRIPTION
Adds the ability to choose (and switch) device when initializing the OpenCL context, per #38.

For an example of this in use, see
https://gist.github.com/NHDaly/bf18263fdee4d78bae5c4e1de8ad7208