### PR TITLE
Perform Cartesian copies between CPU and GPU using linear slices.

### DIFF
--- a/src/host/abstractarray.jl
+++ b/src/host/abstractarray.jl
@@ -205,6 +205,7 @@ for (dstTyp, srcTyp) in (AbstractGPUArray=>Array, Array=>AbstractGPUArray)
         for i in 1:m:m*n
             srcoff = LinearIndices(src)[srcrange[i]]
             dstoff = LinearIndices(dst)[dstrange[i]]
+            # TODO: Use asynchronous memory copies
             copyto!(dst, dstoff, src, srcoff, m)
         end
 


### PR DESCRIPTION
We currently 'materialize' one of the cartesian ranges GPU-side by allocating and copying to a temporary contiguous buffer, which can be extremely costly (but results in fewer copy operations). Since GPU arrays are typically large, avoid that by splitting the cartesian ranges in slices of contiguous memory, and copying those using the existing linear copying machinery.

Verified the implementation outside of GPUArrays using the following:

```julia
using Test

linear_copyto(dst, dstrange::CartesianIndices{0}, src, srcrange::CartesianIndices{0}) = dst

function linear_copyto(dst, dstrange::CartesianIndices{N}, src, srcrange::CartesianIndices{N}) where {N}
    # figure out how many dimensions of the Cartesian ranges map onto contiguous memory of
    # both source and destination. we will copy these slices one by one as linear ranges.
    contiguous_dims = 1
    for dim in 2:N
        # a slice is broken up if the previous dimension didn't cover the entire range
        if axes(src, dim-1) == axes(srcrange, dim-1) &&
           axes(dst, dim-1) == axes(dstrange, dim-1)
            contiguous_dims = dim
        else
            break
        end
    end

    m = prod(size(dstrange)[1:contiguous_dims])       # inner, contiguous length
    n = prod(size(dstrange)[contiguous_dims+1:end])   # outer non-contiguous length
    @assert m*n == length(srcrange) == length(dstrange)

    # copy linear slices
    for i in 1:m:m*n
        srcoff = LinearIndices(src)[srcrange[i]]
        dstoff = LinearIndices(dst)[dstrange[i]]
        copyto!(dst, dstoff, src, srcoff, m)
    end

    dst
end

function main()
    A = ones(3,3,3)
    B = zeros(3,3,3)
    C = copy(B)

    cases = (1:1, 1:2, 1:3, 2:2, 2:3, 3:3)
    for A1 in cases, A2 in cases, A3 in cases,
        B1 in cases, B2 in cases, B3 in cases
        Aidx = CartesianIndices((A1, A2, A3))
        Bidx = CartesianIndices((B1, B2, B3))
        size(Aidx) == size(Bidx) || continue

        linear_copyto(B, Bidx, A, Aidx)
        copyto!(C, Bidx, A, Aidx)
        @test B == C
    end

    return
end
```
