### PR TITLE
`repeat` for Julia 1.6 and higher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.5'
           - '1.6'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [compat]
 AbstractFFTs = "0.4, 0.5, 1.0"
 Adapt = "2.0, 3.0"
-julia = "1.5"
+julia = "1.6"
 
 [extras]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"

--- a/src/host/base.jl
+++ b/src/host/base.jl
@@ -22,6 +22,8 @@ if VERSION ≥ v"1.6"
 
     function repeat_inner(xs::AnyGPUArray, inner)
         out = similar(xs, eltype(xs), inner .* size(xs))
+        any(==(0), size(out)) && return out # consistent with `Base.repeat`
+
         gpu_call(repeat_inner_kernel!, xs, inner, out; total_threads=prod(size(out)))
         return out
     end
@@ -44,6 +46,8 @@ if VERSION ≥ v"1.6"
 
     function repeat_outer(xs::AnyGPUArray, outer)
         out = similar(xs, eltype(xs), outer .* size(xs))
+        any(==(0), size(out)) && return out # consistent with `Base.repeat`
+
         gpu_call(repeat_outer_kernel!, xs, size(xs), outer, out; total_threads=prod(size(out)))
         return out
     end

--- a/src/host/base.jl
+++ b/src/host/base.jl
@@ -1,117 +1,75 @@
 # common Base functionality
 
-if VERSION ≥ v"1.6"
-    import Base: _RepeatInnerOuter
+import Base: _RepeatInnerOuter
 
-    function repeat_inner_kernel!(
-        ctx::AbstractKernelContext,
-        xs::AbstractArray{<:Any, N},
-        inner::NTuple{N, Int},
-        out::AbstractArray{<:Any, N}
-    ) where {N}
-        dest_inds = @cartesianidx(out).I
-        # Get the "stride" index in each dimension, where the size
-        # of the stride is given by `inner`. The stride-index then
-        # corresponds to the index of the repeated value in `xs`.
-        src_inds = ntuple(i -> (dest_inds[i] - 1) ÷ inner[i] + 1, N)
+function repeat_inner_kernel!(
+    ctx::AbstractKernelContext,
+    xs::AbstractArray{<:Any, N},
+    inner::NTuple{N, Int},
+    out::AbstractArray{<:Any, N}
+) where {N}
+    dest_inds = @cartesianidx(out).I
+    # Get the "stride" index in each dimension, where the size
+    # of the stride is given by `inner`. The stride-index then
+    # corresponds to the index of the repeated value in `xs`.
+    src_inds = ntuple(i -> (dest_inds[i] - 1) ÷ inner[i] + 1, N)
 
-        @inbounds out[dest_inds...] = xs[src_inds...]
+    @inbounds out[dest_inds...] = xs[src_inds...]
 
-        return nothing
-    end
-
-    function repeat_inner(xs::AnyGPUArray, inner)
-        out = similar(xs, eltype(xs), inner .* size(xs))
-        any(==(0), size(out)) && return out # consistent with `Base.repeat`
-
-        gpu_call(repeat_inner_kernel!, xs, inner, out; total_threads=prod(size(out)))
-        return out
-    end
-
-    function repeat_outer_kernel!(
-        ctx::AbstractKernelContext,
-        xs::AbstractArray{<:Any, N},
-        xssize::NTuple{N},
-        outer::NTuple{N},
-        out::AbstractArray{<:Any, N}
-    ) where {N}
-        dest_inds = @cartesianidx(out).I
-        # Outer is just wrapping around the edges of `xs`.
-        src_inds = ntuple(i -> (dest_inds[i] - 1) % xssize[i] + 1, N)
-
-        @inbounds out[dest_inds...] = xs[src_inds...]
-
-        return nothing
-    end
-
-    function repeat_outer(xs::AnyGPUArray, outer)
-        out = similar(xs, eltype(xs), outer .* size(xs))
-        any(==(0), size(out)) && return out # consistent with `Base.repeat`
-
-        gpu_call(repeat_outer_kernel!, xs, size(xs), outer, out; total_threads=prod(size(out)))
-        return out
-    end
-
-    # Overload methods used by `Base.repeat`.
-    # No need to implement `repeat_inner_outer` since this is implemented in `Base` as
-    # `repeat_outer(repeat_inner(arr, inner), outer)`.
-    function _RepeatInnerOuter.repeat_inner(xs::AnyGPUArray{<:Any, N}, dims::NTuple{N}) where {N}
-        return repeat_inner(xs, dims)
-    end
-
-    function _RepeatInnerOuter.repeat_outer(xs::AnyGPUArray{<:Any, N}, dims::NTuple{N}) where {N}
-        return repeat_outer(xs, dims)
-    end
-
-    function _RepeatInnerOuter.repeat_outer(xs::AnyGPUArray{<:Any, 1}, dims::Tuple{Any})
-        return repeat_outer(xs, dims)
-    end
-
-    function _RepeatInnerOuter.repeat_outer(xs::AnyGPUArray{<:Any, 2}, dims::NTuple{2, Any})
-        return repeat_outer(xs, dims)
-    end
-else
-    function Base.repeat(a::AbstractGPUVecOrMat, m::Int, n::Int = 1)
-        o, p = size(a, 1), size(a, 2)
-        b = similar(a, o*m, p*n)
-        if length(b) == 0
-            return b
-        end
-        gpu_call(b, a, o, p, m, n; total_threads=n) do ctx, b, a, o, p, m, n
-            j = linear_index(ctx)
-            j > n && return
-            d = (j - 1) * p + 1
-            @inbounds for i in 1:m
-                c = (i - 1) * o + 1
-                for r in 1:p
-                    for k in 1:o
-                        b[k - 1 + c, r - 1 + d] = a[k, r]
-                    end
-                end
-            end
-            return
-        end
-        return b
-    end
-
-    function Base.repeat(a::AbstractGPUVector, m::Int)
-        o = length(a)
-        b = similar(a, o*m)
-        if length(b) == 0
-            return b
-        end
-        gpu_call(b, a, o, m; total_threads=m) do ctx, b, a, o, m
-            i = linear_index(ctx)
-            i > m && return
-            c = (i - 1)*o + 1
-            @inbounds for i in 1:o
-                b[c + i - 1] = a[i]
-            end
-            return
-        end
-        return b
-    end
+    return nothing
 end
+
+function repeat_inner(xs::AnyGPUArray, inner)
+    out = similar(xs, eltype(xs), inner .* size(xs))
+    any(==(0), size(out)) && return out # consistent with `Base.repeat`
+
+    gpu_call(repeat_inner_kernel!, xs, inner, out; total_threads=prod(size(out)))
+    return out
+end
+
+function repeat_outer_kernel!(
+    ctx::AbstractKernelContext,
+    xs::AbstractArray{<:Any, N},
+    xssize::NTuple{N},
+    outer::NTuple{N},
+    out::AbstractArray{<:Any, N}
+) where {N}
+    dest_inds = @cartesianidx(out).I
+    # Outer is just wrapping around the edges of `xs`.
+    src_inds = ntuple(i -> (dest_inds[i] - 1) % xssize[i] + 1, N)
+
+    @inbounds out[dest_inds...] = xs[src_inds...]
+
+    return nothing
+end
+
+function repeat_outer(xs::AnyGPUArray, outer)
+    out = similar(xs, eltype(xs), outer .* size(xs))
+    any(==(0), size(out)) && return out # consistent with `Base.repeat`
+
+    gpu_call(repeat_outer_kernel!, xs, size(xs), outer, out; total_threads=prod(size(out)))
+    return out
+end
+
+# Overload methods used by `Base.repeat`.
+# No need to implement `repeat_inner_outer` since this is implemented in `Base` as
+# `repeat_outer(repeat_inner(arr, inner), outer)`.
+function _RepeatInnerOuter.repeat_inner(xs::AnyGPUArray{<:Any, N}, dims::NTuple{N}) where {N}
+    return repeat_inner(xs, dims)
+end
+
+function _RepeatInnerOuter.repeat_outer(xs::AnyGPUArray{<:Any, N}, dims::NTuple{N}) where {N}
+    return repeat_outer(xs, dims)
+end
+
+function _RepeatInnerOuter.repeat_outer(xs::AnyGPUArray{<:Any, 1}, dims::Tuple{Any})
+    return repeat_outer(xs, dims)
+end
+
+function _RepeatInnerOuter.repeat_outer(xs::AnyGPUArray{<:Any, 2}, dims::NTuple{2, Any})
+    return repeat_outer(xs, dims)
+end
+
 ## PermutedDimsArrays
 
 using Base: PermutedDimsArrays

--- a/src/host/base.jl
+++ b/src/host/base.jl
@@ -20,8 +20,8 @@ if VERSION ≥ v"1.6"
         return nothing
     end
 
-    function repeat_inner(xs::TV, inner) where {TV<:AbstractGPUArray}
-        out = TV(undef, inner .* size(xs))
+    function repeat_inner(xs::AnyGPUArray, inner)
+        out = similar(xs, eltype(xs), inner .* size(xs))
         gpu_call(repeat_inner_kernel!, xs, inner, out; total_threads=prod(size(out)))
         return out
     end
@@ -42,8 +42,8 @@ if VERSION ≥ v"1.6"
         return nothing
     end
 
-    function repeat_outer(xs::TV, outer) where {TV<:AbstractGPUArray}
-        out = TV(undef, outer .* size(xs))
+    function repeat_outer(xs::AnyGPUArray, outer)
+        out = similar(xs, eltype(xs), outer .* size(xs))
         gpu_call(repeat_outer_kernel!, xs, size(xs), outer, out; total_threads=prod(size(out)))
         return out
     end
@@ -51,19 +51,19 @@ if VERSION ≥ v"1.6"
     # Overload methods used by `Base.repeat`.
     # No need to implement `repeat_inner_outer` since this is implemented in `Base` as
     # `repeat_outer(repeat_inner(arr, inner), outer)`.
-    function _RepeatInnerOuter.repeat_inner(xs::AbstractGPUArray{<:Any, N}, dims::NTuple{N}) where {N}
+    function _RepeatInnerOuter.repeat_inner(xs::AnyGPUArray{<:Any, N}, dims::NTuple{N}) where {N}
         return repeat_inner(xs, dims)
     end
 
-    function _RepeatInnerOuter.repeat_outer(xs::AbstractGPUArray{<:Any, N}, dims::NTuple{N}) where {N}
+    function _RepeatInnerOuter.repeat_outer(xs::AnyGPUArray{<:Any, N}, dims::NTuple{N}) where {N}
         return repeat_outer(xs, dims)
     end
 
-    function _RepeatInnerOuter.repeat_outer(xs::AbstractGPUVector, dims::Tuple{Any})
+    function _RepeatInnerOuter.repeat_outer(xs::AnyGPUArray{<:Any, 1}, dims::Tuple{Any})
         return repeat_outer(xs, dims)
     end
 
-    function _RepeatInnerOuter.repeat_outer(xs::AbstractGPUMatrix, dims::NTuple{2, Any})
+    function _RepeatInnerOuter.repeat_outer(xs::AnyGPUArray{<:Any, 2}, dims::NTuple{2, Any})
         return repeat_outer(xs, dims)
     end
 else

--- a/src/host/base.jl
+++ b/src/host/base.jl
@@ -1,46 +1,113 @@
 # common Base functionality
 
-function Base.repeat(a::AbstractGPUVecOrMat, m::Int, n::Int = 1)
-    o, p = size(a, 1), size(a, 2)
-    b = similar(a, o*m, p*n)
-    if length(b) == 0
-        return b
+if VERSION ≥ v"1.6"
+    import Base: _RepeatInnerOuter
+
+    function repeat_inner_kernel!(
+        ctx::AbstractKernelContext,
+        xs::AbstractArray{<:Any, N},
+        inner::NTuple{N, Int},
+        out::AbstractArray{<:Any, N}
+    ) where {N}
+        dest_inds = @cartesianidx(out).I
+        # Get the "stride" index in each dimension, where the size
+        # of the stride is given by `inner`. The stride-index then
+        # corresponds to the index of the repeated value in `xs`.
+        src_inds = ntuple(i -> (dest_inds[i] - 1) ÷ inner[i] + 1, N)
+
+        @inbounds out[dest_inds...] = xs[src_inds...]
+
+        return nothing
     end
-    gpu_call(b, a, o, p, m, n; total_threads=n) do ctx, b, a, o, p, m, n
-        j = linear_index(ctx)
-        j > n && return
-        d = (j - 1) * p + 1
-        @inbounds for i in 1:m
-            c = (i - 1) * o + 1
-            for r in 1:p
-                for k in 1:o
-                    b[k - 1 + c, r - 1 + d] = a[k, r]
+
+    function repeat_inner(xs::TV, inner) where {TV<:AbstractGPUArray}
+        out = TV(undef, inner .* size(xs))
+        gpu_call(repeat_inner_kernel!, xs, inner, out; total_threads=prod(size(out)))
+        return out
+    end
+
+    function repeat_outer_kernel!(
+        ctx::AbstractKernelContext,
+        xs::AbstractArray{<:Any, N},
+        xssize::NTuple{N},
+        outer::NTuple{N},
+        out::AbstractArray{<:Any, N}
+    ) where {N}
+        dest_inds = @cartesianidx(out).I
+        # Outer is just wrapping around the edges of `xs`.
+        src_inds = ntuple(i -> (dest_inds[i] - 1) % xssize[i] + 1, N)
+
+        @inbounds out[dest_inds...] = xs[src_inds...]
+
+        return nothing
+    end
+
+    function repeat_outer(xs::TV, outer) where {TV<:AbstractGPUArray}
+        out = TV(undef, outer .* size(xs))
+        gpu_call(repeat_outer_kernel!, xs, size(xs), outer, out; total_threads=prod(size(out)))
+        return out
+    end
+
+    # Overload methods used by `Base.repeat`.
+    # No need to implement `repeat_inner_outer` since this is implemented in `Base` as
+    # `repeat_outer(repeat_inner(arr, inner), outer)`.
+    function _RepeatInnerOuter.repeat_inner(xs::AbstractGPUArray{<:Any, N}, dims::NTuple{N}) where {N}
+        return repeat_inner(xs, dims)
+    end
+
+    function _RepeatInnerOuter.repeat_outer(xs::AbstractGPUArray{<:Any, N}, dims::NTuple{N}) where {N}
+        return repeat_outer(xs, dims)
+    end
+
+    function _RepeatInnerOuter.repeat_outer(xs::AbstractGPUVector, dims::Tuple{Any})
+        return repeat_outer(xs, dims)
+    end
+
+    function _RepeatInnerOuter.repeat_outer(xs::AbstractGPUMatrix, dims::NTuple{2, Any})
+        return repeat_outer(xs, dims)
+    end
+else
+    function Base.repeat(a::AbstractGPUVecOrMat, m::Int, n::Int = 1)
+        o, p = size(a, 1), size(a, 2)
+        b = similar(a, o*m, p*n)
+        if length(b) == 0
+            return b
+        end
+        gpu_call(b, a, o, p, m, n; total_threads=n) do ctx, b, a, o, p, m, n
+            j = linear_index(ctx)
+            j > n && return
+            d = (j - 1) * p + 1
+            @inbounds for i in 1:m
+                c = (i - 1) * o + 1
+                for r in 1:p
+                    for k in 1:o
+                        b[k - 1 + c, r - 1 + d] = a[k, r]
+                    end
                 end
             end
+            return
         end
-        return
-    end
-    return b
-end
-
-function Base.repeat(a::AbstractGPUVector, m::Int)
-    o = length(a)
-    b = similar(a, o*m)
-    if length(b) == 0
         return b
     end
-    gpu_call(b, a, o, m; total_threads=m) do ctx, b, a, o, m
-        i = linear_index(ctx)
-        i > m && return
-        c = (i - 1)*o + 1
-        @inbounds for i in 1:o
-            b[c + i - 1] = a[i]
-        end
-        return
-    end
-    return b
-end
 
+    function Base.repeat(a::AbstractGPUVector, m::Int)
+        o = length(a)
+        b = similar(a, o*m)
+        if length(b) == 0
+            return b
+        end
+        gpu_call(b, a, o, m; total_threads=m) do ctx, b, a, o, m
+            i = linear_index(ctx)
+            i > m && return
+            c = (i - 1)*o + 1
+            @inbounds for i in 1:o
+                b[c + i - 1] = a[i]
+            end
+            return
+        end
+        return b
+    end
+end
 ## PermutedDimsArrays
 
 using Base: PermutedDimsArrays

--- a/test/testsuite/base.jl
+++ b/test/testsuite/base.jl
@@ -187,6 +187,34 @@ end
         @test compare(a-> repeat(a, 0),     AT, rand(Float32, 10))
         @test compare(a-> repeat(a, 0),     AT, rand(Float32, 5, 4))
         @test compare(a-> repeat(a, 4, 0),  AT, rand(Float32, 10, 15))
+
+        if VERSION ≥ v"1.6"
+            # Test inputs.
+            x = rand(Float32, 10)
+            xmat = rand(Float32, 2, 10)
+            arr = rand(Float32, 3, 2, 10)
+
+            # Inner.
+            @test compare(a -> repeat(a, inner=(2, )), AT, x)
+            @test compare(a -> repeat(a, inner=(2, 3)), AT, xmat)
+            @test compare(a -> repeat(a, inner=(2, 3, 4)), AT, xarr)
+            # Outer.
+            @test compare(a -> repeat(a, outer=(2, )), AT, x)
+            @test compare(a -> repeat(a, outer=(2, 3)), AT, xmat)
+            @test compare(a -> repeat(a, outer=(2, 3, 4)), AT, xarr)
+            # Both.
+            @test compare(a -> repeat(a, inner=(2, ), outer=(2, )), AT, x)
+            @test compare(a -> repeat(a, inner=(2, 3), outer=(2, 3)), AT, xmat)
+            @test compare(a -> repeat(a, inner=(2, 3, 4), outer=(2, 1, 4)), AT, xarr)
+            # Repeat which expands dimensionality.
+            @test compare(a -> repeat(a, inner=(2, 1, 3)), AT, x)
+            @test compare(a -> repeat(a, outer=(2, 1, 3)), AT, x)
+            @test compare(a -> repeat(a, inner=(2, 1, 3), outer=(2, 2, 3)), AT, x)
+
+            @test compare(a -> repeat(a, inner=(2, 1, 3)), AT, xmat)
+            @test compare(a -> repeat(a, outer=(2, 1, 3)), AT, xmat)
+            @test compare(a -> repeat(a, inner=(2, 1, 3), outer=(2, 2, 3)), AT, xmat)
+        end
     end
 
     @testset "permutedims" begin

--- a/test/testsuite/base.jl
+++ b/test/testsuite/base.jl
@@ -188,33 +188,31 @@ end
         @test compare(a-> repeat(a, 0),     AT, rand(Float32, 5, 4))
         @test compare(a-> repeat(a, 4, 0),  AT, rand(Float32, 10, 15))
 
-        if VERSION ≥ v"1.6"
-            # Test inputs.
-            x = rand(Float32, 10)
-            xmat = rand(Float32, 2, 10)
-            xarr = rand(Float32, 3, 2, 10)
+        # Test inputs.
+        x = rand(Float32, 10)
+        xmat = rand(Float32, 2, 10)
+        xarr = rand(Float32, 3, 2, 10)
 
-            # Inner.
-            @test compare(a -> repeat(a, inner=(2, )), AT, x)
-            @test compare(a -> repeat(a, inner=(2, 3)), AT, xmat)
-            @test compare(a -> repeat(a, inner=(2, 3, 4)), AT, xarr)
-            # Outer.
-            @test compare(a -> repeat(a, outer=(2, )), AT, x)
-            @test compare(a -> repeat(a, outer=(2, 3)), AT, xmat)
-            @test compare(a -> repeat(a, outer=(2, 3, 4)), AT, xarr)
-            # Both.
-            @test compare(a -> repeat(a, inner=(2, ), outer=(2, )), AT, x)
-            @test compare(a -> repeat(a, inner=(2, 3), outer=(2, 3)), AT, xmat)
-            @test compare(a -> repeat(a, inner=(2, 3, 4), outer=(2, 1, 4)), AT, xarr)
-            # Repeat which expands dimensionality.
-            @test compare(a -> repeat(a, inner=(2, 1, 3)), AT, x)
-            @test compare(a -> repeat(a, outer=(2, 1, 3)), AT, x)
-            @test compare(a -> repeat(a, inner=(2, 1, 3), outer=(2, 2, 3)), AT, x)
+        # Inner.
+        @test compare(a -> repeat(a, inner=(2, )), AT, x)
+        @test compare(a -> repeat(a, inner=(2, 3)), AT, xmat)
+        @test compare(a -> repeat(a, inner=(2, 3, 4)), AT, xarr)
+        # Outer.
+        @test compare(a -> repeat(a, outer=(2, )), AT, x)
+        @test compare(a -> repeat(a, outer=(2, 3)), AT, xmat)
+        @test compare(a -> repeat(a, outer=(2, 3, 4)), AT, xarr)
+        # Both.
+        @test compare(a -> repeat(a, inner=(2, ), outer=(2, )), AT, x)
+        @test compare(a -> repeat(a, inner=(2, 3), outer=(2, 3)), AT, xmat)
+        @test compare(a -> repeat(a, inner=(2, 3, 4), outer=(2, 1, 4)), AT, xarr)
+        # Repeat which expands dimensionality.
+        @test compare(a -> repeat(a, inner=(2, 1, 3)), AT, x)
+        @test compare(a -> repeat(a, outer=(2, 1, 3)), AT, x)
+        @test compare(a -> repeat(a, inner=(2, 1, 3), outer=(2, 2, 3)), AT, x)
 
-            @test compare(a -> repeat(a, inner=(2, 1, 3)), AT, xmat)
-            @test compare(a -> repeat(a, outer=(2, 1, 3)), AT, xmat)
-            @test compare(a -> repeat(a, inner=(2, 1, 3), outer=(2, 2, 3)), AT, xmat)
-        end
+        @test compare(a -> repeat(a, inner=(2, 1, 3)), AT, xmat)
+        @test compare(a -> repeat(a, outer=(2, 1, 3)), AT, xmat)
+        @test compare(a -> repeat(a, inner=(2, 1, 3), outer=(2, 2, 3)), AT, xmat)
     end
 
     @testset "permutedims" begin

--- a/test/testsuite/base.jl
+++ b/test/testsuite/base.jl
@@ -192,7 +192,7 @@ end
             # Test inputs.
             x = rand(Float32, 10)
             xmat = rand(Float32, 2, 10)
-            arr = rand(Float32, 3, 2, 10)
+            xarr = rand(Float32, 3, 2, 10)
 
             # Inner.
             @test compare(a -> repeat(a, inner=(2, )), AT, x)


### PR DESCRIPTION
This PR adds an implementation of `Base.repeat` for arrays of arbitrary dimensionality. It unfortunately makes use of `Base._RepeatInnerOuter` which is only available on ≥ 1.6, but AFAIK this simplifies the implementation (plus my motivation was usage on Julia v1.6).

I haven't looked into an implementation for < 1.6, but guessing we can at least re-use the kernel for those too if we want to support earlier versions.