### PR TITLE
Support newest tagged FillArrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,5 +15,5 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Adapt = "0.4.1, 1.0"
-FillArrays = "0.3, 0.4, 0.5, 0.6"
+FillArrays = "0.3, 0.4, 0.5, 0.6, 0.7"
 julia = "1.0"


### PR DESCRIPTION
This restriction keeps throwing unresolvable requirements errors in `Pkg` for me and the latest tag seems to work fine.