### PR TITLE
Avoid calling copyto kernel with no threads.

### DIFF
--- a/src/device/execution.jl
+++ b/src/device/execution.jl
@@ -57,8 +57,11 @@ function gpu_call(kernel::Base.Callable, args...;
     end
 
     if total_threads !== nothing
+        @assert total_threads > 0
         gpu_call(backend(target), kernel, args, total_threads; name=name)
     else
+        @assert threads > 0
+        @assert blocks > 0
         gpu_call(backend(target), kernel, args, threads, blocks; name=name)
     end
 end

--- a/src/host/abstractarray.jl
+++ b/src/host/abstractarray.jl
@@ -136,6 +136,7 @@ function Base.copyto!(dest::AbstractGPUArray{T, N}, destcrange::CartesianIndices
         throw(DimensionMismatch("Ranges don't match their size. Found: $shape, $(size(srccrange))"))
     end
     len = length(destcrange)
+    len == 0 && return dest
 
     dest_offsets = first(destcrange) - one(CartesianIndex{N})
     src_offsets = first(srccrange) - one(CartesianIndex{N})

--- a/test/testsuite/base.jl
+++ b/test/testsuite/base.jl
@@ -158,5 +158,9 @@ function test_base(AT)
             inds = rand(1:100, 150, 150)
             @test compare(x->permutedims(view(x, inds, :), (3, 2, 1)), AT, rand(100, 100))
         end
+
+        @testset "circshift" begin
+            @test compare(x->circshift(x, (0,1)), AT, reshape(Vector(1:16), (4,4)))
+        end
     end
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/CuArrays.jl/issues/657