### PR TITLE
Overload `cholesky` method in order to prevent scalar indexing for `Diagonal`

### DIFF
--- a/src/host/linalg.jl
+++ b/src/host/linalg.jl
@@ -101,6 +101,19 @@ end
 
 Base.copy(D::Diagonal{T, <:AbstractGPUArray{T, N}}) where {T, N} = Diagonal(copy(D.diag))
 
+# prevent scalar indexing
+function LinearAlgebra.cholesky!(D::Diagonal{T, <:AbstractGPUArray{T, N}}, 
+    ::Val{false} = Val(false); check::Bool = true
+) where {T, N}
+    info = 0
+    if all(isreal.(D.diag)) && all(D.diag .> 0)
+        D.diag .= sqrt.(D.diag)
+    elseif check
+        throw(PosDefException(0))
+    end
+    Cholesky(D, 'U', convert(LinearAlgebra.BlasInt, info))
+end
+
 
 ## matrix multiplication
 

--- a/src/host/linalg.jl
+++ b/src/host/linalg.jl
@@ -108,8 +108,9 @@ function LinearAlgebra.cholesky!(D::Diagonal{T, <:AbstractGPUArray{T, N}},
     info = 0
     if mapreduce(x -> isreal(x) && isposdef(x), &, D.diag)
         D.diag .= sqrt.(D.diag)
-    elseif check
-        throw(PosDefException(0))
+    else
+        info = findfirst(x -> !isreal(x) || !isposdef(x), collect(D.diag))
+        check && throw(PosDefException(info))
     end
     Cholesky(D, 'U', convert(LinearAlgebra.BlasInt, info))
 end

--- a/src/host/linalg.jl
+++ b/src/host/linalg.jl
@@ -106,7 +106,7 @@ function LinearAlgebra.cholesky!(D::Diagonal{T, <:AbstractGPUArray{T, N}},
     ::Val{false} = Val(false); check::Bool = true
 ) where {T, N}
     info = 0
-    if all(isreal.(D.diag)) && all(D.diag .> 0)
+    if mapreduce(x -> isreal(x) && isposdef(x), &, D.diag)
         D.diag .= sqrt.(D.diag)
     elseif check
         throw(PosDefException(0))

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -17,6 +17,15 @@
         @test compare(x -> permutedims(x, [2,1,4,3]), AT, randn(ComplexF32,3,4,5,1))
     end
 
+    @testset "cholesky" begin
+        n = 128
+        a = AT(rand(Float32, n))
+        S = a' * a 
+        F = collect(S)
+        @test collect(cholesky(S).U) ≈ collect(cholesky(F).U)
+        @test collect(cholesky(S).L) ≈ collect(cholesky(F).L)
+    end
+
     @testset "symmetric" begin
         @testset "Hermitian" begin
             A    = rand(Float32,2,2)
@@ -105,6 +114,7 @@
             D = Diagonal(d)
             F = AT(collect(D))
             @show which(cholesky, Tuple{typeof(D)})
+            @show which(cholesky, Tuple{typeof(F)})
             @test collect(cholesky(D).U) ≈ collect(cholesky(F).U)
             @test collect(cholesky(D).L) ≈ collect(cholesky(F).L)
         end

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -24,6 +24,10 @@
         F = collect(S)
         @test collect(cholesky(S).U) ≈ collect(cholesky(F).U)
         @test collect(cholesky(S).L) ≈ collect(cholesky(F).L)
+
+        # dispatch info for debugging purposes
+        d = Hermitian(LinearAlgebra.cholcopy(S)).data
+        @show which(LAPACK.potrf!, Tuple{Char, typeof(d)})
     end
 
     @testset "symmetric" begin
@@ -113,8 +117,6 @@
             d = AT(rand(Float32, n))
             D = Diagonal(d)
             F = AT(collect(D))
-            @show which(cholesky, Tuple{typeof(D)})
-            @show which(cholesky, Tuple{typeof(F)})
             @test collect(cholesky(D).U) ≈ collect(cholesky(F).U)
             @test collect(cholesky(D).L) ≈ collect(cholesky(F).L)
         end

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -103,7 +103,7 @@
             n = 128
             d = AT(rand(Float32, n))
             D = Diagonal(d)
-            F = collect(D)
+            F = AT(collect(D))
             @test collect(cholesky(D).U) ≈ collect(cholesky(F).U)
             @test collect(cholesky(D).L) ≈ collect(cholesky(F).L)
         end

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -99,6 +99,15 @@
             @test collect(D) == collect(C)
         end
 
+        @testset "cholesky + Diagonal" begin
+            n = 128
+            d = AT(rand(Float32, n))
+            D = Diagonal(d)
+            F = collect(D)
+            @test collect(cholesky(D).U) ≈ collect(cholesky(F).U)
+            @test collect(cholesky(D).L) ≈ collect(cholesky(F).L)
+        end
+
         @testset "$f! with diagonal $d" for (f, f!) in ((triu, triu!), (tril, tril!)),
                                             d in -2:2
             A = randn(Float32, 10, 10)

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -108,6 +108,12 @@
             @test collect(cholesky(D).L) ≈ collect(cholesky(F).L)
         end
 
+        @testset "cholesky + Diagonal" begin
+            d = AT([1f0, 2f0, -1f0, 0f0])
+            D = Diagonal(d)
+            @test cholesky(D, check = false).info == 3
+        end
+
         @testset "$f! with diagonal $d" for (f, f!) in ((triu, triu!), (tril, tril!)),
                                             d in -2:2
             A = randn(Float32, 10, 10)

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -19,7 +19,7 @@
 
     @testset "cholesky" begin
         n = 128
-        a = AT(rand(Float32, n))
+        a = AT(rand(Float32, n, n))
         S = a' * a 
         F = collect(S)
         @test collect(cholesky(S).U) ≈ collect(cholesky(F).U)

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -107,9 +107,7 @@
             F = collect(D)
             @test collect(cholesky(D).U) ≈ collect(cholesky(F).U)
             @test collect(cholesky(D).L) ≈ collect(cholesky(F).L)
-        end
 
-        @testset "cholesky + Diagonal" begin
             d = AT([1f0, 2f0, -1f0, 0f0])
             D = Diagonal(d)
             @test cholesky(D, check = false).info == 3

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -104,6 +104,7 @@
             d = AT(rand(Float32, n))
             D = Diagonal(d)
             F = AT(collect(D))
+            @show which(cholesky, Tuple{typeof(D)})
             @test collect(cholesky(D).U) ≈ collect(cholesky(F).U)
             @test collect(cholesky(D).L) ≈ collect(cholesky(F).L)
         end

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -17,18 +17,6 @@
         @test compare(x -> permutedims(x, [2,1,4,3]), AT, randn(ComplexF32,3,4,5,1))
     end
 
-    @testset "cholesky" begin
-        n = 128
-        a = AT(rand(Float32, n, n))
-        S = a' * a 
-        F = collect(S)
-        @test collect(cholesky(S).U) ≈ collect(cholesky(F).U)
-        @test collect(cholesky(S).L) ≈ collect(cholesky(F).L)
-
-        # dispatch info for debugging purposes
-        d = Hermitian(LinearAlgebra.cholcopy(S)).data
-        @show which(LAPACK.potrf!, Tuple{Char, typeof(d)})
-    end
 
     @testset "symmetric" begin
         @testset "Hermitian" begin
@@ -116,7 +104,7 @@
             n = 128
             d = AT(rand(Float32, n))
             D = Diagonal(d)
-            F = AT(collect(D))
+            F = collect(D)
             @test collect(cholesky(D).U) ≈ collect(cholesky(F).U)
             @test collect(cholesky(D).L) ≈ collect(cholesky(F).L)
         end


### PR DESCRIPTION
Makes this work without scalar indexing:
```julia
using CUDA, LinearAlgebra
CUDA.allowscalar(false)

n = 1024
d = CUDA.rand(n)
D = Diagonal(d)
cholesky(D)
```
Performance can probably be improved.