### PR TITLE
Simplify adapt calls when showing arrays.

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,15 +2,15 @@
 
 [[AbstractFFTs]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "8ed9de2f1b1a9b1dee48582ad477c6e67b83eb2c"
+git-tree-sha1 = "485ee0867925449198280d4af84bdb46a2a404d0"
 uuid = "621f4979-c628-5d54-868e-fcf4e3e8185c"
-version = "1.0.0"
+version = "1.0.1"
 
 [[Adapt]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "27edd95a09fd428113ca019c092e8aeca2eb1f2d"
+git-tree-sha1 = "f1b523983a58802c4695851926203b36e28f09db"
 uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-version = "3.0.0"
+version = "3.3.0"
 
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/src/host/abstractarray.jl
+++ b/src/host/abstractarray.jl
@@ -39,30 +39,26 @@ function Serialization.deserialize(s::AbstractSerializer, ::Type{T}) where T <: 
     T(A)
 end
 
-## convert to CPU (keeping wrapper type)
+## showing
 
 struct ToArray end
-
-Adapt.adapt_storage(::ToArray, xs::AbstractArray) = convert(Array, xs)
-convert_to_cpu(xs) = adapt(ToArray(), xs)
-
-## showing
+Adapt.adapt_storage(::ToArray, xs::AbstractGPUArray) = convert(Array, xs)
 
 # display
 Base.print_array(io::IO, X::AnyGPUArray) =
-    Base.print_array(io, convert_to_cpu(X))
+    Base.print_array(io, adapt(ToArray(), X))
 
 # show
 Base._show_nonempty(io::IO, X::AnyGPUArray, prefix::String) =
-    Base._show_nonempty(io, convert_to_cpu(X), prefix)
+    Base._show_nonempty(io, adapt(ToArray(), X), prefix)
 Base._show_empty(io::IO, X::AnyGPUArray) =
-    Base._show_empty(io, convert_to_cpu(X))
+    Base._show_empty(io, adapt(ToArray(), X))
 Base.show_vector(io::IO, v::AnyGPUArray, args...) =
-    Base.show_vector(io, convert_to_cpu(v), args...)
+    Base.show_vector(io, adapt(ToArray(), v), args...)
 
 ## collect to CPU (discarding wrapper type)
 
-collect_to_cpu(xs::AbstractArray) = collect(convert_to_cpu(xs))
+collect_to_cpu(xs::AbstractArray) = collect(adapt(ToArray(), xs))
 Base.collect(X::AnyGPUArray) = collect_to_cpu(X)
 
 


### PR DESCRIPTION
Otherwise containers like `Base.Slice` get flattened to an Array.