### PR TITLE
Fix `Base.mapreduce` to match the new signature in 0.7/1.0

### DIFF
--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -58,8 +58,8 @@ end
 
 for (atype, op) in
     [(:(GPUArray), :(Array)),
-     (:(LinearAlgebra.Adjoint{<:Any,<:GPUArray}), :(x->LinearAlgebra.adjoint(Array(x.parent)))),
-     (:(LinearAlgebra.Transpose{<:Any,<:GPUArray}), :(x->LinearAlgebra.transpose(Array(x.parent))))]
+     (:(LinearAlgebra.Adjoint{<:Any,<:GPUArray}), :(x->LinearAlgebra.adjoint(Array(parent(x))))),
+     (:(LinearAlgebra.Transpose{<:Any,<:GPUArray}), :(x->LinearAlgebra.transpose(Array(parent(x)))))]
   @eval begin
     # for display
     Base.print_array(io::IO, X::($atype)) =

--- a/src/testsuite.jl
+++ b/src/testsuite.jl
@@ -49,7 +49,6 @@ end
 Runs the entire GPUArrays test suite on array type `AT`
 """
 function test(AT::Type{<:GPUArray})
-    GPUArrays.allowscalar(false)
     TestSuite.test_construction(AT)
     TestSuite.test_gpuinterface(AT)
     TestSuite.test_indexing(AT)

--- a/src/testsuite.jl
+++ b/src/testsuite.jl
@@ -49,6 +49,7 @@ end
 Runs the entire GPUArrays test suite on array type `AT`
 """
 function test(AT::Type{<:GPUArray})
+    GPUArrays.allowscalar(false)
     TestSuite.test_construction(AT)
     TestSuite.test_gpuinterface(AT)
     TestSuite.test_indexing(AT)

--- a/src/testsuite/io.jl
+++ b/src/testsuite/io.jl
@@ -12,7 +12,10 @@ function test_io(AT)
 
           show(io, A)
           seekstart(io)
-          @test String(take!(io)) == "[1]"
+          msg = String(take!(io)) # result of e.g. `print` differs on 32bit and 64bit machines
+          # due to different definition of `Int` type
+          # print([1]) shows as [1] on 64bit but Int64[1] on 32bit
+          @test msg == "[1]" || msg == "Int64[1]"
 
           show(io, MIME("text/plain"), B)
           seekstart(io)
@@ -20,7 +23,8 @@ function test_io(AT)
 
           show(io, B)
           seekstart(io)
-          @test String(take!(io)) == "[1 2; 3 4]"
+          msg = String(take!(io))
+          @test msg == "[1 2; 3 4]" || msg == "Int64[1 2; 3 4]"
 
           show(io, MIME("text/plain"), A')
           seekstart(io)

--- a/src/testsuite/io.jl
+++ b/src/testsuite/io.jl
@@ -3,10 +3,24 @@ function test_io(AT)
         @testset "showing" begin
           io = IOBuffer()
           A = AT(Int64[1])
+          B = AT(Int64[1 2;3 4]) # vectors and non-vector arrays showing
+                                 # are handled differently in base/arrayshow.jl
 
           show(io, MIME("text/plain"), A)
           seekstart(io)
           @test String(take!(io)) == "1-element $AT{Int64,1}:\n 1"
+
+          show(io, A)
+          seekstart(io)
+          @test String(take!(io)) == "[1]"
+
+          show(io, MIME("text/plain"), B)
+          seekstart(io)
+          @test String(take!(io)) == "2×2 $AT{Int64,2}:\n 1  2\n 3  4"
+
+          show(io, B)
+          seekstart(io)
+          @test String(take!(io)) == "[1 2; 3 4]"
 
           show(io, MIME("text/plain"), A')
           seekstart(io)

--- a/src/testsuite/mapreduce.jl
+++ b/src/testsuite/mapreduce.jl
@@ -21,6 +21,15 @@ function test_mapreduce(AT)
                         x = T(y)
                         @test sum(y, dims = 2) ≈ Array(sum(x, dims = 2))
                         @test sum(y, dims = 1) ≈ Array(sum(x, dims = 1))
+
+                        y = rand(range, N, N)
+                        x = T(y)
+                        _zero = zero(ET)
+                        _addone(z) = z + one(ET)
+                        @test mapreduce(_addone, +, y; dims = 2, init = _zero) ≈
+                            Array(mapreduce(_addone, +, x; dims = 2, init = _zero))
+                        @test mapreduce(_addone, +, y; init = _zero) ≈
+                            mapreduce(_addone, +, x; init = _zero)
                     end
                 end
                 @testset "sum maximum minimum prod" begin


### PR DESCRIPTION
In Julia 0.7/1.0, the signature of `Base.mapreduce` and its alternative function `Base.mapreducedim` which allows a `dims` argument, have [changed](https://github.com/JuliaLang/julia/pull/27711) to use keyword arguments, i.e.
from
`mapreduce(f, op[, v0], itr)`
`mapreducedim(f, op, itr, region[, v0])`
to
`mapreduce(f, op, itr; dims=:, [init])`

It seems that the bot wasn't able to figure out that this is deprecated syntax. The current head is still passing tests since no test case tries to pass a customised initial value to it.