### PR TITLE
complex norm

### DIFF
--- a/src/host/linalg.jl
+++ b/src/host/linalg.jl
@@ -204,13 +204,14 @@ LinearAlgebra.permutedims!(dest::AbstractGPUArray, src::AbstractGPUArray, perm) 
 ## norm
 
 function LinearAlgebra.norm(v::AbstractGPUArray{T}, p::Real=2) where {T}
-    if p == Inf
+    norm_x = if p == Inf
         maximum(abs.(v))
     elseif p == -Inf
         minimum(abs.(v))
     else
-        mapreduce(x->abs(x)^p, +, v; init=zero(T))^(1/p)
+        mapreduce(x->abs(x)^p, +, v; init=float(zero(T)))^(1/p)
     end
+    return real(norm_x)
 end
 
 

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -148,10 +148,11 @@ end
     @testset "$p-norm($sz x $T)" for sz in [(2,), (2,2), (2,2,2)],
                                      p in Any[1, 2, 3, Inf, -Inf],
                                      T in eltypes
-        if T <: Complex || T == Int8
+        if T == Int8
             continue
         end
-        range = T <: Integer ? (T(1):T(10)) : T # prevent integer overflow
+        range = real(T) <: Integer ? (T.(1:10)) : T # prevent integer overflow
         @test compare(norm, AT, rand(range, sz), Ref(p))
+        @test typeof(norm(rand(range, sz))) <: Real
     end
 end


### PR DESCRIPTION
Hello

I'm not sure if it belongs here or in CUDA.jl, but currently the norm of a complex-valued GPUArray is returning a complex number instead of a real number unless `p=2` in which case it directly calls cublas that returns a real. 
This leads to issues when comparing norms for example for optimization/linesearch/... when working with non-l2 norms.

This PR attempts to fix it (and test it) but this may not be the proper way to do it so I'm open to comment/change requests.

Fixes https://github.com/JuliaGPU/CUDA.jl/issues/1290
