### PR TITLE
new permutedims without unrolling permutation orders

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@ steps:
   - label: "CUDA.jl"
     plugins:
       - JuliaCI/julia#v1:
-          version: 1.6
+          version: 1.7
       - JuliaCI/julia-coverage#v1:
           codecov: true
     command: |
@@ -24,7 +24,7 @@ steps:
   - label: "oneAPI.jl"
     plugins:
       - JuliaCI/julia#v1:
-          version: 1.6
+          version: 1.7
       - JuliaCI/julia-coverage#v1:
           codecov: true
     command: |

--- a/src/host/linalg.jl
+++ b/src/host/linalg.jl
@@ -181,25 +181,30 @@ LinearAlgebra.lmul!(a::Number, B::AbstractGPUArray) = generic_lmul!(a, B)
 
 ## permutedims
 
-function LinearAlgebra.permutedims!(dest::AbstractGPUArray, src::AbstractGPUArray,
-                                    perm::NTuple)
-    Base.checkdims_perm(dest, src, perm)
-    function permutedims_kernel(ctx, dest, src, ::Val{perm}) where {perm}
-        I = @cartesianidx src
-        @inbounds begin
-            J = CartesianIndex(map(i->I[i], perm))
-            dest[J] = src[I]
-        end
-        return
-    end
-    gpu_call(permutedims_kernel, dest, src, Val(perm))
-    return dest
-end
-
 # TODO: implementation without the memory copy
 LinearAlgebra.permutedims!(dest::AbstractGPUArray, src::AbstractGPUArray, perm) =
     permutedims!(dest, src, Tuple(perm))
 
+function LinearAlgebra.permutedims!(dest::AbstractGPUArray, src::AbstractGPUArray,
+                                    perm::NTuple{N}) where N
+    Base.checkdims_perm(dest, src, perm)
+    dest_strides = ntuple(k->k==1 ? 1 : prod(i->size(dest, i), 1:k-1), N)
+    dest_strides_perm = ntuple(i->dest_strides[findfirst(==(i), perm)], N)
+    function permutedims_kernel(ctx, dest, src, dest_strides_perm)
+        LI = @linearidx src
+        I = @inbounds CartesianIndices(src)[LI]
+        dest_index = map_index(I.I, dest_strides_perm)
+        @inbounds dest[dest_index] = src[LI]
+        return
+    end
+    gpu_call(permutedims_kernel, dest, src, dest_strides_perm)
+    return dest
+end
+
+# get linear index from cartesian indices and strides.
+@inline @generated function map_index(I::NTuple{N}, dest_strides::NTuple{N,T}) where {N,T}
+    Expr(:call, :+, one(T), [:(@inbounds (I[$i]-1) * dest_strides[$i]) for i in 1:N]...)
+end
 
 ## norm
 

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -15,6 +15,8 @@
         @test compare(x -> permutedims(x, (2, 1, 3)), AT, rand(Float32, 4, 5, 6))
         @test compare(x -> permutedims(x, (3, 1, 2)), AT, rand(Float32, 4, 5, 6))
         @test compare(x -> permutedims(x, [2,1,4,3]), AT, randn(ComplexF32,3,4,5,1))
+        # high dimensional tensor
+        @test compare(x -> permutedims(x, 18:-1:1), AT, rand(Float32, 4, [2 for _ = 2:18]...))
     end
 
     @testset "symmetric" begin

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -16,7 +16,9 @@
         @test compare(x -> permutedims(x, (3, 1, 2)), AT, rand(Float32, 4, 5, 6))
         @test compare(x -> permutedims(x, [2,1,4,3]), AT, randn(ComplexF32,3,4,5,1))
         # high dimensional tensor
-        @test compare(x -> permutedims(x, 18:-1:1), AT, rand(Float32, 4, [2 for _ = 2:18]...))
+        @static if VERSION >= v"1.7"
+            @test compare(x -> permutedims(x, 18:-1:1), AT, rand(Float32, 4, [2 for _ = 2:18]...))
+        end
     end
 
     @testset "symmetric" begin


### PR DESCRIPTION
fix #375 
## Benchmarks
1. low rank arrays

OLD:
```julia
julia> using CUDA

julia> t = CUDA.randn(200, 200, 200);

julia> using BenchmarkTools

julia> @benchmark CUDA.@sync permutedims($t, (3,2,1))
BenchmarkTools.Trial: 1572 samples with 1 evaluation.
 Range (min … max):  1.624 ms … 514.483 ms  ┊ GC (min … max): 0.00% … 0.49%
 Time  (median):     1.917 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.167 ms ±  24.906 ms  ┊ GC (mean ± σ):  0.16% ± 0.02%

                                         ▁▂▄▅▆██▆▅▄▃▃▁         
  ▂▂▂▂▂▃▃▃▂▃▃▃▂▂▁▂▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁▂▃▃▃▃▄▄▆█████████████▇▆▆▄▄▃▂ ▄
  1.62 ms         Histogram: frequency by time        2.01 ms <

 Memory estimate: 1.45 KiB, allocs estimate: 28.
```

NEW:
```julia
julia> @benchmark CUDA.@sync permutedims($t, (3,2,1))
BenchmarkTools.Trial: 1661 samples with 1 evaluation.
 Range (min … max):  1.599 ms … 513.128 ms  ┊ GC (min … max): 0.00% … 0.58%
 Time  (median):     1.918 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.998 ms ±  22.740 ms  ┊ GC (mean ± σ):  0.18% ± 0.02%

                                              ▁▃██▇█▇▇▃        
  ▂▂▂▂▁▂▁▁▂▃▂▃▄▃▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▂▃▃▃▃▄▅▄▃▃▄▅██████████▇▇▄▄▄▃ ▃
  1.6 ms          Histogram: frequency by time        1.99 ms <

 Memory estimate: 1.39 KiB, allocs estimate: 26.
```

2. for high dimensional arrays, see: https://github.com/under-Peter/OMEinsum.jl/issues/133