### PR TITLE
Make the threads and blocks heuristic nonzero

### DIFF
--- a/src/heuristics.jl
+++ b/src/heuristics.jl
@@ -1,6 +1,6 @@
 function thread_blocks_heuristic(len::Integer)
     # TODO better threads default
-    threads = min(len, 256)
-    blocks = ceil(Int, len / threads)
+    threads = clamp(len, 1, 256)
+    blocks = max(ceil(Int, len / threads), 1)
     (blocks,), (threads,)
 end

--- a/src/testsuite/base.jl
+++ b/src/testsuite/base.jl
@@ -108,5 +108,11 @@ function test_base(AT)
             @test compare(a-> repeat(a, 5),     AT, rand(Float32, 5, 4))
             @test compare(a-> repeat(a, 4, 3),  AT, rand(Float32, 10, 15))
         end
+
+        @testset "heuristics" begin
+            blocks, threads = thread_blocks_heuristic(0)
+            @test blocks == (1,)
+            @test threads == (1,)
+        end
     end
 end


### PR DESCRIPTION
Make sure the minimum number of threads and blocks returned by the
heuristic is 1.  This allows the following code to work.

```julia
using CuArrays
a = Array{Float64}(undef, 0)
fill!(CuArray(a), 0)
```