### PR TITLE
Add copytri! and tests.

### DIFF
--- a/src/host/linalg.jl
+++ b/src/host/linalg.jl
@@ -30,6 +30,35 @@ function Base.copyto!(A::AbstractArray, B::Transpose{<:Any, <:AbstractGPUArray})
 end
 
 
+## copy upper triangle to lower and vice versa
+
+function LinearAlgebra.copytri!(A::AbstractGPUMatrix{T}, uplo::AbstractChar) where T
+  n = LinearAlgebra.checksquare(A)
+  if uplo == 'U'
+      gpu_call(A) do ctx, _A
+        I = @cartesianidx _A
+        i, j = Tuple(I)
+        if j > i
+          _A[j,i] = _A[i,j]
+        end
+        return
+      end
+  elseif uplo == 'L'
+      gpu_call(A) do ctx, _A
+        I = @cartesianidx _A
+        i, j = Tuple(I)
+        if j > i
+          _A[i,j] = _A[j,i]
+        end
+        return
+      end
+  else
+      throw(ArgumentError("uplo argument must be 'U' (upper) or 'L' (lower), got $uplo"))
+  end
+  A
+end
+
+
 ## triangular
 
 function Base.copyto!(A::AbstractArray, B::UpperTriangular{<:Any, <:AbstractGPUArray})

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -15,7 +15,7 @@ function test_linalg(AT)
             @testset for uplo in ('U', 'L')
                 A = AT{Float32}(undef, 128, 128)
                 rand!(A)
-                copytri(A, uplo)
+                LinearAlgebra.copytri!(A, uplo)
                 @test collect(A) == collect(A')
             end
         end

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -13,10 +13,7 @@ function test_linalg(AT)
 
         @testset "copytri!" begin
             @testset for uplo in ('U', 'L')
-                A = AT{Float32}(undef, 128, 128)
-                rand!(A)
-                LinearAlgebra.copytri!(A, uplo)
-                @test collect(A) == collect(A')
+                @test compare(x -> LinearAlgebra.copytri!(x, uplo), AT, rand(Float32, 128, 128))
             end
         end
 

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -11,6 +11,15 @@ function test_linalg(AT)
             @test compare(transpose!, AT, Array{Float32}(undef, 128, 32), rand(Float32, 32, 128))
         end
 
+        @testset "copytri!" begin
+            @testset for uplo in ('U', 'L')
+                A = AT{Float32}(undef, 128, 128)
+                rand!(A)
+                copytri(A, uplo)
+                @test collect(A) == collect(A')
+            end
+        end
+
         @testset "copyto! for triangular" begin
             ga = Array{Float32}(undef, 128, 128)
             gb = AT{Float32}(undef, 128, 128)


### PR DESCRIPTION
This PR adds a kernel for `copytri!` and unit tests. The kernel doesn't support all optional arguments used by `copytri!` - if someone needs these it should be fairly easy to extend.