### PR TITLE
Remove @linearidx in permutedims kernel

### DIFF
--- a/src/host/linalg.jl
+++ b/src/host/linalg.jl
@@ -204,10 +204,12 @@ function LinearAlgebra.permutedims!(dest::AbstractGPUArray, src::AbstractGPUArra
     # get the new strides of destination tensor
     dest_strides = ntuple(k->k==1 ? 1 : prod(i->size(dest, i), 1:k-1), N)
     dest_strides_perm = ntuple(i->dest_strides[findfirst(==(i), perm)], N)
+    LEN = length(src)
 
     function permutedims_kernel(ctx, dest, src, dest_strides_perm)
         # find the cartesian index in source tensor
-        LI = @linearidx src
+        LI = linear_index(ctx, 1)
+        LI > LEN && return
         I = @inbounds CartesianIndices(src)[LI]
 
         # the corresponding linear index in the destination tensor


### PR DESCRIPTION
## NEW
```zsh
➜  scripts git:(master) ✗ JULIA_CUDA_USE_BINARYBUILDER=false julia permutedims.jl       
BenchmarkTools.Trial: 118 samples with 1 evaluation.
 Range (min … max):  42.366 ms … 42.511 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     42.393 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   42.398 ms ± 17.662 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

                   ▃▄▁█▄▆▃ ▁ ▁ ▁ ▃                             
  ▄▁▁▁▄▁▆▄▄▆▆▆▁▇▇▄▇███████▆█▇█▁█▇█▆▇▁▁▆▁▆▄▁▄▄▆▄▇▆▁▁▇▇▁▁▄▁▁▁▁▆ ▄
  42.4 ms         Histogram: frequency by time        42.4 ms <

 Memory estimate: 9.05 KiB, allocs estimate: 95.%
```

## OLD
```zsh
➜  scripts git:(master) ✗ JULIA_CUDA_USE_BINARYBUILDER=false julia permutedims.jl
BenchmarkTools.Trial: 31 samples with 1 evaluation.
 Range (min … max):  165.607 ms … 165.798 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     165.701 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   165.698 ms ±  50.178 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

                       ▃        █           █                    
  ▇▇▁▁▁▇▁▁▇▁▁▇▁▇▁▁▇▁▁▇▇█▇▁▁▇▁▇▁▇█▇▇▇▁▁▇▇▁▇▁▁█▁▁▁▁▁▁▇▁▁▁▁▁▁▁▁▇▇▇ ▁
  166 ms           Histogram: frequency by time          166 ms <
```

## SCRIPT
```zsh
➜  scripts git:(master) ✗ cat permutedims.jl 
using CUDA, BenchmarkTools, Random

let D = 28
    a = CUDA.randn(fill(2, D)...)
    b = CUDA.randn(fill(2, D)...)
    pm = (randperm(D)...,)
    display(@benchmark (CUDA.@sync permutedims!($b, $a, $pm)))
end
```

Please also check the discussion in https://github.com/JuliaGPU/CUDA.jl/issues/1301