### PR TITLE
Call parent when unwrapping arrays.

### DIFF
--- a/src/host/abstractarray.jl
+++ b/src/host/abstractarray.jl
@@ -125,7 +125,7 @@ end
 function Base.copyto!(dest::Array, dstart::Integer,
                       src::WrappedGPUArray, sstart::Integer, n::Integer)
     n == 0 && return dest
-    temp = similar(src, n)
+    temp = similar(parent(src), n)
     copyto!(temp, 1, src, sstart, n)
     copyto!(dest, dstart, temp, 1, n)
     return dest
@@ -134,7 +134,7 @@ end
 function Base.copyto!(dest::WrappedGPUArray, dstart::Integer,
                       src::Array, sstart::Integer, n::Integer)
     n == 0 && return dest
-    temp = similar(dest, n)
+    temp = similar(parent(dest), n)
     copyto!(temp, 1, src, sstart, n)
     copyto!(dest, dstart, temp, 1, n)
     return dest


### PR DESCRIPTION
```julia
julia> view([1], :)
1-element view(::Vector{Int64}, :) with eltype Int64:
 1

julia> similar(view([1], :))
1-element Vector{Int64}:
 0

julia> similar([1]')
1×1 adjoint(::Vector{Int64}) with eltype Int64:
 0

julia> similar(parent([1]'))
1-element Vector{Int64}:
 0
```