### PR TITLE
Fix copying Diagonal matrices

### DIFF
--- a/src/host/linalg.jl
+++ b/src/host/linalg.jl
@@ -97,6 +97,11 @@ function LinearAlgebra.triu!(A::AbstractGPUMatrix{T}, d::Integer = 0) where T
 end
 
 
+## diagonal
+
+Base.copy(D::Diagonal{T, <:AbstractGPUMatrix{T, N}}) where {T, N} = Diagonal(copy(D.diag))
+
+
 ## matrix multiplication
 
 function generic_matmatmul!(C::AbstractArray{R}, A::AbstractArray{T}, B::AbstractArray{S}, a::Number, b::Number) where {T,S,R}

--- a/src/host/linalg.jl
+++ b/src/host/linalg.jl
@@ -99,7 +99,7 @@ end
 
 ## diagonal
 
-Base.copy(D::Diagonal{T, <:AbstractGPUMatrix{T, N}}) where {T, N} = Diagonal(copy(D.diag))
+Base.copy(D::Diagonal{T, <:AbstractGPUArray{T, N}}) where {T, N} = Diagonal(copy(D.diag))
 
 
 ## matrix multiplication

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -79,6 +79,14 @@ end
         @test collect(B) ≈ collect(A) + collect(D)
     end
 
+    @testset "copy diagonal" begin
+        a = AT(rand(Float32, 10))
+        D = Diagonal(a)
+        C = copy(D)
+        @test C isa Diagonal
+        @test collect(D) = collect(C)
+    end
+
     @testset "$f! with diagonal $d" for (f, f!) in ((triu, triu!), (tril, tril!)),
                                         d in -2:2
         A = randn(10, 10)

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -84,7 +84,8 @@ end
         D = Diagonal(a)
         C = copy(D)
         @test C isa Diagonal
-        @test collect(D) = collect(C)
+        @test C.diag isa AT
+        @test collect(D) == collect(C)
     end
 
     @testset "$f! with diagonal $d" for (f, f!) in ((triu, triu!), (tril, tril!)),


### PR DESCRIPTION
Currently, attempting to copy a `Diagonal{<:AbstractGPUArray}` throws an error as it hits the generic [`copyto!`](https://github.com/JuliaGPU/GPUArrays.jl/blob/e1acd425854cba8de622d3757da9f9905a555771/src/host/abstractarray.jl#L95) and tries to assign to off-diagonal elements:

```
using LinearAlgebra
using CUDA

x = CUDA.ones(5, 5)
copy(Diagonal(x))  # Errors
```