### PR TITLE
Bail out when performing empty broadcast.

### DIFF
--- a/src/host/broadcast.jl
+++ b/src/host/broadcast.jl
@@ -52,6 +52,7 @@ end
 # For more information see the Base documentation.
 @inline function Base.copyto!(dest::BroadcastGPUArray, bc::Broadcasted{Nothing})
     axes(dest) == axes(bc) || Broadcast.throwdm(axes(dest), axes(bc))
+    isempty(dest) && return dest
     bc′ = Broadcast.preprocess(dest, bc)
     gpu_call(dest, bc′; name="broadcast") do ctx, dest, bc′
         let I = @cartesianidx(dest)

--- a/test/testsuite/broadcasting.jl
+++ b/test/testsuite/broadcasting.jl
@@ -163,6 +163,10 @@ function broadcasting(AT)
         cpy.(1:10, Ref(a), Ref(b))
         @test Array(a) == Array(b)
     end
+
+    @testset "stackoverflow in copy(::Broadcast)" begin
+        copy(Base.broadcasted(identity, AT(Int[])))
+    end
 end
 
 function vec3(AT)


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/CUDA.jl/issues/82.