### PR TITLE
Added all to mapreduce.jl, tests for any/all and rand/rand!

### DIFF
--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -1,9 +1,10 @@
-import Base: any, count, countnz
+import Base: any, all, count, countnz
 
 #############################
 # reduce
 # functions in base implemented with a direct loop need to be overloaded to use mapreduce
 any(pred, A::GPUArray) = Bool(mapreduce(pred, |, Int32(0), A))
+all(pred, A::GPUArray) = Bool(mapreduce(pred, &, Int32(1), A))
 count(pred, A::GPUArray) = Int(mapreduce(pred, +, UInt32(0), A))
 countnz(A::GPUArray) = Int(mapreduce(x-> x != 0, +, UInt32(0), A))
 countnz(A::GPUArray, dim) = Int(mapreducedim(x-> x != 0, +, UInt32(0), A, dim))

--- a/src/testsuite/mapreduce.jl
+++ b/src/testsuite/mapreduce.jl
@@ -38,5 +38,13 @@ function run_mapreduce(Typ)
                 end
             end
         end
+        @testset "any all" begin
+            for Ac in ([false, false], [false, true], [true, true])
+                A = Typ(Ac)
+                @test typeof(A) == Typ{Bool,1}
+                @test any(A) == any(Ac)
+                @test all(A) == all(Ac)
+            end
+        end
     end
 end

--- a/src/testsuite/random.jl
+++ b/src/testsuite/random.jl
@@ -1,0 +1,20 @@
+using GPUArrays
+using Base.Test, GPUArrays.TestSuite
+
+function run_random(Typ)
+    @testset "Random" begin
+        @testset "rand" begin  # uniform
+            for T in (Float32, Float64)
+                @test length(rand(Typ{T,1}, (4,))) == 4
+                @test length(rand(Typ, T, 4)) == 4
+                @test length(rand(Typ{T,2}, (4,5))) == 20
+                @test length(rand(Typ, T, 4, 5)) == 20
+                A = rand(Typ{T,2}, (2,2))
+                B = copy(A)
+                @test all(A .== B)
+                rand!(B)
+                @test !any(A .== B)
+            end
+        end
+    end
+end

--- a/src/testsuite/testsuite.jl
+++ b/src/testsuite/testsuite.jl
@@ -41,6 +41,7 @@ include("mapreduce.jl")
 include("base.jl")
 include("indexing.jl")
 # include("vector.jl")
+include("random.jl")
 
 function supported_eltypes()
     (Float32, Float64, Int32, Int64, Complex64, Complex128)
@@ -60,6 +61,7 @@ function run_tests(Typ)
     run_linalg(Typ)
     run_mapreduce(Typ)
     run_indexing(Typ)
+    run_random(Typ)
 end
 
 export against_base, run_tests, supported_eltypes


### PR DESCRIPTION
Tests for https://github.com/JuliaGPU/GPUArrays.jl/pull/98. Also tested on `CuArrays`:
```
julia> GPUArrays.TestSuite.run_random(CuArray)
Test Summary: | Pass  Total
Random        |   12     12

julia> GPUArrays.TestSuite.run_mapreduce(CuArray)
Test Summary: | Pass  Total
mapreduce     |  173    173
```
though the full test suite fails for `CuArray` on broadcasting.