### PR TITLE
stop CuArray from failing GPUArrays test

### DIFF
--- a/src/testsuite/mapreduce.jl
+++ b/src/testsuite/mapreduce.jl
@@ -25,7 +25,7 @@ function test_mapreduce(AT)
                         y = rand(range, N, N)
                         x = T(y)
                         _zero = zero(ET)
-                        _addone(z) = z + one(ET)
+                        _addone(z) = z + one(typeof(z))
                         @test mapreduce(_addone, +, y; dims = 2, init = _zero) ≈
                             Array(mapreduce(_addone, +, x; dims = 2, init = _zero))
                         @test mapreduce(_addone, +, y; init = _zero) ≈


### PR DESCRIPTION
See #145 for more detail. Workaround a problem that makes a closure capturing a free ***local*** variable of a mutable struct or a type to be determined as non-bitstype, which prevents CUDAnative from compiling a kernel function that takes such closure as argument. It's a bit unfortunate that Gitlab CI won't run a PR from a forked repo, thus causing the error to pop up on CI after merging.