### PR TITLE
Perform comparisons on the CPU.

### DIFF
--- a/src/reference.jl
+++ b/src/reference.jl
@@ -379,7 +379,7 @@ end
 
 const GLOBAL_RNG = Ref{Union{Nothing,GPUArrays.RNG}}(nothing)
 function GPUArrays.default_rng(::Type{<:JLArray})
-    if GLOBAL_RNG[] == nothing
+    if GLOBAL_RNG[] === nothing
         N = MAXTHREADS
         state = JLArray{NTuple{4, UInt32}}(undef, N)
         rng = GPUArrays.RNG(state)

--- a/test/testsuite.jl
+++ b/test/testsuite.jl
@@ -55,7 +55,7 @@ macro testsuite(name, ex)
     safe_name = lowercase(replace(name, " "=>"_"))
     fn = Symbol("test_$(safe_name)")
     quote
-        $fn(AT) = $(esc(ex))(AT)
+        $(esc(fn))(AT) = $(esc(ex))(AT)
 
         @assert !haskey(tests, $name)
         tests[$name] = $fn

--- a/test/testsuite/broadcasting.jl
+++ b/test/testsuite/broadcasting.jl
@@ -54,9 +54,9 @@ function broadcasting(AT)
             @testset "Adjoint and Transpose" begin
                 A = AT(rand(ET, N))
                 A' .= ET(2)
-                @test all(isequal(ET(2)'), A)
+                @test all(isequal(ET(2)'), Array(A))
                 transpose(A) .= ET(1)
-                @test all(isequal(ET(1)), A)
+                @test all(isequal(ET(1)), Array(A))
             end
 
             ############

--- a/test/testsuite/construction.jl
+++ b/test/testsuite/construction.jl
@@ -146,12 +146,12 @@ end
 
 @testsuite "iterator constructors" AT->begin
     for T in supported_eltypes()
-        @test AT(Fill(T(0), (10,))) == fill!(similar(AT{T}, (10,)), T(0))
-        @test AT(Fill(T(0), (10, 10))) == fill!(similar(AT{T}, (10, 10)), T(0))
+        @test Array(AT(Fill(T(0), (10,)))) == Array(fill!(similar(AT{T}, (10,)), T(0)))
+        @test Array(AT(Fill(T(0), (10, 10)))) == Array(fill!(similar(AT{T}, (10, 10)), T(0)))
         if T <: Real
             x = AT{Float32}(Fill(T(0), (10, 10)))
             @test eltype(x) == Float32
-            @test AT(Eye{T}((10))) == AT{T}(I, 10, 10)
+            @test Array(AT(Eye{T}((10)))) == Array(AT{T}(I, 10, 10))
             x = AT{Float32}(Eye{T}(10))
             @test eltype(x) == Float32
         end

--- a/test/testsuite/indexing.jl
+++ b/test/testsuite/indexing.jl
@@ -85,18 +85,16 @@ end
 @testsuite "indexing multidimensional" AT->begin
     @testset "sliced setindex" for T in supported_eltypes()
         x = AT(zeros(T, (10, 10, 10, 10)))
-        y = similar(x, (5, 5, 10, 10))
-        rand!(y)
+        y = AT(rand(T, (5, 5, 10, 10)))
         x[2:6, 2:6, :, :] = y
         @test Array(x[2:6, 2:6, :, :]) == Array(y)
     end
 
     @testset "sliced setindex, CPU source" for T in supported_eltypes()
         x = AT(zeros(T, (2,3,4)))
-        y = similar(x, (2,3))
-        rand!(y)
+        y = AT(rand(T, (2,3)))
         x[:, :, 2] = y
-        @test x[:, :, 2] == y
+        @test Array(x[:, :, 2]) == Array(y)
     end
 
     @allowscalar @testset "empty array" begin

--- a/test/testsuite/random.jl
+++ b/test/testsuite/random.jl
@@ -7,7 +7,7 @@
             B = copy(A)
             rand!(A)
             rand!(B)
-            @test A != B
+            @test Array(A) != Array(B)
 
             rng = if AT <: AbstractGPUArray
                 GPUArrays.default_rng(AT)
@@ -19,7 +19,7 @@
             rand!(rng, A)
             Random.seed!(rng, 1)
             rand!(rng, B)
-            @test all(A .== B)
+            @test all(Array(A) .== Array(B))
         end
 
         A = AT{Bool}(undef, 5)
@@ -34,7 +34,7 @@
             B = copy(A)
             randn!(A)
             randn!(B)
-            @test !any(A .== B)
+            @test !any(Array(A) .== Array(B))
 
             rng = if AT <: AbstractGPUArray
                 GPUArrays.default_rng(AT)
@@ -46,7 +46,7 @@
             randn!(rng, A)
             Random.seed!(rng, 1)
             randn!(rng, B)
-            @test all(A .== B)
+            @test all(Array(A) .== Array(B))
         end
     end
 end


### PR DESCRIPTION
This makes more of the test suite work without a mapreduce implementation.