### PR TITLE
Run CuArrays tests.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,3 +10,9 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[targets]
+test = ["Pkg"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,32 @@
 using GPUArrays, Test
 using GPUArrays.TestSuite
 
+using Pkg
 
-@testset "Julia reference implementation:" begin
+@testset "JLArray" begin
     GPUArrays.test(JLArray)
+end
+
+function test_package(package)
+    mktempdir() do devdir
+        withenv("JULIA_PKG_DEVDIR" => devdir) do
+            # try to install from the same branch of GPUArrays
+            try
+                branch = chomp(read(`git -C $(@__DIR__) rev-parse --abbrev-ref HEAD`, String))
+                Pkg.add(PackageSpec(name=package, rev=String(branch)))
+                @info "Installed $package from $branch branch"
+            catch ex
+                @warn "Could not install $package from same branch as GPUArrays, trying master branch" exception=ex
+                Pkg.add(PackageSpec(name=package, rev="master"))
+            end
+
+            Pkg.test(package)
+        end
+    end
+end
+
+if haskey(ENV, "GITLAB_CI")
+    @testset "CuArray" begin
+        test_package("CuArrays")
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,12 +7,15 @@ using Pkg
     GPUArrays.test(JLArray)
 end
 
-function test_package(package)
+function test_package(package, branch=nothing)
     mktempdir() do devdir
         withenv("JULIA_PKG_DEVDIR" => devdir) do
             # try to install from the same branch of GPUArrays
             try
-                branch = chomp(read(`git -C $(@__DIR__) rev-parse --abbrev-ref HEAD`, String))
+                if branch === nothing
+                    branch = chomp(read(`git -C $(@__DIR__) rev-parse --abbrev-ref HEAD`, String))
+                    branch == "HEAD" && error("in detached HEAD state")
+                end
                 Pkg.add(PackageSpec(name=package, rev=String(branch)))
                 @info "Installed $package from $branch branch"
             catch ex
@@ -26,7 +29,8 @@ function test_package(package)
 end
 
 if haskey(ENV, "GITLAB_CI")
+    branch = ENV["CI_COMMIT_REF_NAME"]
     @testset "CuArray" begin
-        test_package("CuArrays")
+        test_package("CuArrays", branch)
     end
 end


### PR DESCRIPTION
As requested by @vchuravy, run the CuArray tests as part of the GPUArrays tests, if running on CI. Uses the master branch of CuArrays, but also tries to check-out a branch with the same name as the current GPUArrays branch, for improved cross-package development.