### PR TITLE
max pool

### DIFF
--- a/src/GPUArrays.jl
+++ b/src/GPUArrays.jl
@@ -18,9 +18,10 @@ include("convolution.jl")
 include("testsuite/testsuite.jl")
 include("jlbackend.jl")
 include("random.jl")
+include("pool.jl")
 
 export GPUArray, gpu_call, thread_blocks_heuristic, global_size, synchronize_threads
-export linear_index, @linearidx, @cartesianidx, convolution!, device, synchronize
+export linear_index, @linearidx, @cartesianidx, convolution!, device, synchronize, maxpool2d
 export JLArray
 
 end # module

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -16,7 +16,7 @@ function _getindex(xs::GPUArray{T}, i::Integer) where T
 end
 
 function Base.getindex(xs::GPUArray{T}, i::Integer) where T
-    assertslow("getindex")
+    # assertslow("getindex")
     _getindex(xs, i)
 end
 
@@ -27,7 +27,7 @@ function _setindex!(xs::GPUArray{T}, v::T, i::Integer) where T
 end
 
 function Base.setindex!(xs::GPUArray{T}, v::T, i::Integer) where T
-    assertslow("setindex!")
+    # assertslow("setindex!")
     _setindex!(xs, v, i)
 end
 

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -16,7 +16,7 @@ function _getindex(xs::GPUArray{T}, i::Integer) where T
 end
 
 function Base.getindex(xs::GPUArray{T}, i::Integer) where T
-    # assertslow("getindex")
+    assertslow("getindex")
     _getindex(xs, i)
 end
 
@@ -27,7 +27,7 @@ function _setindex!(xs::GPUArray{T}, v::T, i::Integer) where T
 end
 
 function Base.setindex!(xs::GPUArray{T}, v::T, i::Integer) where T
-    # assertslow("setindex!")
+    assertslow("setindex!")
     _setindex!(xs, v, i)
 end
 

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -27,7 +27,7 @@ function maxpool2d_kernel(state, A::AbstractArray{T}, out, Asize, pool, stride, 
 end
 
 
-function maxpool2d(a, pool; stride = 1, pad = 0)
+function maxpool2d{T <: Integer}(a, pool::T; stride = pool, pad = 0)
     b = zeros(typeof(a), size(a,1) + pad * 2, size(a,2) + pad * 2, size(a,3), size(a,4))
     b[pad + 1 : pad + size(a,1), pad + 1 : pad + size(a,2), :, :] = a
     Asize = UInt32.(size(b))

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -1,15 +1,15 @@
 import CUDAnative
 
-function maxpool2d_kernel(state, A::AbstractArray{T}, out, Asize, pool, stride_, outSize) where T
+function maxpool2d_kernel(state, A::AbstractArray{T}, out, Asize, pool, stride, outSize) where T
     ilin = linear_index(state)
     idx = GPUArrays.gpu_ind2sub(Asize, ilin)
     if (idx[1] > outSize[1] || idx[2] > outSize[2] || idx[3] > outSize[3] || idx[4] > outSize[4])
         return
     end
 
-    temp_max = A[((idx[1] - 1) * stride_) + Asize[1] * (idx[2] - 1) * stride_ + (Asize[1] * Asize[2]) * (idx[3] - 1) + (Asize[1] * Asize[2] * Asize[3]) * (idx[4] - 1) + 1]
-    max_pos = ((idx[1] - 1) * stride_) + Asize[1] * (idx[2] - 1) * stride_ + (Asize[1] * Asize[2]) * (idx[3] - 1) + (Asize[1] * Asize[2] * Asize[3]) * (idx[4] - 1) + 1
-    curr_pos = ((idx[1] - 1) * stride_) + Asize[1] * (idx[2] - 1) * stride_ + (Asize[1] * Asize[2]) * (idx[3] - 1) + (Asize[1] * Asize[2] * Asize[3]) * (idx[4] - 1) + 1
+    temp_max = A[((idx[1] - 1) * stride) + Asize[1] * (idx[2] - 1) * stride + (Asize[1] * Asize[2]) * (idx[3] - 1) + (Asize[1] * Asize[2] * Asize[3]) * (idx[4] - 1) + 1]
+    max_pos = ((idx[1] - 1) * stride) + Asize[1] * (idx[2] - 1) * stride + (Asize[1] * Asize[2]) * (idx[3] - 1) + (Asize[1] * Asize[2] * Asize[3]) * (idx[4] - 1) + 1
+    curr_pos = ((idx[1] - 1) * stride) + Asize[1] * (idx[2] - 1) * stride + (Asize[1] * Asize[2]) * (idx[3] - 1) + (Asize[1] * Asize[2] * Asize[3]) * (idx[4] - 1) + 1
 
     for p in 1:pool
         for p in 1:pool
@@ -27,14 +27,16 @@ function maxpool2d_kernel(state, A::AbstractArray{T}, out, Asize, pool, stride_,
 end
 
 
-function maxpool2d(a, pool; stride_ = 1)
-    Asize = UInt32.(size(a))
+function maxpool2d(a, pool; stride = 1, pad = 0)
+    b = zeros(typeof(a), size(a,1) + pad * 2, size(a,2) + pad * 2, size(a,3), size(a,4))
+    b[pad + 1 : pad + size(a,1), pad + 1 : pad + size(a,2), :, :] = a
+    Asize = UInt32.(size(b))
     pool = UInt32(pool)
-    stride_ = UInt32(stride_)
-    out = similar(a)
-    out = out[1:(div(Asize[1] - pool, stride_) + 1), 1:(div(Asize[2] - pool, stride_) + 1), :, :]
+    stride = UInt32(stride)
+    out = similar(b)
+    out = out[1:(div(Asize[1] - pool, stride) + 1), 1:(div(Asize[2] - pool, stride) + 1), :, :]
     outSize = UInt32.(size(out))
-    gpu_call(maxpool2d_kernel, a, (a, out, Asize, pool, stride_, outSize))
+    gpu_call(maxpool2d_kernel, b, (b, out, Asize, pool, stride, outSize))
     GPUArrays.synchronize(out)
     out
 end

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -1,5 +1,3 @@
-import CUDAnative
-
 function maxpool2d_kernel(state, A::AbstractArray{T}, out, Asize, pool, stride, outSize) where T
     ilin = linear_index(state)
     idx = GPUArrays.gpu_ind2sub(Asize, ilin)
@@ -33,9 +31,10 @@ function maxpool2d{T <: Integer}(a, pool::T; stride = pool, pad = 0)
     Asize = UInt32.(size(b))
     pool = UInt32(pool)
     stride = UInt32(stride)
-    out = similar(b)
-    out = out[1:(div(Asize[1] - pool, stride) + 1), 1:(div(Asize[2] - pool, stride) + 1), :, :]
-    outSize = UInt32.(size(out))
+    outSize = [i for i in size(b)]
+    outSize[1:2] = [div(Asize[1] - pool, stride) + 1, div(Asize[2] - pool, stride) + 1]
+    out = similar(b, outSize...)
+    outSize = UInt32.(tuple(outSize...))
     gpu_call(maxpool2d_kernel, b, (b, out, Asize, pool, stride, outSize))
     GPUArrays.synchronize(out)
     out

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -1,0 +1,42 @@
+import CUDAnative
+
+function maxpool2d_kernel(state, A::AbstractArray{T}, out, Asize, pool, stride_, outSize) where T
+    ilin = linear_index(state)
+    idx = GPUArrays.gpu_ind2sub(Asize, ilin)
+    if (idx[1] > outSize[1] || idx[2] > outSize[2] || idx[3] > outSize[3] || idx[4] > outSize[4])
+        return
+    end
+
+    temp_max = A[((idx[1] - 1) * stride_) + Asize[1] * (idx[2] - 1) * stride_ + (Asize[1] * Asize[2]) * (idx[3] - 1) + (Asize[1] * Asize[2] * Asize[3]) * (idx[4] - 1) + 1]
+    max_pos = ((idx[1] - 1) * stride_) + Asize[1] * (idx[2] - 1) * stride_ + (Asize[1] * Asize[2]) * (idx[3] - 1) + (Asize[1] * Asize[2] * Asize[3]) * (idx[4] - 1) + 1
+    curr_pos = ((idx[1] - 1) * stride_) + Asize[1] * (idx[2] - 1) * stride_ + (Asize[1] * Asize[2]) * (idx[3] - 1) + (Asize[1] * Asize[2] * Asize[3]) * (idx[4] - 1) + 1
+
+    for p in 1:pool
+        for p in 1:pool
+            m = A[curr_pos]
+            if (m > temp_max)
+                    temp_max = m
+                    max_pos = curr_pos
+            end
+            curr_pos += 1
+        end
+        curr_pos += Asize[1] - pool
+    end
+    out[(idx[1] - 1) + outSize[1] * (idx[2] - 1) + (outSize[1] * outSize[2]) * (idx[3] - 1) + (outSize[1] * outSize[2] * outSize[3]) * (idx[4] - 1) + 1] = temp_max
+    return
+end
+
+
+function maxpool2d(a, pool; stride_ = 1)
+    Asize = UInt32.(size(a))
+    pool = UInt32(pool)
+    stride_ = UInt32(stride_)
+    out = similar(a)
+    out = out[1:(div(Asize[1] - pool, stride_) + 1), 1:(div(Asize[2] - pool, stride_) + 1), :, :]
+    outSize = UInt32.(size(out))
+    gpu_call(maxpool2d_kernel, a, (a, out, Asize, pool, stride_, outSize))
+    GPUArrays.synchronize(out)
+    out
+end
+
+

--- a/src/testsuite/pool.jl
+++ b/src/testsuite/pool.jl
@@ -7,7 +7,7 @@ function run_pool(Typ)
       continue
     end
     @testset "$ET" begin
-      @testset "maxpool" begin
+      @testset "maxpool with padding" begin
         pool = 3
         stride = 3
         pad = 3
@@ -18,7 +18,34 @@ function run_pool(Typ)
         out1 = maxpool(b, (3, 3))
 
         a = T(a)
-        out2 = GPUArrays.maxpool2d(a, pool, stride = 3, pad = 3)
+        out2 = GPUArrays.maxpool2d(a, pool, pad = pad)
+        
+        @test out1 ≈ out2
+      end
+
+      @testset "maxpool without padding" begin
+        pool = 3
+        stride = 3
+
+        a = rand(ET, 9,9,3,1)
+        out1 = maxpool(a, (3, 3))
+
+        a = T(a)
+        out2 = GPUArrays.maxpool2d(a, pool)
+        
+        @test out1 ≈ out2
+      end
+
+
+      @testset "maxpool with full kernel" begin
+        pool = 9
+        stride = 1
+
+        a = rand(ET, 9,9,3,1)
+        out1 = maxpool(a, (9, 9))
+
+        a = T(a)
+        out2 = GPUArrays.maxpool2d(a, pool, stride = stride)
         
         @test out1 ≈ out2
       end

--- a/src/testsuite/pool.jl
+++ b/src/testsuite/pool.jl
@@ -18,6 +18,7 @@ function run_pool(Typ)
         out1 = maxpool(b, (3, 3))
 
         a = T(a)
+        GPUArrays.allowslow(true)
         out2 = GPUArrays.maxpool2d(a, pool, pad = pad)
         
         @test out1 ≈ out2
@@ -31,6 +32,7 @@ function run_pool(Typ)
         out1 = maxpool(a, (3, 3))
 
         a = T(a)
+        GPUArrays.allowslow(true)
         out2 = GPUArrays.maxpool2d(a, pool)
         
         @test out1 ≈ out2
@@ -45,6 +47,7 @@ function run_pool(Typ)
         out1 = maxpool(a, (9, 9))
 
         a = T(a)
+        GPUArrays.allowslow(true)
         out2 = GPUArrays.maxpool2d(a, pool, stride = stride)
         
         @test out1 ≈ out2

--- a/src/testsuite/pool.jl
+++ b/src/testsuite/pool.jl
@@ -1,0 +1,27 @@
+using GPUArrays.TestSuite, Base.Test, Flux
+
+function run_pool(Typ)
+  for ET in supported_eltypes()
+    T = Typ{ET}
+    if (ET == Complex{Float32} || ET == Complex{Float64})
+      continue
+    end
+    @testset "$ET" begin
+      @testset "maxpool" begin
+        pool = 3
+        stride = 3
+        pad = 3
+
+        a = rand(ET, 9,9,3,1)
+        b = zeros(eltype(a), size(a,1) + pad * 2, size(a,2) + pad * 2, size(a,3), size(a,4))
+        b[pad + 1 : pad + size(a,1), pad + 1 : pad + size(a,2), :, :] = a
+        out1 = maxpool(b, (3, 3))
+
+        a = T(a)
+        out2 = GPUArrays.maxpool2d(a, pool, stride = 3, pad = 3)
+        
+        @test out1 ≈ out2
+      end
+    end
+  end
+end

--- a/src/testsuite/testsuite.jl
+++ b/src/testsuite/testsuite.jl
@@ -42,6 +42,7 @@ include("base.jl")
 include("indexing.jl")
 # include("vector.jl")
 include("random.jl")
+include("pool.jl")
 
 function supported_eltypes()
     (Float32, Float64, Int32, Int64, Complex64, Complex128)
@@ -62,6 +63,7 @@ function run_tests(Typ)
     run_mapreduce(Typ)
     run_indexing(Typ)
     run_random(Typ)
+    run_pool(Typ)
 end
 
 export against_base, run_tests, supported_eltypes

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,2 @@
+Flux
+CUDAnative


### PR DESCRIPTION
An implementation of `maxpool`. Here's a sample benchmarking (CPU v/s GPU): https://gist.github.com/americast/95358d972647adf5c7ebcde7c58db51f

Tests were failing due to `getindex is disabled` error. I have made a small change in `src/indexing.jl` as a workaround.

Thanks.