### PR TITLE
Fix typo, ambiguity error with rand in random.jl

### DIFF
--- a/src/random.jl
+++ b/src/random.jl
@@ -57,7 +57,8 @@ function rand!(A::GPUArray{T}) where T <: AbstractFloat
     A
 end
 
-rand(X::Type{<: GPUArray{T, N}}, size::NTuple{N, Integer}) where {T, N} = rand(A, T, size)
+rand(X::Type{<: GPUArray{T, N}}, size::NTuple{N, Integer}) where {T, N} = rand(X, T, size...)
+rand(X::Type{<: GPUArray{T, N}}, size::NTuple{N, Int}) where {T, N} = rand(X, T, size...)
 
 function rand(X::Type{<: GPUArray}, ::Type{ET}, size::Integer...) where ET
     A = similar(X, ET, size)


### PR DESCRIPTION
In particular the method call can be ambiguous if called with a tuple of `Int64`s, e.g.,
```
MethodError: rand(::Type{CuArray{Float32,2}}, ::Tuple{Int64,Int64}) is ambiguous. Candidates:
  rand(T::Type, dims::Tuple{Vararg{Int64,N}} where N) in Base.Random at random.jl:286
  rand(X::Type{#s123} where #s123<:GPUArrays.GPUArray{T,N}, size::Tuple{Vararg{Integer,N}}) where {T, N} in GPUArrays at /home/schmrlng/.julia/v0.6/GPUArrays/src/random.jl:60
Possible fix, define
  rand(::Type{#s123} where #s123<:GPUArrays.GPUArray{T,N}, ::Tuple{Vararg{Int64,N}})
```
(other method in Julia 0.6 at https://github.com/JuliaLang/julia/blob/93168a68268a2023c0da5f14e75ccb807cc4fc35/base/random.jl#L286)