### PR TITLE
add methods for axpby, axpy, scal

### DIFF
--- a/src/host/linalg.jl
+++ b/src/host/linalg.jl
@@ -293,3 +293,11 @@ function Base.similar(A::Hermitian{<:Any,<:AbstractGPUArray}, ::Type{T}) where T
     fill!(view(B, diagind(B)), 0)
     return Hermitian(B, ifelse(A.uplo == 'U', :U, :L))
 end
+
+
+## axp{b}y
+
+LinearAlgebra.axpby!(alpha::Number, x::AbstractGPUArray,
+                     beta::Number,  y::AbstractGPUArray) = y .= x.*alpha .+ y.*beta
+
+LinearAlgebra.axpy!(alpha::Number, x::AbstractGPUArray, y::AbstractGPUArray) = y .+= x.*alpha

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -186,6 +186,14 @@
         @test compare(rmul!, AT, rand(T, a), Ref(rand(T)))
         @test compare(lmul!, AT, Ref(rand(T)), rand(T, b))
     end
+
+    @testset "axp{b}y" for T in eltypes
+        alpha, beta = 0.5, 2.0
+        x = T.([2,4,6])
+        y = T.([3,4,5])
+        @test axpby!(alpha,x,beta,y) ≈ T.([7,10,13])
+        @test axpy!(alpha,x,y) ≈ T.([8,12,16])
+    end
 end
 
 @testsuite "linalg/mul!/vector-matrix" (AT, eltypes)->begin


### PR DESCRIPTION
closes https://github.com/JuliaGPU/CUDA.jl/issues/1399

BFloat16 now does *not* iterate, and is hence comparably fast to Float32 on an A100:

```
julia> using CUDA, LinearAlgebra, BFloat16s, BenchmarkTools

julia> X=rand(100000);

julia> Y=rand(100000);

julia> cuF32X=CuArray{Float32}(X);

julia> cuF32Y=CuArray{Float32}(Y);

julia> cuB16X=CuArray{BFloat16}(X);

julia> cuB16Y=CuArray{BFloat16}(Y);

julia> @benchmark CUDA.@sync axpby!(0.5,$cuF32X,1.5,$cuF32Y)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  11.511 μs … 176.752 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     12.313 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   12.477 μs ±   3.206 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

              ▃▆██▂                                             
  ▁▁▁▁▁▁▁▂▂▃▂▄█████▆▄▃▃▃▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  11.5 μs         Histogram: frequency by time         14.7 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark CUDA.@sync axpby!(0.5,$cuB16X,1.5,$cuB16Y)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  13.285 μs … 220.654 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     14.938 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   15.421 μs ±   4.057 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

           ▂█▇█▆▂▁                                              
  ▂▁▁▂▂▂▃▄▆███████▇▆▆▇▇█▇▇▆▅▅▅▄▄▄▄▃▃▃▃▃▃▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂ ▄
  13.3 μs         Histogram: frequency by time         19.7 μs <

 Memory estimate: 3.14 KiB, allocs estimate: 42.
```