### PR TITLE
Remove mapidx.

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -67,11 +67,3 @@ end
 # `fill!` in general for all `GPUDestArray` so we just go straight to the fallback
 @inline Base.copyto!(dest::GPUDestArray, bc::Broadcasted{<:Broadcast.AbstractArrayStyle{0}}) =
     copyto!(dest, convert(Broadcasted{Nothing}, bc))
-
-# TODO: is this still necessary?
-function mapidx(f::F, A::GPUArray, args::NTuple{N, Any}) where {F,N}
-    gpu_call(A, (f, A, args)) do state, f::F, A, args
-        ilin = @linearidx(A, state)
-        f(ilin, A, args...)
-    end
-end

--- a/src/testsuite/base.jl
+++ b/src/testsuite/base.jl
@@ -28,25 +28,6 @@ end
 
 function test_base(AT)
     @testset "base functionality" begin
-        @testset "mapidx" begin
-            a = rand(ComplexF32, 77)
-            b = rand(ComplexF32, 77)
-            A = AT(a)
-            B = AT(b)
-            off = 1
-            GPUArrays.mapidx(A, (B, off, length(A))) do i, a, b, off, len
-                x = b[i]
-                x2 = b[min(i+off, len)]
-                a[i] = x * x2
-            end
-            foreach(1:length(a)) do i
-                x = b[i]
-                x2 = b[min(i+off, length(a))]
-                a[i] = x * x2
-            end
-            @test Array(A) ≈ a
-        end
-
         @testset "copyto!" begin
             x = fill(0f0, (10, 10))
             y = rand(Float32, (20, 10))


### PR DESCRIPTION
You can just broadcast over indices:

```julia
julia> using CuArrays

julia> a = CuArray{Int}(5)
5-element CuArray{Int64,1}:
 0
 0
 0
 0
 0

julia> a .= eachindex(a)
5-element CuArray{Int64,1}:
 1
 2
 3
 4
 5
```