### PR TITLE
Fix `repeat` when length = 0

### DIFF
--- a/src/host/base.jl
+++ b/src/host/base.jl
@@ -3,6 +3,9 @@
 function Base.repeat(a::AbstractGPUVecOrMat, m::Int, n::Int = 1)
     o, p = size(a, 1), size(a, 2)
     b = similar(a, o*m, p*n)
+    if length(b) == 0
+        return b
+    end
     gpu_call(b, a, o, p, m, n; total_threads=n) do ctx, b, a, o, p, m, n
         j = linear_index(ctx)
         j > n && return
@@ -23,6 +26,9 @@ end
 function Base.repeat(a::AbstractGPUVector, m::Int)
     o = length(a)
     b = similar(a, o*m)
+    if length(b) == 0
+        return b
+    end
     gpu_call(b, a, o, m; total_threads=m) do ctx, b, a, o, m
         i = linear_index(ctx)
         i > m && return

--- a/test/testsuite/base.jl
+++ b/test/testsuite/base.jl
@@ -184,6 +184,9 @@ end
         @test compare(a-> repeat(a, 5),     AT, rand(Float32, 10))
         @test compare(a-> repeat(a, 5),     AT, rand(Float32, 5, 4))
         @test compare(a-> repeat(a, 4, 3),  AT, rand(Float32, 10, 15))
+        @test compare(a-> repeat(a, 0),     AT, rand(Float32, 10))
+        @test compare(a-> repeat(a, 0),     AT, rand(Float32, 5, 4))
+        @test compare(a-> repeat(a, 4, 0),  AT, rand(Float32, 10, 15))
     end
 
     @testset "permutedims" begin


### PR DESCRIPTION
Same problem as in #81, fixed in #300, but for `repeat`.