### PR TITLE
Add `extrema` support

### DIFF
--- a/src/host/mapreduce.jl
+++ b/src/host/mapreduce.jl
@@ -22,7 +22,7 @@ neutral_element(::typeof(Base.:(*)), T) = one(T)
 neutral_element(::typeof(Base.mul_prod), T) = one(T)
 neutral_element(::typeof(Base.min), T) = typemax(T)
 neutral_element(::typeof(Base.max), T) = typemin(T)
-if isdefined(Base, :_extrema_rf)
+if VERSION >= v"1.8.0-DEV.1465"
     neutral_element(::typeof(Base._extrema_rf), ::Type{<:NTuple{2,T}}) where {T} = typemax(T), typemin(T)
 end
 

--- a/src/host/mapreduce.jl
+++ b/src/host/mapreduce.jl
@@ -22,6 +22,9 @@ neutral_element(::typeof(Base.:(*)), T) = one(T)
 neutral_element(::typeof(Base.mul_prod), T) = one(T)
 neutral_element(::typeof(Base.min), T) = typemax(T)
 neutral_element(::typeof(Base.max), T) = typemin(T)
+if isdefined(Base, :_extrema_rf)
+    neutral_element(::typeof(Base._extrema_rf), ::Type{<:NTuple{2,T}}) where {T} = typemax(T), typemin(T)
+end
 
 # resolve ambiguities
 Base.mapreduce(f, op, A::AnyGPUArray, As::AbstractArrayOrBroadcasted...;

--- a/test/testsuite.jl
+++ b/test/testsuite.jl
@@ -17,6 +17,12 @@ using Adapt
 struct ArrayAdaptor{AT} end
 Adapt.adapt_storage(::ArrayAdaptor{AT}, xs::AbstractArray) where {AT} = AT(xs)
 
+≈(a, b) = Base.isapprox(a, b)
+function ≈(a::T, b::T) where {T<:AbstractArray{<:NTuple{2,Number}}}
+    ET = eltype(eltype(T))
+    Base.isapprox(reinterpret(ET, a), reinterpret(ET, b))
+end
+
 function compare(f, AT::Type{<:AbstractGPUArray}, xs...; kwargs...)
     # copy on the CPU, adapt on the GPU, but keep Ref's
     cpu_in = map(x -> isa(x, Base.RefValue) ? x[] : deepcopy(x), xs)

--- a/test/testsuite/reductions.jl
+++ b/test/testsuite/reductions.jl
@@ -77,7 +77,7 @@ end
     end
 end
 
-@testsuite "reductions/minimum maximum" (AT, eltypes)->begin
+@testsuite "reductions/minimum maximum extrema" (AT, eltypes)->begin
     @testset "$ET" for ET in eltypes
         range = ET <: Real ? (ET(1):ET(10)) : ET
         for (sz,dims) in [(10,)=>[1], (10,10)=>[1,2], (10,10,10)=>[1,2,3], (10,10,10)=>[],
@@ -90,6 +90,11 @@ end
                 @test compare(A->maximum(A), AT, rand(range, sz))
                 @test compare(A->maximum(x->x*x, A), AT, rand(range, sz))
                 @test compare(A->maximum(A; dims=dims), AT, rand(range, sz))
+                if isdefined(Base, :_extrema_rf)
+                    @test compare(A->extrema(A), AT, rand(range, sz))
+                    @test compare(A->extrema(x->x*x, A), AT, rand(range, sz))
+                    @test compare(A->extrema(A; dims=dims), AT, rand(range, sz))
+                end
             end
         end
 
@@ -98,6 +103,9 @@ end
             if !(ET <: Complex)
                 @test compare((A,R)->minimum!(R, A), AT, rand(range, sz), fill(typemax(ET), red))
                 @test compare((A,R)->maximum!(R, A), AT, rand(range, sz), fill(typemin(ET), red))
+                if isdefined(Base, :_extrema_rf)
+                    @test compare((A,R)->extrema!(R, A), AT, rand(range, sz), fill((typemax(ET),typemin(ET)), red))
+                end
             end
         end
     end

--- a/test/testsuite/reductions.jl
+++ b/test/testsuite/reductions.jl
@@ -90,7 +90,7 @@ end
                 @test compare(A->maximum(A), AT, rand(range, sz))
                 @test compare(A->maximum(x->x*x, A), AT, rand(range, sz))
                 @test compare(A->maximum(A; dims=dims), AT, rand(range, sz))
-                if isdefined(Base, :_extrema_rf)
+                if VERSION >= v"1.8.0-DEV.1465"
                     @test compare(A->extrema(A), AT, rand(range, sz))
                     @test compare(A->extrema(x->x*x, A), AT, rand(range, sz))
                     @test compare(A->extrema(A; dims=dims), AT, rand(range, sz))
@@ -103,7 +103,7 @@ end
             if !(ET <: Complex)
                 @test compare((A,R)->minimum!(R, A), AT, rand(range, sz), fill(typemax(ET), red))
                 @test compare((A,R)->maximum!(R, A), AT, rand(range, sz), fill(typemin(ET), red))
-                if isdefined(Base, :_extrema_rf)
+                if VERSION >= v"1.8.0-DEV.1465"
                     @test compare((A,R)->extrema!(R, A), AT, rand(range, sz), fill((typemax(ET),typemin(ET)), red))
                 end
             end


### PR DESCRIPTION
On `1.8` `Base.extrema` is `mapreduce` based.
This PR just add the default initial value.