### PR TITLE
 Overload `\` and `ldiv!` in order to prevent scalar indexing for Diagonal

### DIFF
--- a/src/host/linalg.jl
+++ b/src/host/linalg.jl
@@ -129,7 +129,7 @@ end
 
 Base.:\(D::Diagonal, b::AbstractGPUArray{<:Any, 1}) = cu(D.diag) .\ b
 
-function LinearAlgebra.ldiv!(D::Diagonal{<:Any, <:AbstractGPUArray}, B::AbstractGPUVecOrMat)
+function LinearAlgebra.ldiv!(D::Diagonal{<:Any, <:AbstractGPUArray}, B::StridedVecOrMat)
     m, n = size(B, 1), size(B, 2)
     if m != length(D.diag)
         throw(DimensionMismatch("diagonal matrix is $(length(D.diag)) by $(length(D.diag)) but right hand side has $m rows"))
@@ -144,8 +144,6 @@ function LinearAlgebra.ldiv!(D::Diagonal{<:Any, <:AbstractGPUArray}, B::Abstract
     end
     return B
 end
-
-LinearAlgebra.ldiv!(D::Diagonal{<:Any, <:Any}, B::AbstractGPUArray) = LinearAlgebra.ldiv!(cu(D), B)
 
 function _ldiv_inner!(D, B::AbstractGPUArray)
     B .= D.diag .\ B

--- a/src/host/linalg.jl
+++ b/src/host/linalg.jl
@@ -127,7 +127,8 @@ else
     end
 end
 
-Base.:\(D::Diagonal, b::AbstractGPUArray{<:Any, 1}) = cu(D.diag) .\ b
+Base.:\(D::Diagonal, b::AbstractGPUVector) = typeof(b)(D.diag) .\ b
+Base.:\(D::Diagonal, B::AbstractGPUMatrix) = typeof(B)(hcat(D.diag))[:, 1] .\ B
 
 function LinearAlgebra.ldiv!(D::Diagonal{<:Any, <:AbstractGPUArray}, B::StridedVecOrMat)
     m, n = size(B, 1), size(B, 2)

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -138,6 +138,7 @@
             res = D \ B
             @test collect(res) ≈ collect(D) \ collect(B)
             @test collect(res) ≈ collect(D \ collect(B))
+            @test collect(res) ≈ collect(Diagonal(collect(d)) \ B)
         end
 
         @testset "$f! with diagonal $d" for (f, f!) in ((triu, triu!), (tril, tril!)),

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -81,10 +81,7 @@
                 @test cpu_a == Array(collect(TR(gpu_a)))
 
                 copyto!(gpu_a, rand(Float32, (128,128)))
-                gpu_c = copyto!(gpu_b, TR(gpu_a))
-                @test all(Array(gpu_b) .== TR(Array(gpu_a)))
-                @test gpu_c isa AT
-            end
+                gpu_c = copyto!(gpu_b, TR(gpu_a))collect(D)
 
             for TR in (UpperTriangular, LowerTriangular, UnitUpperTriangular, UnitLowerTriangular)
                 gpu_a = AT(rand(Float32, (128,128))) |> TR
@@ -128,6 +125,18 @@
             d = AT([1f0, 2f0, -1f0, 0f0])
             D = Diagonal(d)
             @test cholesky(D, check = false).info == 3
+        end
+
+        @testset "ldiv! + Diagonal" begin
+            n = 128
+            d = AT(rand(Float32, n))
+            D = Diagonal(d)
+            B = AT(rand(Float32, n, n))
+            res = D \ B
+            @test collect(res) ≈ collect(D) \ collect(B)
+            @test collect(res) ≈ D \ collect(B)
+            D = Diagonal(collect(d))
+            @test collect(D \ B) ≈ collect(res)
         end
 
         @testset "$f! with diagonal $d" for (f, f!) in ((triu, triu!), (tril, tril!)),

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -137,9 +137,7 @@
             B = AT(rand(Float32, n, n))
             res = D \ B
             @test collect(res) ≈ collect(D) \ collect(B)
-            @test collect(res) ≈ D \ collect(B)
-            D = Diagonal(collect(d))
-            @test collect(D \ B) ≈ collect(res)
+            @test collect(res) ≈ collect(D \ collect(B))
         end
 
         @testset "$f! with diagonal $d" for (f, f!) in ((triu, triu!), (tril, tril!)),

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -152,8 +152,8 @@
             D = Diagonal(d)
             b = AT(rand(Float32, n))
             B = AT(rand(Float32, n, n))
-            X = AT(zeros(n, n))
-            Y = zeros(n, n)
+            X = AT(zeros(Float32, n, n))
+            Y = zeros(Float32, n, n)
             ldiv!(X, D, B)
             ldiv!(Y, Diagonal(collect(d)), collect(B))
             @test collect(X) ≈ Y

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -81,7 +81,10 @@
                 @test cpu_a == Array(collect(TR(gpu_a)))
 
                 copyto!(gpu_a, rand(Float32, (128,128)))
-                gpu_c = copyto!(gpu_b, TR(gpu_a))collect(D)
+                gpu_c = copyto!(gpu_b, TR(gpu_a))
+                @test all(Array(gpu_b) .== TR(Array(gpu_a)))
+                @test gpu_c isa AT
+            end
 
             for TR in (UpperTriangular, LowerTriangular, UnitUpperTriangular, UnitLowerTriangular)
                 gpu_a = AT(rand(Float32, (128,128))) |> TR


### PR DESCRIPTION
This **partially** addresses #91 by providing methods for diagonal matrices. 