### PR TITLE
Don't add a public adapt method for Array.

### DIFF
--- a/src/host/abstractarray.jl
+++ b/src/host/abstractarray.jl
@@ -41,8 +41,10 @@ end
 
 ## convert to CPU (keeping wrapper type)
 
-Adapt.adapt_storage(::Type{<:Array}, xs::AbstractArray) = convert(Array, xs)
-convert_to_cpu(xs) = adapt(Array, xs)
+struct ToArray end
+
+Adapt.adapt_storage(::ToArray, xs::AbstractArray) = convert(Array, xs)
+convert_to_cpu(xs) = adapt(ToArray(), xs)
 
 ## showing
 


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/GPUArrays.jl/issues/296.