### PR TITLE
Support `Transpose` and `Adjoint` in broadcast better

### DIFF
--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -30,10 +30,6 @@ function deserialize(s::AbstractSerializer, ::Type{T}) where T <: GPUArray
     T(A)
 end
 
-@inline unpack_buffer(x) = x
-@inline unpack_buffer(x::GPUArray) = pointer(x)
-@inline unpack_buffer(x::Ref{<: GPUArray}) = unpack_buffer(x[])
-
 function to_cartesian(A, indices::Tuple)
     start = CartesianIndex(ntuple(length(indices)) do i
         val = indices[i]

--- a/src/array.jl
+++ b/src/array.jl
@@ -21,6 +21,8 @@ function JLArray{T, N}(size::NTuple{N, Integer}) where {T, N}
     JLArray{T, N}(Array{T, N}(undef, size), size)
 end
 
+struct JLBackend <: GPUBackend end
+backend(::Type{<:JLArray}) = JLBackend()
 
 ## getters
 
@@ -120,7 +122,7 @@ function AbstractDeviceArray(ptr::Array, shape::Vararg{Integer, N}) where N
     reshape(ptr, shape)
 end
 
-function _gpu_call(f, A::JLArray, args::Tuple, blocks_threads::Tuple{T, T}) where T <: NTuple{N, Integer} where N
+function _gpu_call(::JLBackend, f, A, args::Tuple, blocks_threads::Tuple{T, T}) where T <: NTuple{N, Integer} where N
     blocks, threads = blocks_threads
     idx = ntuple(i-> 1, length(blocks))
     blockdim = blocks

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -2,44 +2,54 @@ using Base.Broadcast
 
 import Base.Broadcast: BroadcastStyle, Broadcasted, ArrayStyle
 
-# We define a generic `BroadcastStyle` here that should be sufficient for most cases
+# we define a generic `BroadcastStyle` here that should be sufficient for most cases.
 # dependent packages like `CuArrays` can define their own `BroadcastStyle` allowing
 # them to further change or optimize broadcasting.
-# TODO: Investigate if we should define out own `GPUArrayStyle{N} <: AbstractArrayStyle{N}`
-# NOTE: This uses the specific `T` that was used e.g. `JLArray` or `CLArray` for ArrayStyle, instead
-#       of using `ArrayStyle{GPUArray}`, this is due to the fact how `similar` works.
+#
+# TODO: investigate if we should define out own `GPUArrayStyle{N} <: AbstractArrayStyle{N}`
+#
+# NOTE: this uses the specific `T` that was used e.g. `JLArray` or `CLArray` for ArrayStyle,
+#       instead of using `ArrayStyle{GPUArray}`, due to the fact how `similar` works.
 BroadcastStyle(::Type{T}) where {T<:GPUArray} = ArrayStyle{T}()
 
 # These wrapper types otherwise forget that they are GPU compatible
-# Note: Don't directly use ArrayStyle{GPUArray} here since that would mean that `CuArrays`
-# customizations no longer take effect.
+#
+# NOTE: Don't directly use ArrayStyle{GPUArray} here since that would mean that `CuArrays`
+#       customization no longer take effect.
 BroadcastStyle(::Type{<:LinearAlgebra.Transpose{<:Any,T}}) where {T<:GPUArray} = BroadcastStyle(T)
 BroadcastStyle(::Type{<:LinearAlgebra.Adjoint{<:Any,T}}) where {T<:GPUArray} = BroadcastStyle(T)
+BroadcastStyle(::Type{<:SubArray{<:Any,<:Any,T}}) where {T<:GPUArray} = BroadcastStyle(T)
 
 backend(::Type{<:LinearAlgebra.Transpose{<:Any,T}}) where {T<:GPUArray} = backend(T)
 backend(::Type{<:LinearAlgebra.Adjoint{<:Any,T}}) where {T<:GPUArray} = backend(T)
+backend(::Type{<:SubArray{<:Any,<:Any,T}}) where {T<:GPUArray} = backend(T)
 
 # This Union is a hack. Ideally Base would have a Transpose <: WrappedArray <: AbstractArray
 # and we could define our methods in terms of Union{GPUArray, WrappedArray{<:Any, <:GPUArray}}
 const GPUDestArray = Union{GPUArray,
                            LinearAlgebra.Transpose{<:Any,<:GPUArray},
-                           LinearAlgebra.Adjoint{<:Any,<:GPUArray}}
+                           LinearAlgebra.Adjoint{<:Any,<:GPUArray},
+                           SubArray{<:Any,<:Any,<:GPUArray}}
 
 # This method is responsible for selection the output type of broadcast
-function Base.similar(bc::Broadcasted{<:ArrayStyle{GPU}}, ::Type{ElType}) where {GPU <: GPUArray, ElType}
+function Base.similar(bc::Broadcasted{<:ArrayStyle{GPU}}, ::Type{ElType}) where
+                     {GPU <: GPUArray, ElType}
     similar(GPU, ElType, axes(bc))
 end
 
-# We purposefully only specialise `copyto!`, dependent packages need to make sure that they can handle:
+# We purposefully only specialize `copyto!`, dependent packages need to make sure that they
+# can handle:
 # - `bc::Broadcast.Broadcasted{Style}`
 # - `ex::Broadcast.Extruded`
-# - `LinearAlgebra.Transpose{,<:GPUArray}` and  `LinearAlgebra.Adjoint{,<:GPUArray}`
-# as arguments to a kernel and that they do the right conversion.
+# - `LinearAlgebra.Transpose{,<:GPUArray}` and `LinearAlgebra.Adjoint{,<:GPUArray}`, etc
+#    as arguments to a kernel and that they do the right conversion.
 #
-# This Broadcast can be further customised by:
-# - `Broadcast.preprocess(dest::GPUArray, bc::Broadcasted{Nothing})` which allows for a complete transformation
-#   Broadcasted based on the output type just at the end of the pipeline.
-# - `Broadcast.broadcasted(::Style, f)` selection of an implementation of `f` compatible with `Style`
+# This Broadcast can be further customize by:
+# - `Broadcast.preprocess(dest::GPUArray, bc::Broadcasted{Nothing})` which allows for a
+#   complete transformation based on the output type just at the end of the pipeline.
+# - `Broadcast.broadcasted(::Style, f)` selection of an implementation of `f` compatible
+#   with `Style`
+#
 # For more information see the Base documentation.
 @inline function Base.copyto!(dest::GPUDestArray, bc::Broadcasted{Nothing})
     axes(dest) == axes(bc) || Broadcast.throwdm(axes(dest), axes(bc))
@@ -53,11 +63,10 @@ end
     return dest
 end
 
-# Base defines this method as a performance optimization, but we don't know how
-# to do `fill!` in general for all `GPUDestArray` so we just straight go to the fallback
-@inline function Base.copyto!(dest::GPUDestArray, bc::Broadcasted{<:Broadcast.AbstractArrayStyle{0}})
-    return copyto!(dest, convert(Broadcasted{Nothing}, bc))
-end
+# Base defines this method as a performance optimization, but we don't know how to do
+# `fill!` in general for all `GPUDestArray` so we just go straight to the fallback
+@inline Base.copyto!(dest::GPUDestArray, bc::Broadcasted{<:Broadcast.AbstractArrayStyle{0}}) =
+    copyto!(dest, convert(Broadcasted{Nothing}, bc))
 
 # TODO: is this still necessary?
 function mapidx(f, A::GPUArray, args::NTuple{N, Any}) where N

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -16,6 +16,9 @@ BroadcastStyle(::Type{T}) where {T<:GPUArray} = ArrayStyle{T}()
 BroadcastStyle(::Type{<:LinearAlgebra.Transpose{<:Any,T}}) where {T<:GPUArray} = BroadcastStyle(T)
 BroadcastStyle(::Type{<:LinearAlgebra.Adjoint{<:Any,T}}) where {T<:GPUArray} = BroadcastStyle(T)
 
+backend(::Type{<:LinearAlgebra.Transpose{<:Any,T}}) where {T<:GPUArray} = backend(T)
+backend(::Type{<:LinearAlgebra.Adjoint{<:Any,T}}) where {T<:GPUArray} = backend(T)
+
 # This Union is a hack. Ideally Base would have a Transpose <: WrappedArray <: AbstractArray
 # and we could define our methods in terms of Union{GPUArray, WrappedArray{<:Any, <:GPUArray}}
 const GPUDestArray = Union{GPUArray,

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -5,7 +5,10 @@
 
 Base.any(A::GPUArray{Bool}) = mapreduce(identity, |, A; init = false)
 Base.all(A::GPUArray{Bool}) = mapreduce(identity, &, A; init = true)
-Base.count(pred, A::GPUArray) = Int(mapreduce(pred, +, A; init = 0))
+
+Base.any(f::Function, A::GPUArray) = mapreduce(f, |, A; init = false)
+Base.all(f::Function, A::GPUArray) = mapreduce(f, &, A; init = true)
+Base.count(pred::Function, A::GPUArray) = Int(mapreduce(pred, +, A; init = 0))
 
 Base.:(==)(A::GPUArray, B::GPUArray) = Bool(mapreduce(==, &, A, B; init = true))
 

--- a/src/testsuite/broadcasting.jl
+++ b/src/testsuite/broadcasting.jl
@@ -45,15 +45,13 @@ function broadcasting(AT)
                 @test Array(gres) == cres
             end
 
-            # These tests are broken on CuArrays since we are missing `mapreduce` over device arrays
-            # add them back once we have them
-            # @testset "Tuple" begin
-            #     @test compare(AT, rand(ET, 3, N), rand(ET, 3, N), rand(ET, N), rand(ET, N), rand(ET, N)) do out, arr, a, b, c
-            #         broadcast!(out, arr, (a, b, c)) do xx, yy
-            #             xx + first(yy)
-            #         end
-            #     end
-            # end
+            @testset "Tuple" begin
+                @test compare(AT, rand(ET, 3, N), rand(ET, 3, N), rand(ET, N), rand(ET, N), rand(ET, N)) do out, arr, a, b, c
+                    broadcast!(out, arr, (a, b, c)) do xx, yy
+                        xx + first(yy)
+                    end
+                end
+            end
 
             @testset "Adjoint and Transpose" begin
                 A = AT(rand(ET, N))

--- a/src/testsuite/broadcasting.jl
+++ b/src/testsuite/broadcasting.jl
@@ -45,12 +45,22 @@ function broadcasting(AT)
                 @test Array(gres) == cres
             end
 
-            @testset "Tuple" begin
-                @test compare(AT, rand(ET, 3, N), rand(ET, 3, N), rand(ET, N), rand(ET, N), rand(ET, N)) do out, arr, a, b, c
-                    broadcast!(out, arr, (a, b, c)) do xx, yy
-                        xx + first(yy)
-                    end
-                end
+            # These tests are broken on CuArrays since we are missing `mapreduce` over device arrays
+            # add them back once we have them
+            # @testset "Tuple" begin
+            #     @test compare(AT, rand(ET, 3, N), rand(ET, 3, N), rand(ET, N), rand(ET, N), rand(ET, N)) do out, arr, a, b, c
+            #         broadcast!(out, arr, (a, b, c)) do xx, yy
+            #             xx + first(yy)
+            #         end
+            #     end
+            # end
+
+            @testset "Adjoint and Transpose" begin
+                A = AT(rand(ET, N))
+                A' .= ET(2)
+                @test all(x->x==ET(2), A)
+                transpose(A) .= ET(1)
+                @test all(x->x==ET(1), A)
             end
 
             ############


### PR DESCRIPTION
@maleadt as discussed earlier today, I didn't quite finish it so the CuArray changes are at https://github.com/JuliaGPU/CuArrays.jl/tree/vc/things

@SimonDanisch thoughts on the backend addition? The issue is that with wrapper types like `Adjoint`/`Transpose`/`SubArray` there is no easy dispatch target anymore so something trait-like might work quite well.

@andreasnoack would it make sense to introduce `Adjoint{T, A} <: Wrapper{T, A<:AbstractArray{T}} <: AbstractArray{T}` into the base hierarchy? Right now we need to enumerate and special treat all the wrapper types.