### PR TITLE
allow tests using Julia v1.0 (Travis)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ os:
 dist: trusty
 julia:
   - 0.7
+  - 1.0
   - nightly
 matrix:
  allow_failures:


### PR DESCRIPTION
There are tests using Julia v1.0 on Appveyor but not on Travis. Since these are passing and there have been a lot of commits, it might make sense to release a new version of GPUArrays.jl?