### PR TITLE
Properly error when broadcasting type-unstable functions.

### DIFF
--- a/test/testsuite/broadcasting.jl
+++ b/test/testsuite/broadcasting.jl
@@ -1,6 +1,16 @@
 @testsuite "broadcasting" AT->begin
     broadcasting(AT)
     vec3(AT)
+
+    @testset "type instabilities" begin
+        f(x) = x ? 1.0 : 0
+        try
+            f.(AT(rand(Bool, 1)))
+        catch err
+            @test err isa ErrorException
+            @test contains(err.msg, "GPU broadcast resulted in non-concrete element type")
+        end
+    end
 end
 
 test_idx(idx, A::AbstractArray{T}) where T = A[idx] * T(2)


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/CUDA.jl/issues/145.

```julia
julia> function h(x)
           if x ≤ 0
               ψ = -π / CUDA.tan(π * x)
           else
               ψ = zero(x)
           end
           return ψ
       end
h (generic function with 1 method)

julia> h.(CUDA.randn(3))
ERROR: GPU broadcast resulted in non-concrete element type AbstractFloat.
This probably means that the function you are broadcasting contains an error or type instability.
```