### PR TITLE
Specialize permutedims kernel for the permutation.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@ steps:
   - label: "CUDA.jl"
     plugins:
       - JuliaCI/julia#v0.4:
-          version: 1.5
+          version: nightly
       - JuliaCI/julia-coverage#v0.2:
           codecov: true
     command: |
@@ -25,7 +25,7 @@ steps:
   - label: "oneAPI.jl"
     plugins:
       - JuliaCI/julia#v0.4:
-          version: 1.5
+          version: nightly
       - JuliaCI/julia-coverage#v0.2:
           codecov: true
     command: |


### PR DESCRIPTION
About a 30% performance improvement. I assume it's reasonable to specialize the kernel on the permutation, if we're using tuples in the first place. We can always add a fully-dynamic kernel that could also work with Vector-typed inputs.

```
julia> src = CuArray(rand(Complex{Float64}, 256, 256, 256));

julia> dst = similar(src);

julia> @benchmark CUDA.@sync permutedims!(dst, src, (2, 1, 3))
BenchmarkTools.Trial: 
  memory estimate:  576 bytes
  allocs estimate:  24
  --------------
  minimum time:     1.532 ms (0.00% GC)
  median time:      1.561 ms (0.00% GC)
  mean time:        1.614 ms (0.00% GC)
  maximum time:     16.173 ms (0.00% GC)
  --------------
  samples:          3094
  evals/sample:     1

julia> @benchmark CUDA.@sync permutedims!(dst, src, (2, 1, 3))
BenchmarkTools.Trial: 
  memory estimate:  512 bytes
  allocs estimate:  22
  --------------
  minimum time:     2.226 ms (0.00% GC)
  median time:      2.262 ms (0.00% GC)
  mean time:        2.333 ms (0.00% GC)
  maximum time:     14.548 ms (0.00% GC)
  --------------
  samples:          2141
  evals/sample:     1
```