### PR TITLE
Add broadcasted arrays support for mapreduce

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -69,6 +69,7 @@ function Base.similar(bc::Broadcasted{ArrayStyle{JLArray}}, ::Type{T}) where T
     similar(JLArray{T}, axes(bc))
 end
 
+Base.similar(bc::Broadcasted{ArrayStyle{JLArray}}, ::Type{T}, dims...) where {T} = JLArray{T}(undef, dims...)
 
 ## gpuarray interface
 

--- a/src/testsuite/construction.jl
+++ b/src/testsuite/construction.jl
@@ -59,6 +59,16 @@ function constructors(AT)
             @test B isa AT{T,1}
             @test size(B) == (7,)
             @test eltype(B) == T
+
+            B = similar(Broadcast.Broadcasted(*, (B, B)), Int32, 11, 15)
+            @test B isa AT{Int32,2}
+            @test size(B) == (11, 15)
+            @test eltype(B) == Int32
+
+            B = similar(Broadcast.Broadcasted(*, (B, B)), T)
+            @test B isa AT{T,2}
+            @test size(B) == (11, 15)
+            @test eltype(B) == T
         end
     end
     @testset "comparison against Array" begin

--- a/src/testsuite/mapreduce.jl
+++ b/src/testsuite/mapreduce.jl
@@ -32,6 +32,14 @@ function test_mapreduce(AT)
                         ET <: Complex || @test compare(minimum, AT,rand(range, dims))
                     end
                 end
+
+                @testset "broadcasted arrays" begin
+                    for dims in ((4048,), (1024,1024), (77,), (1923,209))
+                        @test compare(x->mapreduce(z -> z + one(z), +,
+                                                   Broadcast.Broadcasted(+, (x, x));
+                                                   init = zero(ET)), AT, rand(range, dims))
+                    end
+                end
             end
         end
         @testset "any all ==" begin


### PR DESCRIPTION
This change allows broadcasted arrays to be passed to `mapreduce`.  For example the following is now supported.

```julia
a = CuArray(rand(256, 10))
b = CuArray(rand(256,1))
mapreduce(identity, +, Broadcast.Broadcasted(*,(a,b)), init=0.0)
```

This requires JuliaGPU/CuArrays.jl#358.