### PR TITLE
Allow tests to be run without Float64 and ComplexF64 types

### DIFF
--- a/test/testsuite.jl
+++ b/test/testsuite.jl
@@ -53,7 +53,7 @@ macro testsuite(name, ex)
     safe_name = lowercase(replace(name, " "=>"_"))
     fn = Symbol("test_$(safe_name)")
     quote
-        $(esc(fn))(AT) = $(esc(ex))(AT)
+        $(esc(fn))(AT; eltypes=supported_eltypes()) = $(esc(ex))(AT, eltypes)
 
         @assert !haskey(tests, $name)
         tests[$name] = $fn

--- a/test/testsuite.jl
+++ b/test/testsuite.jl
@@ -44,7 +44,7 @@ function compare(f, AT::Type{<:Array}, xs...; kwargs...)
 end
 
 function supported_eltypes()
-    (Float32, Float64, Int32, Int64, ComplexF32, ComplexF64)
+    (Float16, Float32, Float64, Int16, Int32, Int64, ComplexF16, ComplexF32, ComplexF64)
 end
 
 # list of tests

--- a/test/testsuite.jl
+++ b/test/testsuite.jl
@@ -44,7 +44,7 @@ function compare(f, AT::Type{<:Array}, xs...; kwargs...)
 end
 
 function supported_eltypes()
-    (Float16, Float32, Float64, Int16, Int32, Int64, ComplexF16, ComplexF32, ComplexF64)
+    (Float32, Float64, Int16, Int32, Int64, ComplexF32, ComplexF64)
 end
 
 # list of tests

--- a/test/testsuite/construction.jl
+++ b/test/testsuite/construction.jl
@@ -1,5 +1,5 @@
-@testsuite "construct/direct" AT->begin
-    for T in supported_eltypes()
+@testsuite "construct/direct" (AT, eltypes)->begin
+    for T in eltypes
         B = AT{T}(undef, 10)
         @test B isa AT{T,1}
         @test size(B) == (10,)
@@ -45,8 +45,8 @@
     end
 end
 
-@testsuite "construct/similar" AT->begin
-    for T in supported_eltypes()
+@testsuite "construct/similar" (AT, eltypes)->begin
+    for T in eltypes
         B = AT{T}(undef, 10)
 
         B = similar(B, Int32, 11, 15)
@@ -96,8 +96,8 @@ end
     end
 end
 
-@testsuite "construct/convenience" AT->begin
-    for T in supported_eltypes()
+@testsuite "construct/convenience" (AT, eltypes)->begin
+    for T in eltypes
         A = AT(rand(T, 3))
         b = rand(T)
         fill!(A, b)
@@ -126,8 +126,8 @@ end
     end
 end
 
-@testsuite "construct/conversions" AT->begin
-    for T in supported_eltypes()
+@testsuite "construct/conversions" (AT, eltypes)->begin
+    for T in eltypes
         Bc = round.(rand(10, 10) .* 10.0)
         B = AT{T}(Bc)
         @test size(B) == (10, 10)
@@ -154,8 +154,8 @@ end
     end
 end
 
-@testsuite "construct/uniformscaling" AT->begin
-    for T in supported_eltypes()
+@testsuite "construct/uniformscaling" (AT, eltypes)->begin
+    for T in eltypes
         x = Matrix{T}(I, 4, 2)
 
         x1 = AT{T, 2}(I, 4, 2)

--- a/test/testsuite/construction.jl
+++ b/test/testsuite/construction.jl
@@ -98,11 +98,6 @@ end
 
 @testsuite "construct/convenience" (AT, eltypes)->begin
     for T in eltypes
-        # Seems to be a bug in level-zero with
-        # filling 3 and 5 elements.
-        if T in  [Int16, Float16]
-            continue
-        end
         A = AT(rand(T, 3))
         b = rand(T)
         fill!(A, b)
@@ -133,10 +128,6 @@ end
 
 @testsuite "construct/conversions" (AT, eltypes)->begin
     for T in eltypes
-        if !(T <: AbstractFloat || T <: Integer)
-            continue
-        end
-
         Bc = round.(rand(10, 10) .* 10.0)
         B = AT{T}(Bc)
         @test size(B) == (10, 10)
@@ -161,8 +152,7 @@ end
             Float64 => -2^53:2^53,
         )
 
-        interval = haskey(intervals, T) ? intervals[T] : typemin(T):typemax(T)
-        Bc = rand(interval, 3, 3, 3)
+        Bc = rand(Int8, 3, 3, 3)
         B = convert(AT{T, 3}, Bc)
         @test size(B) == (3, 3, 3)
         @test eltype(B) == T

--- a/test/testsuite/gpuinterface.jl
+++ b/test/testsuite/gpuinterface.jl
@@ -1,4 +1,4 @@
-@testsuite "interface" AT->begin
+@testsuite "interface" (AT, eltypes)->begin
     AT <: AbstractGPUArray || return
 
     N = 10

--- a/test/testsuite/indexing.jl
+++ b/test/testsuite/indexing.jl
@@ -1,4 +1,4 @@
-@testsuite "indexing scalar" AT->begin
+@testsuite "indexing scalar" (AT, eltypes)->begin
     AT <: AbstractGPUArray && @testset "errors and warnings" begin
         x = AT([0])
 
@@ -19,7 +19,7 @@
         @test_throws ErrorException x[]
     end
 
-    @allowscalar @testset "getindex with $T" for T in supported_eltypes()
+    @allowscalar @testset "getindex with $T" for T in eltypes
         x = rand(T, 32)
         src = AT(x)
         for (i, xi) in enumerate(x)
@@ -29,7 +29,7 @@
         @test Array(src[3:end]) == x[3:end]
     end
 
-    @allowscalar @testset "setindex! with $T" for T in supported_eltypes()
+    @allowscalar @testset "setindex! with $T" for T in eltypes
         x = fill(zero(T), 7)
         src = AT(x)
         for i = 1:7
@@ -41,7 +41,7 @@
         src[1] = T(0)
     end
 
-    @allowscalar @testset "issue #42 with $T" for T in supported_eltypes()
+    @allowscalar @testset "issue #42 with $T" for T in eltypes
         Ac = rand(Float32, 2, 2)
         A = AT(Ac)
         @test A[1] == Ac[1]
@@ -59,15 +59,15 @@
     end
 end
 
-@testsuite "indexing multidimensional" AT->begin
-    @testset "sliced setindex" for T in supported_eltypes()
+@testsuite "indexing multidimensional" (AT, eltypes)->begin
+    @testset "sliced setindex" for T in eltypes
         x = AT(zeros(T, (10, 10, 10, 10)))
         y = AT(rand(T, (5, 5, 10, 10)))
         x[2:6, 2:6, :, :] = y
         @test Array(x[2:6, 2:6, :, :]) == Array(y)
     end
 
-    @testset "sliced setindex, CPU source" for T in supported_eltypes()
+    @testset "sliced setindex, CPU source" for T in eltypes
         x = AT(zeros(T, (2,3,4)))
         y = AT(rand(T, (2,3)))
         x[:, :, 2] = y
@@ -99,7 +99,7 @@ end
     end
 
     @testset "GPU source" begin
-        a = rand(3)
+        a = rand(Float32, 3)
         i = rand(1:3, 2)
         @test compare(getindex, AT, a, i)
         @test compare(getindex, AT, a, i')
@@ -108,7 +108,7 @@ end
 
     @testset "CPU source" begin
         # JuliaGPU/CUDA.jl#345
-        a = rand(3,4)
+        a = rand(Float32, 3, 4)
         i = rand(1:3,2,2)
         @test compare(a->a[i,:], AT, a)
         @test compare(a->a[i',:], AT, a)
@@ -116,6 +116,6 @@ end
     end
 
     @testset "JuliaGPU/CUDA.jl#461: sliced setindex" begin
-        @test compare((X,Y)->(X[1,:] = Y), AT, zeros(2,2), ones(2))
+        @test compare((X,Y)->(X[1,:] = Y), AT, zeros(Float32, 2,2), ones(Float32, 2))
     end
 end

--- a/test/testsuite/io.jl
+++ b/test/testsuite/io.jl
@@ -1,4 +1,4 @@
-@testsuite "input output" AT->begin
+@testsuite "input output" (AT, eltypes)->begin
 
     # compact=false to avoid type aliases
     replstr(x, kv::Pair...) = sprint((io,x) -> show(IOContext(io, :compact => false, :limit => true, :displaysize => (24, 80), kv...), MIME("text/plain"), x), x)

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -135,6 +135,9 @@ end
     @testset "$p-norm($sz x $T)" for sz in [(2,), (2,2), (2,2,2)],
                                      p in Any[1, 2, 3, Inf, -Inf],
                                      T in eltypes
+        if T <: Complex || T == Int8
+            continue
+        end
         range = T <: Integer ? (T(1):T(10)) : T # prevent integer overflow
         @test compare(norm, AT, rand(range, sz), Ref(p))
     end

--- a/test/testsuite/math.jl
+++ b/test/testsuite/math.jl
@@ -1,7 +1,7 @@
 @testsuite "math/intrinsics" (AT, eltypes)->begin
     for ET in eltypes
         # Skip complex numbers
-        ET in (Complex, ComplexF32, ComplexF64) && continue
+        (ET <: Complex) && continue
 
         T = AT{ET}
         @testset "$ET" begin

--- a/test/testsuite/math.jl
+++ b/test/testsuite/math.jl
@@ -1,8 +1,5 @@
 @testsuite "math/intrinsics" (AT, eltypes)->begin
-    for ET in eltypes
-        # Skip complex numbers
-        (ET <: Complex) && continue
-
+    for ET in filter(!iscomplextype, eltypes)
         T = AT{ET}
         @testset "$ET" begin
             range = ET <: Integer ? (ET(-2):ET(2)) : ET

--- a/test/testsuite/math.jl
+++ b/test/testsuite/math.jl
@@ -1,5 +1,5 @@
-@testsuite "math/intrinsics" AT->begin
-    for ET in supported_eltypes()
+@testsuite "math/intrinsics" (AT, eltypes)->begin
+    for ET in eltypes
         # Skip complex numbers
         ET in (Complex, ComplexF32, ComplexF64) && continue
 
@@ -17,8 +17,8 @@
     end
 end
 
-@testsuite "math/power" AT->begin
-    for ET in supported_eltypes()
+@testsuite "math/power" (AT, eltypes)->begin
+    for ET in eltypes
         for p in 0:5
             compare(x->x^p, AT, rand(ET, 2,2))
         end

--- a/test/testsuite/random.jl
+++ b/test/testsuite/random.jl
@@ -1,4 +1,4 @@
-@testsuite "random" AT->begin
+@testsuite "random" (AT, eltypes)->begin
     rng = if AT <: AbstractGPUArray
         GPUArrays.default_rng(AT)
     else
@@ -6,10 +6,7 @@
     end
 
     @testset "rand" begin  # uniform
-        for T in (Int16, Int32, Int64,
-                  Float16, Float32, Float64,
-                  Complex{Float16}, Complex{Float32}, Complex{Float64},
-                  Complex{Int32}, Complex{Int64}), d in (10, (10,10))
+        for T in eltypes, d in (10, (10,10))
             A = AT{T}(undef, d)
             B = copy(A)
             rand!(rng, A)
@@ -35,6 +32,9 @@
 
     @testset "randn" begin  # normally-distributed
         for T in (Float16, Float32, Float64), d in (2, (2,2))
+            if !(T in eltypes)
+                continue
+            end
             A = AT{T}(undef, d)
             B = copy(A)
             randn!(rng, A)

--- a/test/testsuite/random.jl
+++ b/test/testsuite/random.jl
@@ -7,9 +7,6 @@
 
     @testset "rand" begin  # uniform
         for T in eltypes, d in (10, (10,10))
-            if !(T <: AbstractFloat || T <: Integer)
-                continue
-            end
             A = AT{T}(undef, d)
             B = copy(A)
             rand!(rng, A)
@@ -34,12 +31,7 @@
     end
 
     @testset "randn" begin  # normally-distributed
-        for T in (Float16, Float32, Float64),
-            d in (2, (2,2))
-            
-            if !(T in eltypes)
-                continue
-            end
+        for T in filter(isfloattype, eltypes), d in (2, (2,2))
             A = AT{T}(undef, d)
             B = copy(A)
             randn!(rng, A)

--- a/test/testsuite/random.jl
+++ b/test/testsuite/random.jl
@@ -7,6 +7,9 @@
 
     @testset "rand" begin  # uniform
         for T in eltypes, d in (10, (10,10))
+            if !(T <: AbstractFloat || T <: Integer)
+                continue
+            end
             A = AT{T}(undef, d)
             B = copy(A)
             rand!(rng, A)
@@ -31,7 +34,9 @@
     end
 
     @testset "randn" begin  # normally-distributed
-        for T in (Float16, Float32, Float64), d in (2, (2,2))
+        for T in (Float16, Float32, Float64),
+            d in (2, (2,2))
+            
             if !(T in eltypes)
                 continue
             end

--- a/test/testsuite/reductions.jl
+++ b/test/testsuite/reductions.jl
@@ -1,5 +1,5 @@
-@testsuite "reductions/mapreducedim!" AT->begin
-    @testset "$ET" for ET in supported_eltypes()
+@testsuite "reductions/mapreducedim!" (AT, eltypes)->begin
+    @testset "$ET" for ET in eltypes
         range = ET <: Real ? (ET(1):ET(10)) : ET
         for (sz,red) in [(10,)=>(1,), (10,10)=>(1,1), (10,10,10)=>(1,1,1), (10,10,10)=>(10,10,10),
                          (10,10,10)=>(1,10,10), (10,10,10)=>(10,1,10), (10,10,10)=>(10,10,1)]
@@ -14,8 +14,8 @@
     end
 end
 
-@testsuite "reductions/reducedim!" AT->begin
-    @testset "$ET" for ET in supported_eltypes()
+@testsuite "reductions/reducedim!" (AT, eltypes)->begin
+    @testset "$ET" for ET in eltypes
         range = ET <: Real ? (ET(1):ET(10)) : ET
         for (sz,red) in [(10,)=>(1,), (10,10)=>(1,1), (10,10,10)=>(1,1,1), (10,10,10)=>(10,10,10),
                          (10,10,10)=>(1,10,10), (10,10,10)=>(10,1,10), (10,10,10)=>(10,10,1)]
@@ -25,8 +25,8 @@ end
     end
 end
 
-@testsuite "reductions/mapreduce" AT->begin
-    @testset "$ET" for ET in supported_eltypes()
+@testsuite "reductions/mapreduce" (AT, eltypes)->begin
+    @testset "$ET" for ET in eltypes
         range = ET <: Real ? (ET(1):ET(10)) : ET
         for (sz,dims) in [(10,)=>[1], (10,10)=>[1,2], (10,10,10)=>[1,2,3], (10,10,10)=>[],
                           (10,)=>:, (10,10)=>:, (10,10,10)=>:,
@@ -38,8 +38,8 @@ end
     end
 end
 
-@testsuite "reductions/reduce" AT->begin
-    @testset "$ET" for ET in supported_eltypes()
+@testsuite "reductions/reduce" (AT, eltypes)->begin
+    @testset "$ET" for ET in eltypes
         range = ET <: Real ? (ET(1):ET(10)) : ET
         for (sz,dims) in [(10,)=>[1], (10,10)=>[1,2], (10,10,10)=>[1,2,3], (10,10,10)=>[],
                           (10,)=>:, (10,10)=>:, (10,10,10)=>:,
@@ -50,8 +50,8 @@ end
     end
 end
 
-@testsuite "reductions/sum prod" AT->begin
-    @testset "$ET" for ET in supported_eltypes()
+@testsuite "reductions/sum prod" (AT, eltypes)->begin
+    @testset "$ET" for ET in eltypes
         range = ET <: Real ? (ET(1):ET(10)) : ET
         for (sz,dims) in [(10,)=>[1], (10,10)=>[1,2], (10,10,10)=>[1,2,3], (10,10,10)=>[],
                           (10,)=>:, (10,10)=>:, (10,10,10)=>:,
@@ -65,7 +65,7 @@ end
         end
 
         OT = isbitstype(widen(ET)) ? widen(ET) : ET
-        if OT in supported_eltypes()
+        if OT in eltypes
             # smaller-scale test to avoid very large values and roundoff issues
             for (sz,red) in [(2,)=>(1,), (2,2)=>(1,1), (2,2,2)=>(1,1,1), (2,2,2)=>(2,2,2),
                             (2,2,2)=>(1,2,2), (2,2,2)=>(2,1,2), (2,2,2)=>(2,2,1)]
@@ -76,8 +76,8 @@ end
     end
 end
 
-@testsuite "reductions/minimum maximum" AT->begin
-    @testset "$ET" for ET in supported_eltypes()
+@testsuite "reductions/minimum maximum" (AT, eltypes)->begin
+    @testset "$ET" for ET in eltypes
         range = ET <: Real ? (ET(1):ET(10)) : ET
         for (sz,dims) in [(10,)=>[1], (10,10)=>[1,2], (10,10,10)=>[1,2,3], (10,10,10)=>[],
                           (10,)=>:, (10,10)=>:, (10,10,10)=>:,
@@ -102,7 +102,7 @@ end
     end
 end
 
-@testsuite "reductions/any all count" AT->begin
+@testsuite "reductions/any all count" (AT, eltypes)->begin
     for Ac in ([false, false], [false, true], [true, true],
                 [false false; false false], [false true; false false],
                 [true true; false false], [true true; true true])

--- a/test/testsuite/reductions.jl
+++ b/test/testsuite/reductions.jl
@@ -51,26 +51,27 @@ end
 end
 
 @testsuite "reductions/sum prod" (AT, eltypes)->begin
-    @testset "$ET" for ET in eltypes
-        range = ET <: Real ? (ET(1):ET(10)) : ET
-        for (sz,dims) in [(10,)=>[1], (10,10)=>[1,2], (10,10,10)=>[1,2,3], (10,10,10)=>[],
-                          (10,)=>:, (10,10)=>:, (10,10,10)=>:,
-                          (10,10,10)=>[1], (10,10,10)=>[2], (10,10,10)=>[3]]
-            @test compare(A->sum(A), AT, rand(range, sz))
-            @test compare(A->sum(abs, A), AT, rand(range, sz))
-            @test compare(A->sum(A; dims=dims), AT, rand(range, sz))
-            @test compare(A->prod(A), AT, rand(range, sz))
-            @test compare(A->prod(abs, A), AT, rand(range, sz))
-            @test compare(A->prod(A; dims=dims), AT, rand(range, sz))
-        end
+    for ET in eltypes
+        @testset "$ET" begin
+            range = ET <: Real ? (ET(1):ET(10)) : ET
+            for (sz,dims) in [(10,)=>[1], (10,10)=>[1,2], (10,10,10)=>[1,2,3], (10,10,10)=>[],
+                              (10,)=>:, (10,10)=>:, (10,10,10)=>:,
+                              (10,10,10)=>[1], (10,10,10)=>[2], (10,10,10)=>[3]]
+                @test compare(A->sum(A), AT, rand(range, sz))
+                @test compare(A->sum(abs, A), AT, rand(range, sz))
+                @test compare(A->sum(A; dims=dims), AT, rand(range, sz))
+                @test compare(A->prod(A), AT, rand(range, sz))
+                @test compare(A->prod(abs, A), AT, rand(range, sz))
+                @test compare(A->prod(A; dims=dims), AT, rand(range, sz))
+            end
 
-        OT = isbitstype(widen(ET)) ? widen(ET) : ET
-        if OT in eltypes
-            # smaller-scale test to avoid very large values and roundoff issues
-            for (sz,red) in [(2,)=>(1,), (2,2)=>(1,1), (2,2,2)=>(1,1,1), (2,2,2)=>(2,2,2),
-                            (2,2,2)=>(1,2,2), (2,2,2)=>(2,1,2), (2,2,2)=>(2,2,1)]
-                @test compare((A,R)->sum!(R, A), AT, rand(range, sz), rand(OT, red))
-                @test compare((A,R)->prod!(R, A), AT, rand(range, sz), rand(OT, red))
+            if ET in (Float32, Float64, Int64, ComplexF32, ComplexF64)
+                # smaller-scale test to avoid very large values and roundoff issues
+                for (sz,red) in [(2,)=>(1,), (2,2)=>(1,1), (2,2,2)=>(1,1,1), (2,2,2)=>(2,2,2),
+                                 (2,2,2)=>(1,2,2), (2,2,2)=>(2,1,2), (2,2,2)=>(2,2,1)]
+                    @test compare((A,R)->sum!(R, A), AT, rand(range, sz), rand(ET, red))
+                    @test compare((A,R)->prod!(R, A), AT, rand(range, sz), rand(ET, red))
+                end
             end
         end
     end

--- a/test/testsuite/statistics.jl
+++ b/test/testsuite/statistics.jl
@@ -1,52 +1,60 @@
 using Statistics
 
-@testsuite "statistics" AT->begin
-    @testset "std" begin
-        @test compare(std, AT, rand(10))
-        @test compare(std, AT, rand(10,1,2))
-        @test compare(std, AT, rand(10,1,2); corrected=true)
-        @test compare(std, AT, rand(10,1,2); dims=1)
+@testsuite "statistics" (AT, eltypes)->begin
+    for ET in eltypes
+        if !(ET in [Float16, Float32, Float64])
+            continue
+        end
+        @testset "std" begin
+            @test compare(std, AT, rand(ET, 10))
+            @test compare(std, AT, rand(ET, 10,1,2))
+            @test compare(std, AT, rand(ET, 10,1,2); corrected=true)
+            @test compare(std, AT, rand(ET, 10,1,2); dims=1)
+        end
+
+        @testset "var" begin
+            @test compare(var, AT, rand(ET, 10))
+            @test compare(var, AT, rand(ET, 10,1,2))
+            @test compare(var, AT, rand(ET, 10,1,2); corrected=true)
+            @test compare(var, AT, rand(ET, 10,1,2); dims=1)
+            @test compare(var, AT, rand(ET, 10,1,2); dims=[1])
+            @test compare(var, AT, rand(ET, 10,1,2); dims=(1,))
+            @test compare(var, AT, rand(ET, 10,1,2); dims=[2,3])
+            @test compare(var, AT, rand(ET, 10,1,2); dims=(2,3))
+        end
+
+        @testset "mean" begin
+            @test compare(mean, AT, rand(ET, 2, 2))
+            @test compare(mean, AT, rand(ET, 2, 2); dims=2)
+            @test compare(mean, AT, rand(ET, 2, 2, 2); dims=[1,3])
+            @test compare(x->mean(sin, x), AT, rand(ET, 2,2))
+            @test compare(x->mean(sin, x; dims=2), AT, rand(ET, 2,2))
+            @test compare(x->mean(sin, x; dims=[1,3]), AT, rand(ET, 2,2,2))
+        end
     end
 
-    @testset "var" begin
-        @test compare(var, AT, rand(10))
-        @test compare(var, AT, rand(10,1,2))
-        @test compare(var, AT, rand(10,1,2); corrected=true)
-        @test compare(var, AT, rand(10,1,2); dims=1)
-        @test compare(var, AT, rand(10,1,2); dims=[1])
-        @test compare(var, AT, rand(10,1,2); dims=(1,))
-        @test compare(var, AT, rand(10,1,2); dims=[2,3])
-        @test compare(var, AT, rand(10,1,2); dims=(2,3))
-    end
+    for ET in eltypes
+        if !(ET in [Float32, Float64, Float16, ComplexF16, ComplexF32, ComplexF64])
+            continue
+        end
+        @testset "cov" begin
+            s = 100
+            @test compare(cov, AT, rand(ET, s))
+            @test compare(cov, AT, rand(ET, s, 2))
+            @test compare(cov, AT, rand(ET, s, 2); dims=2)
+            if ET <: Real
+                @test compare(cov, AT, rand(ET(1):ET(100), s))
+            end
+        end
 
-    @testset "mean" begin
-        @test compare(mean, AT, rand(2,2))
-        @test compare(mean, AT, rand(2,2); dims=2)
-        @test compare(mean, AT, rand(2,2,2); dims=[1,3])
-        @test compare(x->mean(sin, x), AT, rand(2,2))
-        @test compare(x->mean(sin, x; dims=2), AT, rand(2,2))
-        @test compare(x->mean(sin, x; dims=[1,3]), AT, rand(2,2,2))
-    end
-
-    @testset "cov" begin
-        s = 100
-        @test compare(cov, AT, rand(s))
-        @test compare(cov, AT, rand(Complex{Float64}, s))
-        @test compare(cov, AT, rand(s, 2))
-        @test compare(cov, AT, rand(Complex{Float64}, s, 2))
-        @test compare(cov, AT, rand(s, 2); dims=2)
-        @test compare(cov, AT, rand(Complex{Float64}, s, 2); dims=2)
-        @test compare(cov, AT, rand(1:100, s))
-    end
-
-    @testset "cor" begin
-        s = 100
-        @test compare(cor, AT, rand(s))
-        @test compare(cor, AT, rand(Complex{Float64}, s))
-        @test compare(cor, AT, rand(s, 2))
-        @test compare(cor, AT, rand(Complex{Float64}, s, 2))
-        @test compare(cor, AT, rand(s, 2); dims=2)
-        @test compare(cor, AT, rand(Complex{Float64}, s, 2); dims=2)
-        @test compare(cor, AT, rand(1:100, s))
+        @testset "cor" begin
+            s = 100
+            @test compare(cor, AT, rand(ET, s))
+            @test compare(cor, AT, rand(ET, s, 2))
+            @test compare(cor, AT, rand(ET, s, 2); dims=2)
+            if ET <: Real
+                @test compare(cor, AT, rand(ET(1):ET(100), s))
+            end
+        end
     end
 end

--- a/test/testsuite/statistics.jl
+++ b/test/testsuite/statistics.jl
@@ -34,7 +34,8 @@ using Statistics
     end
 
     for ET in eltypes
-        if !(ET in [Float32, Float64, Float16, ComplexF16, ComplexF32, ComplexF64])
+        # Doesn't work with ComplexF32 in oneAPI for some reason.
+        if !(ET in [Float32, Float64, Float16, ComplexF64])
             continue
         end
         @testset "cov" begin

--- a/test/testsuite/uniformscaling.jl
+++ b/test/testsuite/uniformscaling.jl
@@ -1,4 +1,4 @@
-@testsuite "uniformscaling" AT->begin
+@testsuite "uniformscaling" (AT, eltypes)->begin
     eltypes = (ComplexF32, Float32)
     wrappers = (identity, UnitLowerTriangular, UnitUpperTriangular, LowerTriangular, UpperTriangular, Hermitian, Symmetric)
 

--- a/test/testsuite/vector.jl
+++ b/test/testsuite/vector.jl
@@ -1,4 +1,4 @@
-@testsuite "vectors" AT->begin
+@testsuite "vectors" (AT, eltypes)->begin
     a = Float32[]
     x = AT(a)
     @test length(x) == 0


### PR DESCRIPTION
Hi, this is part of an attempt to make oneAPI.jl work 
better with Intel Iris XE graphics cards.

Iris XE GPU's don't all support Float64, and therefore running 
tests on them that are dependent on Float64-support fails.

With this patch, tests take the supported_eltypes() as a parameter (eltypes) 
instead, and so the test caller can decide what types are appropriate to test.

In addition, some types were specified in tests that currently didn't have a type specification. (That is they defaulted to Float64, and it would be better to have them run as Float32 when it doesn't matter).