### PR TITLE
fillarrays compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,5 +15,5 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 Adapt = "0.4.1, 1.0"
 FFTW = "0.2, 0.3, 1.0"
-FillArrays = "0.3, 0.4, 0.5, 0.6, 0.7"
+FillArrays = "0"
 julia = "1.0"


### PR DESCRIPTION
FillArrays seems to use new `0.x` versions for non-breaking changes, plus AFAICT we're only using the `Fill` constructor anyway, so breakage in the `0.x` line seems pretty unlikely. But I can just add `0.8` explicitly if people prefer it.