### PR TITLE
Broadcast cleanup

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.7-alpha
 StaticArrays
 FFTW
+FillArrays

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -1,4 +1,4 @@
-import Base: show, showcompact, similar, convert, _reshape, map!, copyto!, map, copy, deepcopy
+import Base: similar, convert, _reshape, map!, copyto!, map, copy, deepcopy
 
 # Dense GPU Array
 abstract type GPUArray{T, N} <: DenseArray{T, N} end

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -16,16 +16,6 @@ struct LocalMemory{T} <: GPUArray{T, 1}
     LocalMemory{T}(x::Integer) where T = new{T}(x)
 end
 
-#=
-AbstractArray interface
-=#
-
-function Base.show(io::IO, A::GPUArray)
-    print(io, "GPU: ")
-    Base.show(io, Array(A), repr)
-end
-
-
 ############################################
 # serialization
 import Serialization: AbstractSerializer, serialize, deserialize, serialize_type

--- a/src/array.jl
+++ b/src/array.jl
@@ -30,15 +30,9 @@ pointer(x::JLArray) = pointer(x.data)
 
 
 ## I/O
-
-Base.show(io::IO, x::JLArray) = show(io, collect(x))
-Base.show(io::IO, x::LinearAlgebra.Adjoint{<:Any,<:JLArray}) = show(io, LinearAlgebra.adjoint(collect(x.parent)))
-Base.show(io::IO, x::LinearAlgebra.Transpose{<:Any,<:JLArray}) = show(io, LinearAlgebra.transpose(collect(x.parent)))
-
-Base.show(io::IO, ::MIME"text/plain", x::JLArray) = show(io, MIME"text/plain"(), collect(x))
-Base.show(io::IO, ::MIME"text/plain", x::LinearAlgebra.Adjoint{<:Any,<:JLArray}) = show(io, MIME"text/plain"(), LinearAlgebra.adjoint(collect(x.parent)))
-Base.show(io::IO, ::MIME"text/plain", x::LinearAlgebra.Transpose{<:Any,<:JLArray}) = show(io, MIME"text/plain"(), LinearAlgebra.transpose(collect(x.parent)))
-
+Base.print_array(io::IO, x::GPUArray) = Base.print_array(io, collect(x))B
+Base.print_array(io::IO, x::LinearAlgebra.Adjoint{<:Any,<:GPUArray}) = Base.print_array(io, LinearAlgebra.adjoint(collect(x.parent)))
+Base.print_array(io::IO, x::LinearAlgebra.Transpose{<:Any,<:GPUArray}) = Base.print_array(io, LinearAlgebra.transpose(collect(x.parent)))
 
 ## other
 

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -1,33 +1,13 @@
 using Base.Broadcast
-import Base.Broadcast: Broadcasted
 
-import Base.Broadcast: BroadcastStyle, AbstractArrayStyle, Broadcasted, broadcast_axes
-import Base.Broadcast: DefaultArrayStyle, materialize!, flatten, ArrayStyle, combine_styles
+import Base.Broadcast: BroadcastStyle, Broadcasted, ArrayStyle
 
 BroadcastStyle(::Type{T}) where T <: GPUArray = ArrayStyle{T}()
-BroadcastStyle(::Type{Any}, ::Type{T}) where T <: GPUArray = ArrayStyle{T}()
-BroadcastStyle(::Type{T}, ::Type{Any}) where T <: GPUArray = ArrayStyle{T}()
-BroadcastStyle(::Type{T1}, ::Type{T2}) where {T1 <: GPUArray, T2 <: GPUArray} = ArrayStyle{T}()
 
-const GPUBroadcast = Broadcasted{<: ArrayStyle{<: GPUArray}}
-
-function Base.similar(bc::Broadcasted{ArrayStyle{GPU}}, ::Type{ElType}) where {GPU <: GPUArray, ElType}
+function Base.similar(bc::Broadcasted{<:ArrayStyle{GPU}}, ::Type{ElType}) where {GPU <: GPUArray, ElType}
     similar(GPU, ElType, axes(bc))
 end
 
-@inline function Base.copyto!(dest::GPUArray, bc::GPUBroadcast)
-    axes(dest) == axes(bc) || Broadcast.throwdm(axes(dest), axes(bc))
-    bc′ = Broadcast.preprocess(dest, bc)
-    gpu_call(dest, (dest, bc′)) do state, dest, bc′
-        let I = CartesianIndex(@cartesianidx(dest))
-            @inbounds dest[I] = bc′[I]
-        end
-    end
-
-    return dest
-end
-
-# the same?
 @inline function Base.copyto!(dest::GPUArray, bc::Broadcasted{Nothing})
     axes(dest) == axes(bc) || Broadcast.throwdm(axes(dest), axes(bc))
     bc′ = Broadcast.preprocess(dest, bc)


### PR DESCRIPTION
The `BroadcastStyle` definitions are already defined by Base and the last one is wrong (and untested).

`copyto!` only needs to be defined for the output type and not for `GPUBroadcast`