### PR TITLE
Implement RNG for Bool & Int8

### DIFF
--- a/src/host/random.jl
+++ b/src/host/random.jl
@@ -37,7 +37,7 @@ end
 
 function gpu_rand(::Type{T}, ctx::AbstractKernelContext, randstate::AbstractVector{NTuple{4, UInt32}}) where T <: Integer
     threadid = GPUArrays.threadidx(ctx)
-    result = T(0)
+    result = zero(T)
     if sizeof(T) >= 4
         for _ in 1:sizeof(T) >> 2
             randstate[threadid], y = next_rand(randstate[threadid])

--- a/test/testsuite/random.jl
+++ b/test/testsuite/random.jl
@@ -18,11 +18,10 @@
             @test all(A .== B)
         end
 
-        # TODO: Remove @allowscalar once `in` is implemented
         A = AT{Bool}(undef, 5)
         rand!(A)
-        @test @allowscalar true in A
-        @test @allowscalar false in A
+        @test true in Array(A)
+        @test false in Array(A)
     end
 
     @testset "randn" begin  # uniform

--- a/test/testsuite/random.jl
+++ b/test/testsuite/random.jl
@@ -1,6 +1,6 @@
 @testsuite "random" AT->begin
     @testset "rand" begin  # uniform
-        for T in (Float32, Float64, Int64, Int32,
+        for T in (Int8, Float32, Float64, Int64, Int32,
                     Complex{Float32}, Complex{Float64},
                     Complex{Int64}, Complex{Int32}), d in (2, (2,2))
             A = AT{T}(undef, d)

--- a/test/testsuite/random.jl
+++ b/test/testsuite/random.jl
@@ -17,6 +17,12 @@
             rand!(rng, B)
             @test all(A .== B)
         end
+
+        # TODO: Remove @allowscalar once `in` is implemented
+        A = AT{Bool}(undef, 5)
+        rand!(A)
+        @test @allowscalar true in A
+        @test @allowscalar false in A
     end
 
     @testset "randn" begin  # uniform


### PR DESCRIPTION
Can't find the issue but there was one which noted the fact that `CUDA.rand(Bool, 10)` did not result in a random numbers but was rather an array of zeros (mostly uninitialized memory). This PR is a unrefined hack to fix that. I don't know anything about the formal properties our RNG must satisfy. The distribution looked fine to me, as long as the end user uses it for monte-carlo and not cryptography related work we are probably fine. 
If there is any slight objection to the validity of this RNG then close this PR down. I really don't mind.