### PR TITLE
Run the testsuite with Base.Array

### DIFF
--- a/src/host/abstractarray.jl
+++ b/src/host/abstractarray.jl
@@ -79,8 +79,8 @@ for (D, S) in ((AbstractOrWrappedGPUArray, Array),
                (Array, AbstractOrWrappedGPUArray),
                (AbstractOrWrappedGPUArray, AbstractOrWrappedGPUArray))
     @eval begin
-        function Base.copyto!(dest::$D{<:Any, N}, rdest::NTuple{N, UnitRange},
-                              src::$S{<:Any, N}, ssrc::NTuple{N, UnitRange}) where {N}
+        function Base.copyto!(dest::$D{<:Any, N}, rdest::UnitRange,
+                              src::$S{<:Any, N}, ssrc::UnitRange) where {N}
             drange = CartesianIndices(rdest)
             srange = CartesianIndices(ssrc)
             copyto!(dest, drange, src, srange)

--- a/src/host/abstractarray.jl
+++ b/src/host/abstractarray.jl
@@ -185,7 +185,7 @@ function Base.copyto!(dest::AbstractOrWrappedGPUArray{<:Any, N}, destcrange::Car
                       src::AbstractOrWrappedGPUArray{<:Any, N}, srccrange::CartesianIndices{N}) where {N}
     shape = size(destcrange)
     if shape != size(srccrange)
-        throw(DimensionMismatch("Ranges don't match their size. Found: $shape, $(size(srccrange))"))
+        throw(ArgumentError("Ranges don't match their size. Found: $shape, $(size(srccrange))"))
     end
     len = length(destcrange)
     len == 0 && return dest
@@ -298,20 +298,20 @@ function reinterpret(::Type{T}, a::AbstractGPUArray{S}, dims::NTuple{N, Integer}
     end
     nel = div(length(a)*sizeof(S),sizeof(T))
     if prod(dims) != nel
-        throw(DimensionMismatch("new dimensions $(dims) must be consistent with array size $(nel)"))
+        throw(ArgumentError("new dimensions $(dims) must be consistent with array size $(nel)"))
     end
     unsafe_reinterpret(T, a, dims)
 end
 
 function Base._reshape(A::AbstractGPUArray{T}, dims::Dims) where T
     n = length(A)
-    prod(dims) == n || throw(DimensionMismatch("parent has $n elements, which is incompatible with size $dims"))
+    prod(dims) == n || throw(ArgumentError("parent has $n elements, which is incompatible with size $dims"))
     return unsafe_reinterpret(T, A, dims)
 end
 #ambig
 function Base._reshape(A::AbstractGPUArray{T, 1}, dims::Tuple{Integer}) where T
     n = Base._length(A)
-    prod(dims) == n || throw(DimensionMismatch("parent has $n elements, which is incompatible with size $dims"))
+    prod(dims) == n || throw(ArgumentError("parent has $n elements, which is incompatible with size $dims"))
     return unsafe_reinterpret(T, A, dims)
 end
 

--- a/src/reference.jl
+++ b/src/reference.jl
@@ -240,8 +240,8 @@ BroadcastStyle(::Type{JLArray{T,N}}) where {T,N} = JLArrayStyle{N}()
 # Allocating the output container
 Base.similar(bc::Broadcasted{JLArrayStyle{N}}, ::Type{T}) where {N,T} =
     similar(JLArray{T}, axes(bc))
-Base.similar(bc::Broadcasted{JLArrayStyle{N}}, ::Type{T}, dims...) where {N,T} =
-    JLArray{T}(undef, dims...)
+Base.similar(bc::Broadcasted{JLArrayStyle{N}}, ::Type{T}, dims) where {N,T} =
+    JLArray{T}(undef, dims)
 
 
 ## math

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,3 +10,7 @@ include("testsuite.jl")
     JLArrays.allowscalar(false)
     TestSuite.test(JLArray)
 end
+
+@testset "Array" begin
+    TestSuite.test(Array)
+end

--- a/test/testsuite.jl
+++ b/test/testsuite.jl
@@ -30,6 +30,15 @@ function compare(f, AT::Type{<:AbstractGPUArray}, xs...; kwargs...)
     collect(cpu_out) ≈ collect(gpu_out)
 end
 
+function compare(f, AT::Type{<:Array}, xs...; kwargs...)
+    # no need to actually run this tests: we have nothing to compoare against,
+    # and we'll run it on a CPU array anyhow when comparing to a GPU array.
+    #
+    # this method exists so that we can at least run the test suite with Array,
+    # and make sure we cover other tests (that don't call `compare`) too.
+    return true
+end
+
 function supported_eltypes()
     (Float32, Float64, Int32, Int64, ComplexF32, ComplexF64)
 end
@@ -64,7 +73,7 @@ include("testsuite/uniformscaling.jl")
 """
 Runs the entire GPUArrays test suite on array type `AT`
 """
-function test(AT::Type{<:AbstractGPUArray})
+function test(AT::Type)
     for (name, fun) in tests
         code = quote
             $fun($AT)

--- a/test/testsuite/base.jl
+++ b/test/testsuite/base.jl
@@ -141,7 +141,10 @@ end
         @test Array(Af0) == af0
         a = rand(ComplexF32, 4, 4)
         A = AT(a)
-        @test_throws ArgumentError reinterpret(Int8, A)
+        if AT <: AbstractGPUArray
+            # FIXME: make reinterpret(::AbstractGPUArray) behave like ::Array
+            @test_throws ArgumentError reinterpret(Int8, A)
+        end
 
         a = rand(ComplexF32, 10 * 10)
         A = AT(a)
@@ -150,7 +153,7 @@ end
         @test Array(Af0) == af0
     end
 
-    @testset "ntuple test" begin
+    AT <: AbstractGPUArray && @testset "ntuple test" begin
         result = AT(Vector{NTuple{3, Float32}}(undef, 1))
         gpu_call(ntuple_test, result, Val(3))
         @test Array(result)[1] == (77, 2*77, 3*77)
@@ -159,7 +162,7 @@ end
         @test Array(result)[1] == (x, 2*x, 3*x)
     end
 
-    @testset "cartesian iteration" begin
+    AT <: AbstractGPUArray && @testset "cartesian iteration" begin
         Ac = rand(Float32, 32, 32)
         A = AT(Ac)
         result = fill!(copy(A), 0.0)
@@ -167,7 +170,7 @@ end
         Array(result) == Ac
     end
 
-    @testset "Custom kernel from Julia function" begin
+    AT <: AbstractGPUArray && @testset "Custom kernel from Julia function" begin
         x = AT(rand(Float32, 100))
         y = AT(rand(Float32, 100))
         gpu_call(clmap!, -, x, y; target=x)

--- a/test/testsuite/base.jl
+++ b/test/testsuite/base.jl
@@ -37,7 +37,7 @@ end
         copyto!(a, r1, b, r2)
         @test x == Array(a)
         r2 = CartesianIndices((4:11, 3:8))
-        @test_throws DimensionMismatch copyto!(a, r1, b, r2)
+        @test_throws ArgumentError copyto!(a, r1, b, r2)
 
         r2 = CartesianIndices((4:10, 3:8))
         x2 = fill(0f0, (10, 10))

--- a/test/testsuite/base.jl
+++ b/test/testsuite/base.jl
@@ -64,9 +64,9 @@ end
         y = rand(Float32, (20,))
         a = AT(x)
         b = AT(y)
-        r1 = (1:7,)
-        r2 = (4:10,)
-        copyto!(x, r1[1], y, r2[1])
+        r1 = 1:7
+        r2 = 4:10
+        copyto!(x, r1, y, r2)
         copyto!(a, r1, b, r2)
         @test x == Array(a)
 

--- a/test/testsuite/construction.jl
+++ b/test/testsuite/construction.jl
@@ -51,15 +51,17 @@
             @test size(B) == (7,)
             @test eltype(B) == T
 
-            B = similar(Broadcast.Broadcasted(*, (B, B)), Int32, (11, 15))
-            @test B isa AT{Int32,2}
-            @test size(B) == (11, 15)
-            @test eltype(B) == Int32
-
             B = similar(Broadcast.Broadcasted(*, (B, B)), T)
-            @test B isa AT{T,2}
-            @test size(B) == (11, 15)
+            @test B isa AT{T,1}
+            @test size(B) == (7,)
             @test eltype(B) == T
+
+            if VERSION >= v"1.5"
+                B = similar(Broadcast.Broadcasted(*, (B, B)), Int32, (11, 15))
+                @test B isa AT{Int32,2}
+                @test size(B) == (11, 15)
+                @test eltype(B) == Int32
+            end
         end
     end
 

--- a/test/testsuite/construction.jl
+++ b/test/testsuite/construction.jl
@@ -122,43 +122,7 @@ end
 
 @testsuite "value constructors" AT->begin
     for T in supported_eltypes()
-        x = fill(zero(T), (2, 2))
-        x1 = fill(AT{T}, T(0), (2, 2))
-        x2 = fill(AT{T}, T(0), (2, 2))
-        x3 = fill(AT{T, 2}, T(0), (2, 2))
-        @test Array(x1) ≈ x
-        @test Array(x2) ≈ x
-        @test Array(x3) ≈ x
-
-        x = fill(T(1), (2, 2))
-        x1 = fill(AT{T}, T(1), (2, 2))
-        x2 = fill(AT{T}, T(1), (2, 2))
-        x3 = fill(AT{T, 2}, T(1), (2, 2))
-        @test Array(x1) ≈ x
-        @test Array(x2) ≈ x
-        @test Array(x3) ≈ x
-
-        fill!(x, 0)
-
-        x1 = fill(AT{T}, 0f0, (2, 2))
-        x2 = fill(AT{T}, T(0), (2, 2))
-        x3 = fill(AT{T, 2}, T(0), (2, 2))
-        @test Array(x1) ≈ x
-        @test Array(x2) ≈ x
-        @test Array(x3) ≈ x
-
-        fill!(x1, 2f0)
-        x2 = fill!(AT{Int32}(undef, (4, 4, 4)), 77f0)
-        @test all(x-> x == 2f0, Array(x1))
-        @test all(x-> x == Int32(77), Array(x2))
-
-        x = fill(zero(T), (0, 2))
-        x1 = fill(AT{T}, T(0), (0, 2))
-        x2 = fill(AT{T}, T(0), (0, 2))
-        x3 = fill(AT{T, 2}, T(0), (0, 2))
-        @test Array(x1) ≈ x
-        @test Array(x2) ≈ x
-        @test Array(x3) ≈ x
+        @test compare((a,b)->fill!(a, b), AT, rand(T, 3), rand(T))
 
         x = Matrix{T}(I, 4, 2)
 
@@ -174,19 +138,13 @@ end
         x1 = AT(T(3) * I, 2, 4)
         @test eltype(x1) == T
         @test Array(x1) ≈ x
-
-        x = fill(T(3), (2, 4))
-        x1 = fill(AT{T}, T(3), (2, 4))
-        copyto!(x, 2I)
-        copyto!(x1, 2I)
-        @test Array(x1) ≈ x
     end
 end
 
 @testsuite "iterator constructors" AT->begin
     for T in supported_eltypes()
-        @test AT(Fill(T(0), (10,))) == fill(AT{T}, T(0), (10,))
-        @test AT(Fill(T(0), (10, 10))) == fill(AT{T}, T(0), (10, 10))
+        @test AT(Fill(T(0), (10,))) == fill!(similar(AT{T}, (10,)), T(0))
+        @test AT(Fill(T(0), (10, 10))) == fill!(similar(AT{T}, (10, 10)), T(0))
         if T <: Real
             x = AT{Float32}(Fill(T(0), (10, 10)))
             @test eltype(x) == Float32

--- a/test/testsuite/construction.jl
+++ b/test/testsuite/construction.jl
@@ -51,7 +51,7 @@
             @test size(B) == (7,)
             @test eltype(B) == T
 
-            B = similar(Broadcast.Broadcasted(*, (B, B)), Int32, 11, 15)
+            B = similar(Broadcast.Broadcasted(*, (B, B)), Int32, (11, 15))
             @test B isa AT{Int32,2}
             @test size(B) == (11, 15)
             @test eltype(B) == Int32
@@ -62,6 +62,7 @@
             @test eltype(B) == T
         end
     end
+
     @testset "comparison against Array" begin
         for typs in [(), (Int,), (Int,1), (Int,2), (Float32,), (Float32,1), (Float32,2)],
             args in [(), (1,), (1,2), ((1,),), ((1,2),),

--- a/test/testsuite/gpuinterface.jl
+++ b/test/testsuite/gpuinterface.jl
@@ -1,4 +1,6 @@
 @testsuite "interface" AT->begin
+    AT <: AbstractGPUArray || return
+
     N = 10
     x = AT(Vector{Int}(undef, N))
     x .= 0

--- a/test/testsuite/indexing.jl
+++ b/test/testsuite/indexing.jl
@@ -1,5 +1,5 @@
 @testsuite "indexing" AT->begin
-    @allowscalar @testset "errors and warnings" begin
+    AT <: AbstractGPUArray && @allowscalar @testset "errors and warnings" begin
         x = AT([0])
 
         allowscalar(true, false)

--- a/test/testsuite/indexing.jl
+++ b/test/testsuite/indexing.jl
@@ -53,15 +53,15 @@
             @test Array(src[3:end]) == x[3:end]
         end
         @testset "multi dim, sliced setindex" begin
-            x = fill(AT{T}, T(0), (10, 10, 10, 10))
-            y = AT{T}(undef, 5, 5, 10, 10)
+            x = AT(zeros(T, (10, 10, 10, 10)))
+            y = similar(x, (5, 5, 10, 10))
             rand!(y)
             x[2:6, 2:6, :, :] = y
             @test Array(x[2:6, 2:6, :, :]) == Array(y)
         end
         @testset "multi dim, sliced setindex, CPU source" begin
-            x = fill(AT{T}, T(0), (2,3,4))
-            y = Array{T}(undef, 2,3)
+            x = AT(zeros(T, (2,3,4)))
+            y = similar(x, (2,3))
             rand!(y)
             x[:, :, 2] = y
             @test x[:, :, 2] == y

--- a/test/testsuite/random.jl
+++ b/test/testsuite/random.jl
@@ -9,7 +9,11 @@
             rand!(B)
             @test !any(A .== B)
 
-            rng = GPUArrays.default_rng(AT)
+            rng = if AT <: AbstractGPUArray
+                GPUArrays.default_rng(AT)
+            else
+                Random.default_rng()
+            end
             Random.seed!(rng)
             Random.seed!(rng, 1)
             rand!(rng, A)
@@ -32,7 +36,11 @@
             randn!(B)
             @test !any(A .== B)
 
-            rng = GPUArrays.default_rng(AT)
+            rng = if AT <: AbstractGPUArray
+                GPUArrays.default_rng(AT)
+            else
+                Random.default_rng()
+            end
             Random.seed!(rng)
             Random.seed!(rng, 1)
             randn!(rng, A)


### PR DESCRIPTION
This'll prevent us from adding/maintaining GPUArrays-specific APIs. After all, we're aiming to be compatible with Base.Array. It doesn't help to write generic code if we have a bunch of custom APIs.