### PR TITLE
Fix broadcast

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7.0-alpha-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 matrix:
   allow_failures:

--- a/src/GPUArrays.jl
+++ b/src/GPUArrays.jl
@@ -4,6 +4,7 @@ module GPUArrays
 using Serialization
 using Random
 using LinearAlgebra
+using Printf
 import Base: copyto!
 
 import Random: rand, rand!

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -31,19 +31,13 @@ end
 
 ############################################
 # serialization
-const BaseSerializer = if isdefined(Base, :AbstractSerializer)
-    Base.AbstractSerializer
-elseif isdefined(Base, :SerializationState)
-    Base.SerializationState
-else
-    error("No Serialization type found. Probably unsupported Julia version")
-end
+import Serialization: AbstractSerializer, serialize, deserialize, serialize_type
 
-function Base.serialize(s::BaseSerializer, t::T) where T <: GPUArray
-    Base.serialize_type(s, T)
+function serialize(s::AbstractSerializer, t::T) where T <: GPUArray
+    serialize_type(s, T)
     serialize(s, Array(t))
 end
-function Base.deserialize(s::BaseSerializer, ::Type{T}) where T <: GPUArray
+function deserialize(s::AbstractSerializer, ::Type{T}) where T <: GPUArray
     A = deserialize(s)
     T(A)
 end

--- a/src/base.jl
+++ b/src/base.jl
@@ -95,11 +95,11 @@ end
 
 # This is pretty ugly, but I feel bad to add those to device arrays, since
 # we're never bound checking... So getindex(a::GPUVector, 10, 10) would silently go unnoticed
-# we need this here for easier implementation of repmat
+# we need this here for easier implementation of repeat
 @inline Base.@propagate_inbounds getidx_2d1d(x::AbstractVector, i, j) = x[i]
 @inline Base.@propagate_inbounds getidx_2d1d(x::AbstractMatrix, i, j) = x[i, j]
 
-function Base.repmat(a::GPUVecOrMat, m::Int, n::Int = 1)
+function Base.repeat(a::GPUVecOrMat, m::Int, n::Int = 1)
     o, p = size(a, 1), size(a, 2)
     b = similar(a, o*m, p*n)
     args = (b, a, UInt32.((o, p, m, n))...)
@@ -121,7 +121,7 @@ function Base.repmat(a::GPUVecOrMat, m::Int, n::Int = 1)
     return b
 end
 
-function Base.repmat(a::GPUVector, m::Int)
+function Base.repeat(a::GPUVector, m::Int)
     o = length(a)
     b = similar(a, o*m)
     gpu_call(a, (b, a, UInt32(o), UInt32(m)), m) do state, b, a, o, m

--- a/src/blas.jl
+++ b/src/blas.jl
@@ -91,9 +91,9 @@ for elty in (Float32, Float64, ComplexF32, ComplexF64)
 end
 
 
-for elty in (Float32, Float64, Complex64, Complex128)
+for elty in (Float32, Float64, ComplexF32, ComplexF64)
     @eval begin
-        function Base.BLAS.gbmv!(trans::Char, m::Int, kl::Int, ku::Int, alpha::($elty), A::GPUMatrix{$elty}, X::GPUVector{$elty}, beta::($elty), Y::GPUVector{$elty})
+        function BLAS.gbmv!(trans::Char, m::Int, kl::Int, ku::Int, alpha::($elty), A::GPUMatrix{$elty}, X::GPUVector{$elty}, beta::($elty), Y::GPUVector{$elty})
             n = size(A, 2)
             if trans == 'N' && (length(X) != n || length(Y) != m)
                 throw(DimensionMismatch("A has dimensions $n, $m, X has length $(length(X)) and Y has length $(length(Y))"))

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -1,168 +1,27 @@
+using Base.Broadcast
 
-import Base.Broadcast: BroadcastStyle, AbstractArrayStyle, Broadcasted, broadcast_axes
-import Base.Broadcast: DefaultArrayStyle, materialize!, flatten, ArrayStyle, combine_styles
-
-BroadcastStyle(::Type{T}) where T <: GPUArray = ArrayStyle{T}()
-BroadcastStyle(::Type{Any}, ::Type{T}) where T <: GPUArray = ArrayStyle{T}()
-BroadcastStyle(::Type{T}, ::Type{Any}) where T <: GPUArray = ArrayStyle{T}()
-BroadcastStyle(::Type{T1}, ::Type{T2}) where {T1 <: GPUArray, T2 <: GPUArray} = ArrayStyle{T}()
-
-const GPUBroadcast = Broadcasted{<: ArrayStyle{<: GPUArray}}
-
-function Base.similar(bc::Broadcasted{ArrayStyle{GPU}}, ::Type{ElType}) where {GPU <: GPUArray, ElType}
-    similar(GPU, ElType, axes(bc))
-end
-
-# copy overload
-
-function gpu_eachindex(f, axes, A::GPUArray, args...)
-    # TODO use axes + offset etc
-    shape = length.(axes)
-    gpu_call(A, (f, shape, A, args...), prod(shape)) do state, f, A, args...
-        lidx = linear_index(state)
-        lidx > length(A) && return
-        cartesian = CartesianIndex(gpu_ind2sub(shape, lidx))
-        f(state, cartesian, A, args...)
-        return
-    end
-end
-
-# copyto! overloads
-@inline function copyto!(dest::GPUArray, B::GPUBroadcast)
-    flat = flatten(B); as = flat.args; f = flat.f
-    gpu_broadcast!(f, dest, as)
-end
-
- # RefValue doesn't work with CUDAnative so we use Tuple, which should have the same behaviour
-deref(x) = x
-deref(x::RefValue) = (x[],)
-
-function gpu_broadcast!(
-        func, out::GPUArray, _args
-    )
-    args = deref.(_args)
-    # TODO handle cases if axes is not OneTo
-    shape = length.(broadcast_axes(out))
-    gshape = UInt32.(size(out))
-    descriptor_tuple = ntuple(length(args)) do i
-        BInfo(shape, args[i])
-    end
-    gpu_call(broadcast_kernel!, out, (func, out, gshape, descriptor_tuple, args))
-    out
-end
-
-@inline function broadcast_kernel!(state, func, out, shape, descriptor, args)
-    ilin = @linearidx(out, state)
-    @inbounds out[ilin] = apply_broadcast(ilin, func, shape, descriptor, args)
-    return
-end
-
-arg_shape(x::Tuple) = (UInt32(length(x)),)
-arg_shape(x::AbstractArray) = UInt32.(size(x))
-arg_shape(x) = () # Scalar
-
-struct BInfo{Typ, N}
-    size::NTuple{N, UInt32}
-    keep::NTuple{N, UInt32}
-    idefault::NTuple{N, UInt32}
-end
-
-function BInfo(shape::NTuple{N, <: Integer}, arg) where N
-    typ = typeof(combine_styles(arg))
-    ashape = arg_shape(arg)
-    keep = ntuple(Val{length(ashape)}) do i
-        # < is not enough normally, but all other checks should have been performed by check broadcast shape
-        ashape[i] < shape[i] && return UInt32(0)
-        UInt32(1)
-    end
-    idefault = ntuple(Val{length(ashape)}) do i
-        ashape[i] < shape[i] && return UInt32(1)
-        UInt32(ashape[i])
-    end
-    BInfo{typ, N}(ashape, keep, idefault)
-end
-
-@propagate_inbounds @inline function _broadcast_getindex(
-        ::BInfo{<: ArrayStyle}, A, I
-    )
-    A[I]
-end
-
-@inline _broadcast_getindex(any, A, I) = A
-
-# don't do anything for empty tuples
-@pure newindex(I, ilin, keep::Tuple{}, Idefault::Tuple{}, size::Tuple{}) = UInt32(1)
-
-# optimize for 1D arrays
-@pure function newindex(I::NTuple{1}, ilin, keep::NTuple{1}, Idefault, size)
-    (keep[1] % Bool) ? ilin : Idefault[1]
-end
-
-# differently shaped arrays
-@generated function newindex(I, ilin::T, keep::NTuple{N}, Idefault, size) where {N, T}
-    exprs = Expr(:tuple)
-    for i = 1:N
-        push!(exprs.args, :(T((keep[$i] % Bool) ? T(I[$i]) : T(Idefault[$i]))))
-    end
-    :(Base.@_inline_meta; gpu_sub2ind(size, $exprs))
-end
-
-for N = 0:15
-    nargs = N + 1
-    inner_expr = []
-    valargs = []
-    for i = 1:N
-        val_i = Symbol("val_", i); I_i = Symbol("I_", i);
-        desi = Symbol("deref_", i)
-        inner = quote
-            # destructure the keeps and As tuples
-            $desi = descriptor[$i]
-            # reverse-broadcast the indices
-            $I_i = newindex(
-                I, ilin,
-                $desi.keep,
-                $desi.idefault,
-                $desi.size
-            )
-            # extract array values
-            @inbounds $val_i = _broadcast_getindex($desi, args[$i], $I_i)
-        end
-        push!(inner_expr, inner)
-        push!(valargs, val_i)
-    end
-    @eval begin
-        @inline function apply_broadcast(ilin, func, shape, descriptor, args::NTuple{$N, Any})
-            # this will hopefully get dead code removed,
-            # if only arrays with linear index are involved, because I should be unused in that case
-            I = gpu_ind2sub(shape, ilin)
-            $(inner_expr...)
-            # call the function and store the result
-            func($(valargs...))
+@inline function Base.copyto!(dest::GPUArray, bc::Broadcast.Broadcasted{Nothing})
+    axes(dest) == axes(bc) || Broadcast.throwdm(axes(dest), axes(bc))
+    # # Performance optimization: broadcast!(identity, dest, A) is equivalent to copyto!(dest, A) if indices match
+    # if bc.f === identity && bc.args isa Tuple{AbstractArray} # only a single input argument to broadcast!
+    #     A = bc.args[1]
+    #     if axes(dest) == axes(A)
+    #         return copyto!(dest, A)
+    #     end
+    # end
+    bc′ = Broadcast.preprocess(dest, bc)
+    gpu_call(dest, (dest, bc′)) do state, dest, bc′
+        let I = CartesianIndex(@cartesianidx(dest))
+            @inbounds dest[I] = bc[I]
         end
     end
+
+    return dest
 end
 
-function foreach_kernel(state, func, shape, descriptor, args)
-    ilin = @linearidx(args[1], state)
-    apply_broadcast(ilin, func, shape, descriptor, args)
-    return
-end
-
-function Base.foreach(func, over::GPUArray, Bs...)
-    shape = UInt32.(size(over))
-    keeps, Idefaults = map_newindexer(shape, over, Bs)
-    args = (over, Bs...)
-    descriptor_tuple = ntuple(length(args)) do i
-        BInfo(args[i], keeps[i], Idefaults[i])
-    end
-    gpu_call(foreach_kernel, over, (func, shape, descriptor_tuple, (over, deref.(Bs)...)))
-    return
-end
-function mapidx_kernel(state, f, A, args)
-    ilin = @linearidx(A, state)
-    f(ilin, A, args...)
-    return
-end
 function mapidx(f, A::GPUArray, args::NTuple{N, Any}) where N
-    gpu_call(mapidx_kernel, A, (f, A, args))
+    gpu_call(A, (f, A, args)) do state, f, A, args
+        ilin = @linearidx(A, state)
+        f(ilin, A, args...)
+    end
 end

--- a/src/construction.jl
+++ b/src/construction.jl
@@ -10,11 +10,6 @@ function fill(X::Type{<: GPUArray}, val::T, dims::NTuple{N, Integer}) where {T, 
     fill!(res, val)
 end
 
-function fill!(A::GPUArray{T, N}, val) where {T, N}
-    A .= identity.(T(val))
-    A
-end
-
 zeros(T::Type{<: GPUArray}, dims::NTuple{N, Integer}) where N = fill(T, zero(eltype(T)), dims)
 ones(T::Type{<: GPUArray}, dims::NTuple{N, Integer}) where N = fill(T, one(eltype(T)), dims)
 

--- a/src/construction.jl
+++ b/src/construction.jl
@@ -1,4 +1,5 @@
-import Base: fill!, similar, eye, zeros, ones, fill
+import Base: fill!, similar, zeros, ones, fill
+import LinearAlgebra: eye
 
 
 function fill(X::Type{<: GPUArray}, val, dims::Integer...)

--- a/src/construction.jl
+++ b/src/construction.jl
@@ -31,8 +31,9 @@ end
 
 (T::Type{<: GPUArray})(x) = convert(T, x)
 (T::Type{<: GPUArray})(dims::Integer...) = T(dims)
-(T::Type{<: GPUArray})(dims::NTuple{N, Base.OneTo{Int}}) where N = T(length.(dims))
+(T::Type{<: GPUArray})(dims::NTuple{N, Base.OneTo{Int}}) where N = T(undef, length.(dims))
 (T::Type{<: GPUArray{X} where X})(dims::NTuple{N, Integer}) where N = similar(T, eltype(T), dims)
+(T::Type{<: GPUArray{X} where X})(::UndefInitializer, dims::NTuple{N, Integer}) where N = similar(T, eltype(T), dims)
 
 similar(x::X, ::Type{T}, size::Base.Dims{N}) where {X <: GPUArray, T, N} = similar(X, T, size)
 similar(::Type{X}, ::Type{T}, size::NTuple{N, Base.OneTo{Int}}) where {X <: GPUArray, T, N} = similar(X, T, length.(size))

--- a/src/jlbackend.jl
+++ b/src/jlbackend.jl
@@ -158,7 +158,7 @@ for (i, sym) in enumerate((:x, :y, :z))
     end
 end
 
-blas_module(::JLArray) = Base.LinAlg.BLAS
+blas_module(::JLArray) = LinearAlgebra.BLAS
 blasbuffer(A::JLArray) = A.data
 
 

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -3,8 +3,6 @@ import Base: any, all, count, countnz, isapprox
 #############################
 # reduce
 # functions in base implemented with a direct loop need to be overloaded to use mapreduce
-any(pred, A::GPUArray) = Bool(mapreduce(pred, |, Int32(0), A))
-all(pred, A::GPUArray) = Bool(mapreduce(pred, &, Int32(1), A))
 count(pred, A::GPUArray) = Int(mapreduce(pred, +, UInt32(0), A))
 countnz(A::GPUArray) = Int(mapreduce(x-> x != 0, +, UInt32(0), A))
 countnz(A::GPUArray, dim) = Int(mapreducedim(x-> x != 0, +, UInt32(0), A, dim))

--- a/src/random.jl
+++ b/src/random.jl
@@ -41,8 +41,8 @@ function gpu_rand(::Type{T}, state, randstate::AbstractVector{NTuple{4, UInt32}}
     return to_number_range(f, T)
 end
 
-global cached_state, clear_cache
 let rand_state_dict = Dict()
+    global cached_state, clear_cache
     clear_cache() = (empty!(rand_state_dict); return)
     function cached_state(x)
         dev = GPUArrays.device(x)

--- a/src/testsuite/base.jl
+++ b/src/testsuite/base.jl
@@ -55,8 +55,8 @@ function run_base(Typ)
             y = rand(Float32, 20, 10)
             a = Typ(x)
             b = Typ(y)
-            r1 = CartesianIndices(CartesianIndex(1, 3), CartesianIndex(7, 8))
-            r2 = CartesianIndices(CartesianIndex(4, 3), CartesianIndex(10, 8))
+            r1 = CartesianIndices((1:7, 3:8))
+            r2 = CartesianIndices((4:10, 3:8))
             copyto!(x, r1, y, r2)
             copyto!(a, r1, b, r2)
             @test x == Array(a)
@@ -132,11 +132,11 @@ function run_base(Typ)
             against_base((a, b, c, d)-> map!(*, a, b, c, d), T, (10,), (10,), (10,), (10,))
         end
 
-        @testset "repmat" begin
-            against_base(a-> repmat(a, 5, 6), T, (10,))
-            against_base(a-> repmat(a, 5), T, (10,))
-            against_base(a-> repmat(a, 5), T, (5, 4))
-            against_base(a-> repmat(a, 4, 3), T, (10, 15))
+        @testset "repeat" begin
+            against_base(a-> repeat(a, 5, 6), T, (10,))
+            against_base(a-> repeat(a, 5), T, (10,))
+            against_base(a-> repeat(a, 5), T, (5, 4))
+            against_base(a-> repeat(a, 4, 3), T, (10, 15))
         end
     end
 end

--- a/src/testsuite/gpuinterface.jl
+++ b/src/testsuite/gpuinterface.jl
@@ -1,7 +1,7 @@
 function run_gpuinterface(Typ)
     @testset "parallel execution interface" begin
         N = 10
-        x = Typ(Vector{Int}(N))
+        x = Typ(Vector{Int}(undef, N))
         x .= 0
         gpu_call(x, (x,)) do state, x
             x[linear_index(state)] = 2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using GPUArrays, Base.Test
+using GPUArrays, Test
 using GPUArrays.TestSuite
 
 


### PR DESCRIPTION
CLArray/CUArray will have to define the equivalent of:

```
function CUDAnative.cudaconvert(bc::Broadcast.Broadcasted{Style}) where Style
    Broadcast.Broadcasted{Style}(bc.f, map(CUDAnative.cudaconvert, bc.args), bc.axes)
end

function CUDAnative.cudaconvert(ex::Broadcast.Extruded)
    Broadcast.Extruded(CUDAnative.cudaconvert(ex.x), ex.keeps, ex.defaults)
end
```

but this simplifies broadcast a bunch. Test failures are down to a handful now and a whole bunch of deprecation warnings to go.