### PR TITLE
Actually fix the matmul coverage

### DIFF
--- a/src/testsuite/blas.jl
+++ b/src/testsuite/blas.jl
@@ -1,14 +1,25 @@
 function test_blas(AT)
     @testset "BLAS" begin
-        @testset "matmul" begin
-            @test compare(*, AT, rand(Float32, 5, 5), rand(Float32, 5, 5))
-            @test compare(*, AT, rand(Float32, 5, 5), rand(Float32, 5))
-            @test compare((a, b)-> a * transpose(b), AT, rand(Float32, 5, 5), rand(Float32, 5, 5))
-            @test compare((c, a, b)-> mul!(c, a, transpose(b)), AT, rand(Float32, 10, 32), rand(Float32, 10, 60), rand(Float32, 32, 60))
-            @test compare((a, b)-> transpose(a) * b, AT, rand(Float32, 5, 5), rand(Float32, 5, 5))
-            @test compare((a, b)-> transpose(a) * transpose(b), AT, rand(Float32, 10, 15), rand(Float32, 1, 10))
-            @test compare((a, b)-> transpose(a) * b, AT, rand(Float32, 10, 15), rand(Float32, 10))
-            @test compare(mul!, AT, rand(Float32, 15), rand(Float32, 15, 10), rand(Float32, 10))
+        @testset "matmul with element type $elty" for elty in (Float32, Float64, ComplexF32, ComplexF64)
+            A = rand(elty, 5, 6)
+            B = rand(elty, 6, 5)
+            C = rand(elty, 5, 5)
+            x = rand(elty, 5)
+            y = rand(elty, 6)
+
+            @test compare(*, AT, A, y)
+            @test compare((t,s) -> transpose(t)*s, AT, A, x)
+            @test compare((t,s) -> adjoint(t)*s  , AT, A, x)
+
+            @test compare(*, AT, A, B)
+            @test compare((t,s) -> transpose(t)*s           , AT, A, C)
+            @test compare((t,s) -> t*transpose(s)           , AT, C, B)
+            @test compare((t,s) -> transpose(t)*transpose(s), AT, A, B)
+            @test compare((t,s) -> adjoint(t)*s             , AT, A, C)
+            @test compare((t,s) -> t*adjoint(s)             , AT, C, B)
+            @test compare((t,s) -> adjoint(t)*adjoint(s)    , AT, A, B)
+            @test compare((t,s) -> transpose(t)*adjoint(s)  , AT, A, B)
+            @test compare((t,s) -> adjoint(t)*transpose(s)  , AT, A, B)
         end
 
         for T in (ComplexF32, Float32)

--- a/src/testsuite/blas.jl
+++ b/src/testsuite/blas.jl
@@ -1,25 +1,14 @@
 function test_blas(AT)
     @testset "BLAS" begin
-        @testset "matmul with element type $elty" for elty in (Float32, Float64, ComplexF32, ComplexF64)
-            A = rand(elty, 5, 6)
-            B = rand(elty, 6, 5)
-            C = rand(elty, 5, 5)
-            x = rand(elty, 5)
-            y = rand(elty, 6)
-
-            @test compare(*, AT, A, y)
-            @test compare(*, AT, transpose(A), x)
-            @test compare(*, AT, adjoint(A), x)
-
-            @test compare(*, AT, A, B)
-            @test compare(*, AT, transpose(A), C)
-            @test compare(*, AT, C, transpose(B))
-            @test compare(*, AT, transpose(A), transpose(B))
-            @test compare(*, AT, adjoint(A), C)
-            @test compare(*, AT, C, adjoint(B))
-            @test compare(*, AT, adjoint(A), adjoint(B))
-            @test compare(*, AT, transpose(A), adjoint(B))
-            @test compare(*, AT, adjoint(A), transpose(B))
+        @testset "matmul" begin
+            @test compare(*, AT, rand(Float32, 5, 5), rand(Float32, 5, 5))
+            @test compare(*, AT, rand(Float32, 5, 5), rand(Float32, 5))
+            @test compare((a, b)-> a * transpose(b), AT, rand(Float32, 5, 5), rand(Float32, 5, 5))
+            @test compare((c, a, b)-> mul!(c, a, transpose(b)), AT, rand(Float32, 10, 32), rand(Float32, 10, 60), rand(Float32, 32, 60))
+            @test compare((a, b)-> transpose(a) * b, AT, rand(Float32, 5, 5), rand(Float32, 5, 5))
+            @test compare((a, b)-> transpose(a) * transpose(b), AT, rand(Float32, 10, 15), rand(Float32, 1, 10))
+            @test compare((a, b)-> transpose(a) * b, AT, rand(Float32, 10, 15), rand(Float32, 10))
+            @test compare(mul!, AT, rand(Float32, 15), rand(Float32, 15, 10), rand(Float32, 10))
         end
 
         for T in (ComplexF32, Float32)


### PR DESCRIPTION
So I thought that `Adjoint` and `Transpose` would be preserved in `compare` but I was wrong so the previous version of this didn't actually exercise anything but `GPUMatrix*GPUVector` and `GPUMatrix*GPUMatrix`. Eventually, it would probably be nice to preserve the wrapper when passed to `compare` but for now, I just move the wrapping to the test closure. Unless there are any objections, I'll merge this fairly soon since we'll need this in `CuArrays` to verify some bugfixes.