### PR TITLE
NNlib integration

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.6
 StaticArrays
+NNlib

--- a/src/GPUArrays.jl
+++ b/src/GPUArrays.jl
@@ -18,6 +18,7 @@ include("convolution.jl")
 include("testsuite/testsuite.jl")
 include("jlbackend.jl")
 include("random.jl")
+include("nnlib.jl")
 
 export GPUArray, gpu_call, thread_blocks_heuristic, global_size, synchronize_threads
 export linear_index, @linearidx, @cartesianidx, convolution!, device, synchronize

--- a/src/nnlib.jl
+++ b/src/nnlib.jl
@@ -1,0 +1,10 @@
+import NNlib: adapt, adapt_
+
+adapt_(::Type{<:GPUArray}, xs::AbstractArray) =
+  isbits(xs) ? xs : convert(GPUArray, xs)
+
+adapt_(::Type{<:GPUArray{T}}, xs::AbstractArray{<:Real}) where T <: AbstractFloat =
+  isbits(xs) ? xs : convert(GPUArray{T}, xs)
+
+# Should go in CLArrays
+# cl(xs) = adapt(CLArray{Float32}, xs)


### PR DESCRIPTION
This will enable us to have generic overloads for functions like `softmax`, so that Flux can work seamlessly with GPUArrays.