### PR TITLE
fix #87

### DIFF
--- a/src/jlbackend.jl
+++ b/src/jlbackend.jl
@@ -7,6 +7,10 @@ struct JLArray{T, N} <: GPUArray{T, N}
     size::NTuple{N, Int}
 end
 
+function showarray(io::IO, A::JLArray, repr::Bool)
+    print(io, "CPU: ")
+    showarray(io, Array(A), repr)
+end
 """
 Thread group local memory
 """


### PR DESCRIPTION
overload show to print CPU instead of confusing GPU