### PR TITLE
Add randn function.

### DIFF
--- a/src/host/random.jl
+++ b/src/host/random.jl
@@ -95,17 +95,17 @@ function Random.rand!(rng::RNG, A::AbstractGPUArray{T}) where T <: Number
     A
 end
 
-function Random.randn!(rng::GPUArrays.RNG, A::AbstractGPUArray{T}) where T <: Number
+function Random.randn!(rng::RNG, A::AbstractGPUArray{T}) where T <: Number
     threads = (length(A) - 1) ÷ 2 + 1
     gpu_call(A, rng.state; total_threads = threads) do ctx, a, randstates
-        idx = linear_index(ctx)
+        idx = 2*(linear_index(ctx) - 1) + 1
         idx > length(a) && return
         U1 = gpu_rand(T, ctx, randstates)
         U2 = gpu_rand(T, ctx, randstates)
         Z0 = sqrt(-2.0 * log(U1)) * cos(2pi * U2)
         Z1 = sqrt(-2.0 * log(U1)) * sin(2pi * U2)
-        @inbounds a[2*(idx - 1) + 1] = Z0
-        @inbounds a[2*(idx - 1) + 2] = Z1
+        @inbounds a[idx] = Z0
+        @inbounds a[idx + 1] = Z1
         return
     end
     A

--- a/src/host/random.jl
+++ b/src/host/random.jl
@@ -102,8 +102,8 @@ function Random.randn!(rng::RNG, A::AbstractGPUArray{T}) where T <: Number
         idx = 2*(linear_index(ctx) - 1) + 1
         U1 = gpu_rand(T, ctx, randstates)
         U2 = gpu_rand(T, ctx, randstates)
-        Z0 = sqrt(ctx, -2.0*log(ctx, U1))*cos(ctx, 2pi*U2)
-        Z1 = sqrt(ctx, -2.0*log(ctx, U1))*sin(ctx, 2pi*U2)
+        Z0 = sqrt(ctx, T(-2.0)*log(ctx, U1))*cos(ctx, T(2pi)*U2)
+        Z1 = sqrt(ctx, T(-2.0)*log(ctx, U1))*sin(ctx, T(2pi)*U2)
         @inbounds a[idx] = Z0
         idx + 1 > length(a) && return
         @inbounds a[idx + 1] = Z1

--- a/src/host/random.jl
+++ b/src/host/random.jl
@@ -100,8 +100,8 @@ function Random.randn!(rng::GPUArrays.RNG, A::AbstractGPUArray{T}) where T <: Nu
     gpu_call(A, rng.state; total_threads = threads) do ctx, a, randstates
         idx = linear_index(ctx)
         idx > length(a) && return
-        U1 = GPUArrays.gpu_rand(T, ctx, randstates)
-        U2 = GPUArrays.gpu_rand(T, ctx, randstates)
+        U1 = gpu_rand(T, ctx, randstates)
+        U2 = gpu_rand(T, ctx, randstates)
         Z0 = sqrt(-2.0 * log(U1)) * cos(2pi * U2)
         Z1 = sqrt(-2.0 * log(U1)) * sin(2pi * U2)
         @inbounds a[2*(idx - 1) + 1] = Z0

--- a/src/host/random.jl
+++ b/src/host/random.jl
@@ -97,14 +97,15 @@ end
 
 function Random.randn!(rng::RNG, A::AbstractGPUArray{T}) where T <: Number
     threads = (length(A) - 1) ÷ 2 + 1
+    length(A) == 0 && return
     gpu_call(A, rng.state; total_threads = threads) do ctx, a, randstates
         idx = 2*(linear_index(ctx) - 1) + 1
-        idx > length(a) && return
         U1 = gpu_rand(T, ctx, randstates)
         U2 = gpu_rand(T, ctx, randstates)
-        Z0 = sqrt(-2.0 * log(U1)) * cos(2pi * U2)
-        Z1 = sqrt(-2.0 * log(U1)) * sin(2pi * U2)
+        Z0 = sqrt(ctx, -2.0*log(ctx, U1))*cos(ctx, 2pi*U2)
+        Z1 = sqrt(ctx, -2.0*log(ctx, U1))*sin(ctx, 2pi*U2)
         @inbounds a[idx] = Z0
+        idx + 1 > length(a) && return
         @inbounds a[idx + 1] = Z1
         return
     end

--- a/src/reference.jl
+++ b/src/reference.jl
@@ -233,6 +233,12 @@ Base.similar(bc::Broadcasted{JLArrayStyle{N}}, ::Type{T}, dims...) where {N,T} =
     JLArray{T}(undef, dims...)
 
 
+## math
+
+for f in (:cos, :sin, :sqrt, :log)
+    @eval GPUArrays.$f(ctx::JLKernelContext, x) = $f(x)
+end
+
 ## memory operations
 
 function Base.copyto!(dest::Array{T}, d_offset::Integer,

--- a/test/testsuite/random.jl
+++ b/test/testsuite/random.jl
@@ -18,4 +18,22 @@
             @test all(A .== B)
         end
     end
+    
+    @testset "randn" begin  # uniform
+        for T in (Float32, Float64), d in (2, (2,2))
+            A = AT{T}(undef, d)
+            B = copy(A)
+            randn!(A)
+            randn!(B)
+            @test !any(A .== B)
+
+            rng = GPUArrays.global_rng(A)
+            Random.seed!(rng)
+            Random.seed!(rng, 1)
+            randn!(rng, A)
+            Random.seed!(rng, 1)
+            randn!(rng, B)
+            @test all(A .== B)
+        end
+    end
 end


### PR DESCRIPTION
Resolves the problems in #277 . Implemented the [Box-Muller transform](https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform) to generate a normalized distribution from Hybrid Tausworthe and Linear Congruent generator already present in the current `rand` implementation.

```julia
# GPU 
a = CuArray{Float32}(undef, 1_000_000)
t = Base.@elapsed begin
    randn!(a)
    synchronize(a)
end
res = t, mean(a), stdm(a, mean(a))
CuArrays.unsafe_free!(a)
res
```
`(0.000174978, 0.00069079286f0, 1.0015252f0)`
```julia
# CPU 
a = Array{Float32}(undef, 1_000_000)
t = Base.@elapsed begin
    randn!(a)
end
t, mean(a), stdm(a, mean(a))
```
`(0.004756459, 0.00080279016f0, 1.0004866f0)`

There is a bug in what have written, and that is in the bounds check. There needs to be a separate check if `idx + 1 >  length(a)` which should probably come after `@inbounds a[idx] = Z0`. Since this branch path is unlikely what is the correct way to signal that to the compiler ? Another question would be if this even mattered performance-wise here and if I am asking an irrelevant question ?