### PR TITLE
fix  `fill` when length = 0

### DIFF
--- a/src/host/construction.jl
+++ b/src/host/construction.jl
@@ -9,6 +9,7 @@ function Base.fill(X::Type{<: AbstractGPUArray{T}}, val, dims::NTuple{N, Integer
     fill!(res, convert(T, val))
 end
 function Base.fill!(A::AbstractGPUArray{T}, x) where T
+    length(A) == 0 && return A
     gpu_call(A, convert(T, x)) do ctx, a, val
         idx = @linearidx(a, ctx)
         @inbounds a[idx] = val

--- a/test/testsuite/construction.jl
+++ b/test/testsuite/construction.jl
@@ -152,6 +152,14 @@ end
         @test all(x-> x == 2f0, Array(x1))
         @test all(x-> x == Int32(77), Array(x2))
 
+        x = fill(zero(T), (0, 2))
+        x1 = fill(AT{T}, T(0), (0, 2))
+        x2 = fill(AT{T}, T(0), (0, 2))
+        x3 = fill(AT{T, 2}, T(0), (0, 2))
+        @test Array(x1) ≈ x
+        @test Array(x2) ≈ x
+        @test Array(x3) ≈ x
+
         x = Matrix{T}(I, 4, 2)
 
         x1 = AT{T, 2}(I, 4, 2)


### PR DESCRIPTION
As reported in [#81](https://github.com/JuliaGPU/CUDA.jl/issues/81) , CUDA.jl . Currently constructors such as `CUDA.zeros(T, 0)` would fail for the types not handled by CUDA memset (64-bit numbers not supported).

Previously
```julia
julia> T = Float64
julia> CuArrays.zeros(T, 0)
ERROR: AssertionError: total_threads > 0
Stacktrace:
 [1] #gpu_call#1 at /scratch/snx3000tds/omlins/9_soft_install_julia_1_4/software/Julia/1.4.1-CrayGNU-19.10-cuda-10.1/extensions/packages/GPUArrays/OXvxB/src/device/execution.jl:60 [inlined]
 [2] gpu_call at /scratch/snx3000tds/omlins/9_soft_install_julia_1_4/software/Julia/1.4.1-CrayGNU-19.10-cuda-10.1/extensions/packages/GPUArrays/OXvxB/src/device/execution.jl:46 [inlined]
 [3] fill!(::CuArray{Float64,1,Nothing}, ::Int64) at /scratch/snx3000tds/omlins/9_soft_install_julia_1_4/software/Julia/1.4.1-CrayGNU-19.10-cuda-10.1/extensions/packages/GPUArrays/OXvxB/src/host/construction.jl:12
 [4] zeros(::Type{T} where T, ::Int64, ::Vararg{Int64,N} where N) at /scratch/snx3000tds/omlins/9_soft_install_julia_1_4/software/Julia/1.4.1-CrayGNU-19.10-cuda-10.1/extensions/packages/CuArrays/l0gXB/src/array.jl:337
 [5] top-level scope at REPL[129]:1
```

Now:

```julia
julia> CUDA.zeros(Float64, 0)
0-element CuArray{Float64,1}
```