### PR TITLE
Mapreduce on array wrappers

### DIFF
--- a/src/host/broadcast.jl
+++ b/src/host/broadcast.jl
@@ -6,7 +6,7 @@ using Base.Broadcast
 
 import Base.Broadcast: BroadcastStyle, Broadcasted, AbstractArrayStyle
 
-const BroadcastGPUArray{T} = Union{AbstractOrWrappedGPUArray{T},
+const BroadcastGPUArray{T} = Union{AnyGPUArray{T},
                                    Base.RefValue{<:AbstractGPUArray{T}}}
 
 """

--- a/src/host/construction.jl
+++ b/src/host/construction.jl
@@ -1,6 +1,6 @@
 # constructors and conversions
 
-function Base.fill!(A::AbstractOrWrappedGPUArray{T}, x) where T
+function Base.fill!(A::AnyGPUArray{T}, x) where T
     length(A) == 0 && return A
     gpu_call(A, convert(T, x)) do ctx, a, val
         idx = @linearidx(a)
@@ -18,16 +18,16 @@ function uniformscaling_kernel(ctx::AbstractKernelContext, res::AbstractArray{T}
     return
 end
 
-function (T::Type{<: AbstractOrWrappedGPUArray{U}})(s::UniformScaling, dims::Dims{2}) where {U}
+function (T::Type{<: AnyGPUArray{U}})(s::UniformScaling, dims::Dims{2}) where {U}
     res = similar(T, dims)
     fill!(res, zero(U))
     gpu_call(uniformscaling_kernel, res, size(res, 1), s; total_threads=minimum(dims))
     res
 end
 
-(T::Type{<: AbstractOrWrappedGPUArray})(s::UniformScaling{U}, dims::Dims{2}) where U = T{U}(s, dims)
+(T::Type{<: AnyGPUArray})(s::UniformScaling{U}, dims::Dims{2}) where U = T{U}(s, dims)
 
-(T::Type{<: AbstractOrWrappedGPUArray})(s::UniformScaling, m::Integer, n::Integer) = T(s, Dims((m, n)))
+(T::Type{<: AnyGPUArray})(s::UniformScaling, m::Integer, n::Integer) = T(s, Dims((m, n)))
 
 function Base.copyto!(A::AbstractGPUMatrix{T}, s::UniformScaling) where T
     fill!(A, zero(T))

--- a/src/host/linalg.jl
+++ b/src/host/linalg.jl
@@ -99,7 +99,7 @@ end
 
 ## matrix multiplication
 
-function generic_matmatmul!(C::AbstractOrWrappedGPUArray{R}, A::AbstractOrWrappedGPUArray{T}, B::AbstractOrWrappedGPUArray{S}, a::Number, b::Number) where {T,S,R}
+function generic_matmatmul!(C::AnyGPUArray{R}, A::AnyGPUArray{T}, B::AnyGPUArray{S}, a::Number, b::Number) where {T,S,R}
     if size(A,2) != size(B,1)
         throw(DimensionMismatch("matrix A has dimensions $(size(A)), matrix B has dimensions $(size(B))"))
     end

--- a/src/host/math.jl
+++ b/src/host/math.jl
@@ -1,6 +1,6 @@
 # Base mathematical operations
 
-function Base.clamp!(A::AbstractOrWrappedGPUArray, low, high)
+function Base.clamp!(A::AnyGPUArray, low, high)
     gpu_call(A, low, high) do ctx, A, low, high
         I = @cartesianidx A
         A[I] = clamp(A[I], low, high)

--- a/src/host/random.jl
+++ b/src/host/random.jl
@@ -67,7 +67,7 @@ struct RNG <: AbstractRNG
 end
 
 # return an instance of GPUArrays.RNG suitable for the requested array type
-default_rng(::Type{<:AbstractGPUArray}) = error("Not implemented") # COV_EXCL_LINE
+default_rng(::Type{<:AnyGPUArray}) = error("Not implemented") # COV_EXCL_LINE
 
 make_seed(rng::RNG) = make_seed(rng, rand(UInt))
 function make_seed(rng::RNG, n::Integer)
@@ -81,7 +81,7 @@ function Random.seed!(rng::RNG, seed::Vector{UInt32})
     return
 end
 
-function Random.rand!(rng::RNG, A::AbstractGPUArray{T}) where T <: Number
+function Random.rand!(rng::RNG, A::AnyGPUArray{T}) where T <: Number
     gpu_call(A, rng.state) do ctx, a, randstates
         idx = linear_index(ctx)
         idx > length(a) && return
@@ -91,7 +91,7 @@ function Random.rand!(rng::RNG, A::AbstractGPUArray{T}) where T <: Number
     A
 end
 
-function Random.randn!(rng::RNG, A::AbstractGPUArray{T}) where T <: Number
+function Random.randn!(rng::RNG, A::AnyGPUArray{T}) where T <: Number
     threads = (length(A) - 1) ÷ 2 + 1
     length(A) == 0 && return
     gpu_call(A, rng.state; total_threads = threads) do ctx, a, randstates


### PR DESCRIPTION
Not representing Reshape/Reinterpret as the underlying array has exposed quite some operations where we did not properly use the `WrappedOr` alias.