### PR TITLE
Fix UniformScaling constructor + copyto!

### DIFF
--- a/src/host/construction.jl
+++ b/src/host/construction.jl
@@ -28,11 +28,14 @@ function uniformscaling_kernel(ctx::AbstractKernelContext, res::AbstractArray{T}
     return
 end
 
-function (T::Type{<: AbstractGPUArray})(s::UniformScaling, dims::Dims{2})
+function (T::Type{<: AbstractGPUArray{U}})(s::UniformScaling, dims::Dims{2}) where {U}
     res = zeros(T, dims)
     gpu_call(uniformscaling_kernel, res, size(res, 1), s; total_threads=minimum(dims))
     res
 end
+
+(T::Type{<: AbstractGPUArray})(s::UniformScaling{U}, dims::Dims{2}) where U = T{U}(s, dims)
+
 (T::Type{<: AbstractGPUArray})(s::UniformScaling, m::Integer, n::Integer) = T(s, Dims((m, n)))
 
 function indexstyle(x::T) where T

--- a/src/host/construction.jl
+++ b/src/host/construction.jl
@@ -38,6 +38,12 @@ end
 
 (T::Type{<: AbstractGPUArray})(s::UniformScaling, m::Integer, n::Integer) = T(s, Dims((m, n)))
 
+function Base.copyto!(A::AbstractGPUMatrix{T}, s::UniformScaling) where T
+    fill!(A, zero(T))
+    gpu_call(uniformscaling_kernel, A, size(A, 1), s; total_threads=minimum(size(A)))
+    A
+end
+
 function indexstyle(x::T) where T
     style = try
         Base.IndexStyle(x)

--- a/test/testsuite/construction.jl
+++ b/test/testsuite/construction.jl
@@ -164,15 +164,26 @@ function value_constructor(AT)
             @test all(x-> x == 2f0, Array(x1))
             @test all(x-> x == Int32(77), Array(x2))
 
-            x = Matrix{T}(I, 2, 2)
+            x = Matrix{T}(I, 4, 2)
 
-            x1 = AT{T, 2}(I, 2, 2)
-            x2 = AT{T}(I, (2, 2))
-            x3 = AT{T, 2}(I, (2, 2))
+            x1 = AT{T, 2}(I, 4, 2)
+            x2 = AT{T}(I, (4, 2))
+            x3 = AT{T, 2}(I, (4, 2))
 
             @test Array(x1) ≈ x
             @test Array(x2) ≈ x
             @test Array(x3) ≈ x
+
+            x = Matrix(T(3) * I, 2, 4)
+            x1 = AT(T(3) * I, 2, 4)
+            @test eltype(x1) == T
+            @test Array(x1) ≈ x
+
+            x = fill(T(3), (2, 4))
+            x1 = fill(AT{T}, T(3), (2, 4))
+            copyto!(x, 2I)
+            copyto!(x1, 2I)
+            @test Array(x1) ≈ x
         end
     end
 end


### PR DESCRIPTION
.. and improve the tests a bit to test rectangular matrices.

Fixes the issue where `CuArray(1f0I, 3, 4)` did not deduce the element type