### PR TITLE
Deprecate the synchronize host API.

### DIFF
--- a/docs/src/interface.md
+++ b/docs/src/interface.md
@@ -23,7 +23,6 @@ Another important set of interfaces relates to executing code on the device:
 GPUArrays.AbstractGPUBackend
 GPUArrays.AbstractKernelContext
 GPUArrays.gpu_call
-GPUArrays.synchronize
 GPUArrays.thread_block_heuristic
 ```
 

--- a/src/GPUArrays.jl
+++ b/src/GPUArrays.jl
@@ -38,5 +38,7 @@ include("host/uniformscaling.jl")
 # CPU reference implementation
 include("reference.jl")
 
+include("deprecated.jl")
+
 
 end # module

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,1 @@
+function synchronize end

--- a/src/device/execution.jl
+++ b/src/device/execution.jl
@@ -1,6 +1,6 @@
 # kernel execution
 
-export AbstractGPUBackend, AbstractKernelContext, gpu_call, synchronize, thread_blocks_heuristic
+export AbstractGPUBackend, AbstractKernelContext, gpu_call, thread_blocks_heuristic
 
 abstract type AbstractGPUBackend end
 
@@ -77,13 +77,3 @@ end
 
 # bottom-line gpu_call method that is expected to be implemented by the back end
 gpu_call(backend::AbstractGPUBackend, kernel, args, threads::Int, blocks::Int; kwargs...) = error("Not implemented") # COV_EXCL_LINE
-
-"""
-    synchronize(A::AbstractArray)
-
-Blocks until all operations are finished on `A`
-"""
-function synchronize(A::AbstractArray)
-    # fallback is a noop, for backends not needing synchronization. This
-    # makes it easier to write generic code that also works for AbstractArrays
-end


### PR DESCRIPTION
We don't use it, and it's a much too coarse synchronization model to build on. Something KA-based would be better (although the user-facing API would still need to be something convenient like this).