### PR TITLE
Implement + and - for UniformScaling and various wrappers

### DIFF
--- a/src/GPUArrays.jl
+++ b/src/GPUArrays.jl
@@ -33,6 +33,7 @@ include("host/linalg.jl")
 include("host/math.jl")
 include("host/random.jl")
 include("host/quirks.jl")
+include("host/uniformscaling.jl")
 
 # CPU reference implementation
 include("reference.jl")

--- a/src/host/uniformscaling.jl
+++ b/src/host/uniformscaling.jl
@@ -1,0 +1,91 @@
+import Base: +, -
+
+const genericwrappers = (
+    :LowerTriangular,
+    :UpperTriangular,
+    :Hermitian,
+    :Symmetric
+)
+
+const unittriangularwrappers = (
+    (:UnitUpperTriangular, :UpperTriangular), 
+    (:UnitLowerTriangular, :LowerTriangular)
+)
+
+function kernel_generic(ctx, B, J)
+    @inbounds index = diagind(B)[linear_index(ctx)]
+    @inbounds B[index] += J
+    return nothing
+end
+
+function kernel_unittriangular(ctx, B, J, diagonal_val)
+    @inbounds index = diagind(B)[linear_index(ctx)]
+    @inbounds B[index] = diagonal_val + J
+    return nothing
+end
+
+for (t1, t2) in unittriangularwrappers
+    @eval begin
+        function (+)(A::$t1{T, <:AbstractGPUMatrix}, J::UniformScaling) where T
+            B = similar(parent(A), typeof(oneunit(T) + J))
+            copyto!(B, parent(A))
+            gpu_call(kernel_unittriangular, B, J, one(eltype(B)); total_threads=minimum(size(B)))
+            return $t2(B)
+        end
+
+        function (-)(J::UniformScaling, A::$t1{T, <:AbstractGPUMatrix}) where T
+            B = similar(parent(A), typeof(J - oneunit(T)))
+            B .= .- parent(A)
+            gpu_call(kernel_unittriangular, B, J, -one(eltype(B)); total_threads=minimum(size(B)))
+            return $t2(B)
+        end
+    end
+end
+
+for t in genericwrappers
+    @eval begin
+        function (+)(A::$t{T, <:AbstractGPUMatrix}, J::UniformScaling) where T
+            B = similar(parent(A), typeof(oneunit(T) + J))
+            copyto!(B, parent(A))
+            gpu_call(kernel_generic, B, J; total_threads=minimum(size(B)))
+            return $t(B)
+        end
+        
+        function (-)(J::UniformScaling, A::$t{T, <:AbstractGPUMatrix}) where T
+            B = similar(parent(A), typeof(J - oneunit(T)))
+            B .= .- parent(A)
+            gpu_call(kernel_generic, B, J; total_threads=minimum(size(B)))
+            return $t(B)
+        end
+    end
+end
+
+# Breaking Hermiticity when adding a complex value to the diagonal
+function (+)(A::Hermitian{T,<:AbstractGPUMatrix}, J::UniformScaling{<:Complex}) where T
+    B = similar(parent(A), typeof(oneunit(T) + J))
+    copyto!(B, parent(A))
+    gpu_call(kernel_generic, B, J; total_threads=minimum(size(B)))
+    return B
+end
+
+function (-)(J::UniformScaling{<:Complex}, A::Hermitian{T,<:AbstractGPUMatrix}) where T
+    B = similar(parent(A), typeof(J - oneunit(T)))
+    B .= .-parent(A)
+    gpu_call(kernel_generic, B, J; total_threads=minimum(size(B)))
+    return B
+end
+
+# Finally the generic matrix version
+function (+)(A::AbstractGPUMatrix{T}, J::UniformScaling) where T
+    B = similar(A, typeof(oneunit(T) + J))
+    copyto!(B, A)
+    gpu_call(kernel_generic, B, J; total_threads=minimum(size(B)))
+    return B
+end
+
+function (-)(J::UniformScaling, A::AbstractGPUMatrix{T}) where T
+    B = similar(A, typeof(J - oneunit(T)))
+    B .= .-A
+    gpu_call(kernel_generic, B, J; total_threads=minimum(size(B)))
+    return B
+end

--- a/test/testsuite.jl
+++ b/test/testsuite.jl
@@ -40,6 +40,7 @@ include("testsuite/linalg.jl")
 include("testsuite/math.jl")
 include("testsuite/fft.jl")
 include("testsuite/random.jl")
+include("testsuite/uniformscaling.jl")
 
 
 """
@@ -57,6 +58,7 @@ function test(AT::Type{<:AbstractGPUArray})
     TestSuite.test_math(AT)
     TestSuite.test_fft(AT)
     TestSuite.test_random(AT)
+    TestSuite.test_uniformscaling(AT)
 end
 
 end

--- a/test/testsuite/uniformscaling.jl
+++ b/test/testsuite/uniformscaling.jl
@@ -1,0 +1,21 @@
+function test_uniformscaling(AT)
+
+    eltypes = (ComplexF32, Float32)
+    wrappers = (identity, UnitLowerTriangular, UnitUpperTriangular, LowerTriangular, UpperTriangular, Hermitian, Symmetric)
+
+    @testset "UniformScaling $f $T1 $T2" for T1 in eltypes, T2 in eltypes, f in wrappers
+        x = ones(T1, 5, 5)
+        y = AT(x)
+
+        xw = f(x)
+        yw = f(y)
+
+        J = one(T2) * I
+
+        # TODO: remove @allowscalar as soon as there is a proper implementation for Symmetric / Hermitian
+        @test @allowscalar collect(xw + J) ≈ collect(yw + J)
+
+        # Missing methods in Base it seems... -(x - I) can be removed when Base supports (I - x)
+        @test @allowscalar collect(-(xw - J)) ≈ collect(J - yw)
+    end
+end


### PR DESCRIPTION
Fixes the issue where `A + I`, `I - A` did not work for A a (wrapped) AbstractGPUArray.

Since GPUArrays does not seem to implement `collect` Symmetric and Hermitian is not yet very good, I did not add tests for those special cases