### PR TITLE
Add n-dimensional repeat

### DIFF
--- a/src/host/base.jl
+++ b/src/host/base.jl
@@ -23,7 +23,7 @@ function repeat_inner(xs::AnyGPUArray, inner)
     out = similar(xs, eltype(xs), inner .* size(xs))
     any(==(0), size(out)) && return out # consistent with `Base.repeat`
 
-    gpu_call(repeat_inner_kernel!, xs, inner, out; total_threads=prod(size(out)))
+    gpu_call(repeat_inner_kernel!, xs, inner, out; elements=prod(size(out)))
     return out
 end
 
@@ -47,7 +47,7 @@ function repeat_outer(xs::AnyGPUArray, outer)
     out = similar(xs, eltype(xs), outer .* size(xs))
     any(==(0), size(out)) && return out # consistent with `Base.repeat`
 
-    gpu_call(repeat_outer_kernel!, xs, size(xs), outer, out; total_threads=prod(size(out)))
+    gpu_call(repeat_outer_kernel!, xs, size(xs), outer, out; elements=prod(size(out)))
     return out
 end
 

--- a/src/host/base.jl
+++ b/src/host/base.jl
@@ -9,7 +9,7 @@ function repeat_inner_kernel!(
 ) where {N}
     # Get single element from src
     idx = @cartesianidx xs
-    val = xs[idx]
+    @inbounds val = xs[idx]
 
     # Loop over "repeat" indices of inner
     for rdx in CartesianIndices(inner)
@@ -39,7 +39,7 @@ function repeat_outer_kernel!(
 ) where {N}
     # Get index to input element
     idx = @cartesianidx xs
-    val = xs[idx]
+    @inbounds val = xs[idx]
 
     # Loop over repeat indices, copying val to out
     for rdx in CartesianIndices(outer)

--- a/src/host/base.jl
+++ b/src/host/base.jl
@@ -22,6 +22,8 @@ if VERSION ≥ v"1.6"
 
     function repeat_inner(xs::AnyGPUArray, inner)
         out = similar(xs, eltype(xs), inner .* size(xs))
+        any(==(0), size(out)) && return out # consistent with `Base.repeat`
+
         gpu_call(repeat_inner_kernel!, xs, inner, out; total_threads=prod(size(out)))
         return out
     end
@@ -44,6 +46,8 @@ if VERSION ≥ v"1.6"
 
     function repeat_outer(xs::AnyGPUArray, outer)
         out = similar(xs, eltype(xs), outer .* size(xs))
+        any(==(0), size(out)) && return out # consistent with `Base.repeat`
+
         gpu_call(repeat_outer_kernel!, xs, size(xs), outer, out; total_threads=prod(size(out)))
         return out
     end

--- a/src/host/base.jl
+++ b/src/host/base.jl
@@ -1,117 +1,75 @@
 # common Base functionality
 
-if VERSION ≥ v"1.6"
-    import Base: _RepeatInnerOuter
+import Base: _RepeatInnerOuter
 
-    function repeat_inner_kernel!(
-        ctx::AbstractKernelContext,
-        xs::AbstractArray{<:Any, N},
-        inner::NTuple{N, Int},
-        out::AbstractArray{<:Any, N}
-    ) where {N}
-        dest_inds = @cartesianidx(out).I
-        # Get the "stride" index in each dimension, where the size
-        # of the stride is given by `inner`. The stride-index then
-        # corresponds to the index of the repeated value in `xs`.
-        src_inds = ntuple(i -> (dest_inds[i] - 1) ÷ inner[i] + 1, N)
+function repeat_inner_kernel!(
+    ctx::AbstractKernelContext,
+    xs::AbstractArray{<:Any, N},
+    inner::NTuple{N, Int},
+    out::AbstractArray{<:Any, N}
+) where {N}
+    dest_inds = @cartesianidx(out).I
+    # Get the "stride" index in each dimension, where the size
+    # of the stride is given by `inner`. The stride-index then
+    # corresponds to the index of the repeated value in `xs`.
+    src_inds = ntuple(i -> (dest_inds[i] - 1) ÷ inner[i] + 1, N)
 
-        @inbounds out[dest_inds...] = xs[src_inds...]
+    @inbounds out[dest_inds...] = xs[src_inds...]
 
-        return nothing
-    end
-
-    function repeat_inner(xs::AnyGPUArray, inner)
-        out = similar(xs, eltype(xs), inner .* size(xs))
-        any(==(0), size(out)) && return out # consistent with `Base.repeat`
-
-        gpu_call(repeat_inner_kernel!, xs, inner, out; total_threads=prod(size(out)))
-        return out
-    end
-
-    function repeat_outer_kernel!(
-        ctx::AbstractKernelContext,
-        xs::AbstractArray{<:Any, N},
-        xssize::NTuple{N},
-        outer::NTuple{N},
-        out::AbstractArray{<:Any, N}
-    ) where {N}
-        dest_inds = @cartesianidx(out).I
-        # Outer is just wrapping around the edges of `xs`.
-        src_inds = ntuple(i -> (dest_inds[i] - 1) % xssize[i] + 1, N)
-
-        @inbounds out[dest_inds...] = xs[src_inds...]
-
-        return nothing
-    end
-
-    function repeat_outer(xs::AnyGPUArray, outer)
-        out = similar(xs, eltype(xs), outer .* size(xs))
-        any(==(0), size(out)) && return out # consistent with `Base.repeat`
-
-        gpu_call(repeat_outer_kernel!, xs, size(xs), outer, out; total_threads=prod(size(out)))
-        return out
-    end
-
-    # Overload methods used by `Base.repeat`.
-    # No need to implement `repeat_inner_outer` since this is implemented in `Base` as
-    # `repeat_outer(repeat_inner(arr, inner), outer)`.
-    function _RepeatInnerOuter.repeat_inner(xs::AnyGPUArray{<:Any, N}, dims::NTuple{N}) where {N}
-        return repeat_inner(xs, dims)
-    end
-
-    function _RepeatInnerOuter.repeat_outer(xs::AnyGPUArray{<:Any, N}, dims::NTuple{N}) where {N}
-        return repeat_outer(xs, dims)
-    end
-
-    function _RepeatInnerOuter.repeat_outer(xs::AnyGPUArray{<:Any, 1}, dims::Tuple{Any})
-        return repeat_outer(xs, dims)
-    end
-
-    function _RepeatInnerOuter.repeat_outer(xs::AnyGPUArray{<:Any, 2}, dims::NTuple{2, Any})
-        return repeat_outer(xs, dims)
-    end
-else
-    function Base.repeat(a::AbstractGPUVecOrMat, m::Int, n::Int = 1)
-        o, p = size(a, 1), size(a, 2)
-        b = similar(a, o*m, p*n)
-        if length(b) == 0
-            return b
-        end
-        gpu_call(b, a, o, p, m, n; total_threads=n) do ctx, b, a, o, p, m, n
-            j = linear_index(ctx)
-            j > n && return
-            d = (j - 1) * p + 1
-            @inbounds for i in 1:m
-                c = (i - 1) * o + 1
-                for r in 1:p
-                    for k in 1:o
-                        b[k - 1 + c, r - 1 + d] = a[k, r]
-                    end
-                end
-            end
-            return
-        end
-        return b
-    end
-
-    function Base.repeat(a::AbstractGPUVector, m::Int)
-        o = length(a)
-        b = similar(a, o*m)
-        if length(b) == 0
-            return b
-        end
-        gpu_call(b, a, o, m; total_threads=m) do ctx, b, a, o, m
-            i = linear_index(ctx)
-            i > m && return
-            c = (i - 1)*o + 1
-            @inbounds for i in 1:o
-                b[c + i - 1] = a[i]
-            end
-            return
-        end
-        return b
-    end
+    return nothing
 end
+
+function repeat_inner(xs::AnyGPUArray, inner)
+    out = similar(xs, eltype(xs), inner .* size(xs))
+    any(==(0), size(out)) && return out # consistent with `Base.repeat`
+
+    gpu_call(repeat_inner_kernel!, xs, inner, out; total_threads=prod(size(out)))
+    return out
+end
+
+function repeat_outer_kernel!(
+    ctx::AbstractKernelContext,
+    xs::AbstractArray{<:Any, N},
+    xssize::NTuple{N},
+    outer::NTuple{N},
+    out::AbstractArray{<:Any, N}
+) where {N}
+    dest_inds = @cartesianidx(out).I
+    # Outer is just wrapping around the edges of `xs`.
+    src_inds = ntuple(i -> (dest_inds[i] - 1) % xssize[i] + 1, N)
+
+    @inbounds out[dest_inds...] = xs[src_inds...]
+
+    return nothing
+end
+
+function repeat_outer(xs::AnyGPUArray, outer)
+    out = similar(xs, eltype(xs), outer .* size(xs))
+    any(==(0), size(out)) && return out # consistent with `Base.repeat`
+
+    gpu_call(repeat_outer_kernel!, xs, size(xs), outer, out; total_threads=prod(size(out)))
+    return out
+end
+
+# Overload methods used by `Base.repeat`.
+# No need to implement `repeat_inner_outer` since this is implemented in `Base` as
+# `repeat_outer(repeat_inner(arr, inner), outer)`.
+function _RepeatInnerOuter.repeat_inner(xs::AnyGPUArray{<:Any, N}, dims::NTuple{N}) where {N}
+    return repeat_inner(xs, dims)
+end
+
+function _RepeatInnerOuter.repeat_outer(xs::AnyGPUArray{<:Any, N}, dims::NTuple{N}) where {N}
+    return repeat_outer(xs, dims)
+end
+
+function _RepeatInnerOuter.repeat_outer(xs::AnyGPUArray{<:Any, 1}, dims::Tuple{Any})
+    return repeat_outer(xs, dims)
+end
+
+function _RepeatInnerOuter.repeat_outer(xs::AnyGPUArray{<:Any, 2}, dims::NTuple{2, Any})
+    return repeat_outer(xs, dims)
+end
+
 ## PermutedDimsArrays
 
 using Base: PermutedDimsArrays

--- a/src/host/base.jl
+++ b/src/host/base.jl
@@ -1,46 +1,113 @@
 # common Base functionality
 
-function Base.repeat(a::AbstractGPUVecOrMat, m::Int, n::Int = 1)
-    o, p = size(a, 1), size(a, 2)
-    b = similar(a, o*m, p*n)
-    if length(b) == 0
-        return b
+if VERSION ≥ v"1.6"
+    import Base: _RepeatInnerOuter
+
+    function repeat_inner_kernel!(
+        ctx::AbstractKernelContext,
+        xs::AbstractArray{<:Any, N},
+        inner::NTuple{N, Int},
+        out::AbstractArray{<:Any, N}
+    ) where {N}
+        dest_inds = @cartesianidx(out).I
+        # Get the "stride" index in each dimension, where the size
+        # of the stride is given by `inner`. The stride-index then
+        # corresponds to the index of the repeated value in `xs`.
+        src_inds = ntuple(i -> (dest_inds[i] - 1) ÷ inner[i] + 1, N)
+
+        @inbounds out[dest_inds...] = xs[src_inds...]
+
+        return nothing
     end
-    gpu_call(b, a, o, p, m, n; elements=n) do ctx, b, a, o, p, m, n
-        j = linear_index(ctx)
-        j > n && return
-        d = (j - 1) * p + 1
-        @inbounds for i in 1:m
-            c = (i - 1) * o + 1
-            for r in 1:p
-                for k in 1:o
-                    b[k - 1 + c, r - 1 + d] = a[k, r]
+
+    function repeat_inner(xs::TV, inner) where {TV<:AbstractGPUArray}
+        out = TV(undef, inner .* size(xs))
+        gpu_call(repeat_inner_kernel!, xs, inner, out; total_threads=prod(size(out)))
+        return out
+    end
+
+    function repeat_outer_kernel!(
+        ctx::AbstractKernelContext,
+        xs::AbstractArray{<:Any, N},
+        xssize::NTuple{N},
+        outer::NTuple{N},
+        out::AbstractArray{<:Any, N}
+    ) where {N}
+        dest_inds = @cartesianidx(out).I
+        # Outer is just wrapping around the edges of `xs`.
+        src_inds = ntuple(i -> (dest_inds[i] - 1) % xssize[i] + 1, N)
+
+        @inbounds out[dest_inds...] = xs[src_inds...]
+
+        return nothing
+    end
+
+    function repeat_outer(xs::TV, outer) where {TV<:AbstractGPUArray}
+        out = TV(undef, outer .* size(xs))
+        gpu_call(repeat_outer_kernel!, xs, size(xs), outer, out; total_threads=prod(size(out)))
+        return out
+    end
+
+    # Overload methods used by `Base.repeat`.
+    # No need to implement `repeat_inner_outer` since this is implemented in `Base` as
+    # `repeat_outer(repeat_inner(arr, inner), outer)`.
+    function _RepeatInnerOuter.repeat_inner(xs::AbstractGPUArray{<:Any, N}, dims::NTuple{N}) where {N}
+        return repeat_inner(xs, dims)
+    end
+
+    function _RepeatInnerOuter.repeat_outer(xs::AbstractGPUArray{<:Any, N}, dims::NTuple{N}) where {N}
+        return repeat_outer(xs, dims)
+    end
+
+    function _RepeatInnerOuter.repeat_outer(xs::AbstractGPUVector, dims::Tuple{Any})
+        return repeat_outer(xs, dims)
+    end
+
+    function _RepeatInnerOuter.repeat_outer(xs::AbstractGPUMatrix, dims::NTuple{2, Any})
+        return repeat_outer(xs, dims)
+    end
+else
+    function Base.repeat(a::AbstractGPUVecOrMat, m::Int, n::Int = 1)
+        o, p = size(a, 1), size(a, 2)
+        b = similar(a, o*m, p*n)
+        if length(b) == 0
+            return b
+        end
+        gpu_call(b, a, o, p, m, n; total_threads=n) do ctx, b, a, o, p, m, n
+            j = linear_index(ctx)
+            j > n && return
+            d = (j - 1) * p + 1
+            @inbounds for i in 1:m
+                c = (i - 1) * o + 1
+                for r in 1:p
+                    for k in 1:o
+                        b[k - 1 + c, r - 1 + d] = a[k, r]
+                    end
                 end
             end
+            return
         end
-        return
-    end
-    return b
-end
-
-function Base.repeat(a::AbstractGPUVector, m::Int)
-    o = length(a)
-    b = similar(a, o*m)
-    if length(b) == 0
         return b
     end
-    gpu_call(b, a, o, m; elements=m) do ctx, b, a, o, m
-        i = linear_index(ctx)
-        i > m && return
-        c = (i - 1)*o + 1
-        @inbounds for i in 1:o
-            b[c + i - 1] = a[i]
-        end
-        return
-    end
-    return b
-end
 
+    function Base.repeat(a::AbstractGPUVector, m::Int)
+        o = length(a)
+        b = similar(a, o*m)
+        if length(b) == 0
+            return b
+        end
+        gpu_call(b, a, o, m; total_threads=m) do ctx, b, a, o, m
+            i = linear_index(ctx)
+            i > m && return
+            c = (i - 1)*o + 1
+            @inbounds for i in 1:o
+                b[c + i - 1] = a[i]
+            end
+            return
+        end
+        return b
+    end
+end
 ## PermutedDimsArrays
 
 using Base: PermutedDimsArrays

--- a/src/host/base.jl
+++ b/src/host/base.jl
@@ -20,8 +20,8 @@ if VERSION ≥ v"1.6"
         return nothing
     end
 
-    function repeat_inner(xs::TV, inner) where {TV<:AbstractGPUArray}
-        out = TV(undef, inner .* size(xs))
+    function repeat_inner(xs::AnyGPUArray, inner)
+        out = similar(xs, eltype(xs), inner .* size(xs))
         gpu_call(repeat_inner_kernel!, xs, inner, out; total_threads=prod(size(out)))
         return out
     end
@@ -42,8 +42,8 @@ if VERSION ≥ v"1.6"
         return nothing
     end
 
-    function repeat_outer(xs::TV, outer) where {TV<:AbstractGPUArray}
-        out = TV(undef, outer .* size(xs))
+    function repeat_outer(xs::AnyGPUArray, outer)
+        out = similar(xs, eltype(xs), outer .* size(xs))
         gpu_call(repeat_outer_kernel!, xs, size(xs), outer, out; total_threads=prod(size(out)))
         return out
     end
@@ -51,19 +51,19 @@ if VERSION ≥ v"1.6"
     # Overload methods used by `Base.repeat`.
     # No need to implement `repeat_inner_outer` since this is implemented in `Base` as
     # `repeat_outer(repeat_inner(arr, inner), outer)`.
-    function _RepeatInnerOuter.repeat_inner(xs::AbstractGPUArray{<:Any, N}, dims::NTuple{N}) where {N}
+    function _RepeatInnerOuter.repeat_inner(xs::AnyGPUArray{<:Any, N}, dims::NTuple{N}) where {N}
         return repeat_inner(xs, dims)
     end
 
-    function _RepeatInnerOuter.repeat_outer(xs::AbstractGPUArray{<:Any, N}, dims::NTuple{N}) where {N}
+    function _RepeatInnerOuter.repeat_outer(xs::AnyGPUArray{<:Any, N}, dims::NTuple{N}) where {N}
         return repeat_outer(xs, dims)
     end
 
-    function _RepeatInnerOuter.repeat_outer(xs::AbstractGPUVector, dims::Tuple{Any})
+    function _RepeatInnerOuter.repeat_outer(xs::AnyGPUArray{<:Any, 1}, dims::Tuple{Any})
         return repeat_outer(xs, dims)
     end
 
-    function _RepeatInnerOuter.repeat_outer(xs::AbstractGPUMatrix, dims::NTuple{2, Any})
+    function _RepeatInnerOuter.repeat_outer(xs::AnyGPUArray{<:Any, 2}, dims::NTuple{2, Any})
         return repeat_outer(xs, dims)
     end
 else

--- a/src/host/base.jl
+++ b/src/host/base.jl
@@ -1,5 +1,4 @@
 # common Base functionality
-
 import Base: _RepeatInnerOuter
 
 function repeat_inner_kernel!(
@@ -8,13 +7,18 @@ function repeat_inner_kernel!(
     inner::NTuple{N, Int},
     out::AbstractArray{<:Any, N}
 ) where {N}
-    dest_inds = @cartesianidx(out).I
-    # Get the "stride" index in each dimension, where the size
-    # of the stride is given by `inner`. The stride-index then
-    # corresponds to the index of the repeated value in `xs`.
-    src_inds = ntuple(i -> (dest_inds[i] - 1) ÷ inner[i] + 1, N)
+    # Get single element from src
+    idx = @cartesianidx xs
+    val = xs[idx]
 
-    @inbounds out[dest_inds...] = xs[src_inds...]
+    # Loop over "repeat" indices of inner
+    for rdx in CartesianIndices(inner)
+        # Get destination CartesianIndex
+        odx = ntuple(N) do i
+            @inbounds (idx[i]-1) * inner[i] + rdx[i]
+        end
+        @inbounds out[CartesianIndex(odx)] = val
+    end
 
     return nothing
 end
@@ -22,8 +26,7 @@ end
 function repeat_inner(xs::AnyGPUArray, inner)
     out = similar(xs, eltype(xs), inner .* size(xs))
     any(==(0), size(out)) && return out # consistent with `Base.repeat`
-
-    gpu_call(repeat_inner_kernel!, xs, inner, out; elements=prod(size(out)))
+    gpu_call(repeat_inner_kernel!, xs, inner, out; elements=length(xs))
     return out
 end
 
@@ -34,11 +37,18 @@ function repeat_outer_kernel!(
     outer::NTuple{N},
     out::AbstractArray{<:Any, N}
 ) where {N}
-    dest_inds = @cartesianidx(out).I
-    # Outer is just wrapping around the edges of `xs`.
-    src_inds = ntuple(i -> (dest_inds[i] - 1) % xssize[i] + 1, N)
+    # Get index to input element
+    idx = @cartesianidx xs
+    val = xs[idx]
 
-    @inbounds out[dest_inds...] = xs[src_inds...]
+    # Loop over repeat indices, copying val to out
+    for rdx in CartesianIndices(outer)
+        # Get destination CartesianIndex
+        odx = ntuple(N) do i
+            @inbounds idx[i] + xssize[i] * (rdx[i] -1)
+        end
+        @inbounds out[CartesianIndex(odx)] = val
+    end
 
     return nothing
 end
@@ -46,8 +56,7 @@ end
 function repeat_outer(xs::AnyGPUArray, outer)
     out = similar(xs, eltype(xs), outer .* size(xs))
     any(==(0), size(out)) && return out # consistent with `Base.repeat`
-
-    gpu_call(repeat_outer_kernel!, xs, size(xs), outer, out; elements=prod(size(out)))
+    gpu_call(repeat_outer_kernel!, xs, size(xs), outer, out; elements=length(xs))
     return out
 end
 

--- a/test/testsuite/base.jl
+++ b/test/testsuite/base.jl
@@ -33,7 +33,7 @@ end
                             )
             dst = AT(dst)
             src = AT(src)
-            
+
             copy!(dst, src)
             @test dst == src
         end
@@ -217,10 +217,15 @@ end
         xmat = rand(Float32, 2, 10)
         xarr = rand(Float32, 3, 2, 10)
 
+        # Note: When testing repeat(x; inner) need to hit both `repeat_inner_src_kernel!`
+        # and `repeat_inner_dst_kernel!` to get full coverage.
+
         # Inner.
         @test compare(a -> repeat(a, inner=(2, )), AT, x)
         @test compare(a -> repeat(a, inner=(2, 3)), AT, xmat)
+        @test compare(a -> repeat(a, inner=(3, 2)), AT, xmat)
         @test compare(a -> repeat(a, inner=(2, 3, 4)), AT, xarr)
+        @test compare(a -> repeat(a, inner=(4, 3, 2)), AT, xarr)
         # Outer.
         @test compare(a -> repeat(a, outer=(2, )), AT, x)
         @test compare(a -> repeat(a, outer=(2, 3)), AT, xmat)
@@ -231,10 +236,12 @@ end
         @test compare(a -> repeat(a, inner=(2, 3, 4), outer=(2, 1, 4)), AT, xarr)
         # Repeat which expands dimensionality.
         @test compare(a -> repeat(a, inner=(2, 1, 3)), AT, x)
+        @test compare(a -> repeat(a, inner=(3, 1, 2)), AT, x)
         @test compare(a -> repeat(a, outer=(2, 1, 3)), AT, x)
         @test compare(a -> repeat(a, inner=(2, 1, 3), outer=(2, 2, 3)), AT, x)
 
         @test compare(a -> repeat(a, inner=(2, 1, 3)), AT, xmat)
+        @test compare(a -> repeat(a, inner=(3, 1, 2)), AT, xmat)
         @test compare(a -> repeat(a, outer=(2, 1, 3)), AT, xmat)
         @test compare(a -> repeat(a, inner=(2, 1, 3), outer=(2, 2, 3)), AT, xmat)
     end

--- a/test/testsuite/base.jl
+++ b/test/testsuite/base.jl
@@ -212,33 +212,31 @@ end
         @test compare(a-> repeat(a, 0),     AT, rand(Float32, 5, 4))
         @test compare(a-> repeat(a, 4, 0),  AT, rand(Float32, 10, 15))
 
-        if VERSION ≥ v"1.6"
-            # Test inputs.
-            x = rand(Float32, 10)
-            xmat = rand(Float32, 2, 10)
-            xarr = rand(Float32, 3, 2, 10)
+        # Test inputs.
+        x = rand(Float32, 10)
+        xmat = rand(Float32, 2, 10)
+        xarr = rand(Float32, 3, 2, 10)
 
-            # Inner.
-            @test compare(a -> repeat(a, inner=(2, )), AT, x)
-            @test compare(a -> repeat(a, inner=(2, 3)), AT, xmat)
-            @test compare(a -> repeat(a, inner=(2, 3, 4)), AT, xarr)
-            # Outer.
-            @test compare(a -> repeat(a, outer=(2, )), AT, x)
-            @test compare(a -> repeat(a, outer=(2, 3)), AT, xmat)
-            @test compare(a -> repeat(a, outer=(2, 3, 4)), AT, xarr)
-            # Both.
-            @test compare(a -> repeat(a, inner=(2, ), outer=(2, )), AT, x)
-            @test compare(a -> repeat(a, inner=(2, 3), outer=(2, 3)), AT, xmat)
-            @test compare(a -> repeat(a, inner=(2, 3, 4), outer=(2, 1, 4)), AT, xarr)
-            # Repeat which expands dimensionality.
-            @test compare(a -> repeat(a, inner=(2, 1, 3)), AT, x)
-            @test compare(a -> repeat(a, outer=(2, 1, 3)), AT, x)
-            @test compare(a -> repeat(a, inner=(2, 1, 3), outer=(2, 2, 3)), AT, x)
+        # Inner.
+        @test compare(a -> repeat(a, inner=(2, )), AT, x)
+        @test compare(a -> repeat(a, inner=(2, 3)), AT, xmat)
+        @test compare(a -> repeat(a, inner=(2, 3, 4)), AT, xarr)
+        # Outer.
+        @test compare(a -> repeat(a, outer=(2, )), AT, x)
+        @test compare(a -> repeat(a, outer=(2, 3)), AT, xmat)
+        @test compare(a -> repeat(a, outer=(2, 3, 4)), AT, xarr)
+        # Both.
+        @test compare(a -> repeat(a, inner=(2, ), outer=(2, )), AT, x)
+        @test compare(a -> repeat(a, inner=(2, 3), outer=(2, 3)), AT, xmat)
+        @test compare(a -> repeat(a, inner=(2, 3, 4), outer=(2, 1, 4)), AT, xarr)
+        # Repeat which expands dimensionality.
+        @test compare(a -> repeat(a, inner=(2, 1, 3)), AT, x)
+        @test compare(a -> repeat(a, outer=(2, 1, 3)), AT, x)
+        @test compare(a -> repeat(a, inner=(2, 1, 3), outer=(2, 2, 3)), AT, x)
 
-            @test compare(a -> repeat(a, inner=(2, 1, 3)), AT, xmat)
-            @test compare(a -> repeat(a, outer=(2, 1, 3)), AT, xmat)
-            @test compare(a -> repeat(a, inner=(2, 1, 3), outer=(2, 2, 3)), AT, xmat)
-        end
+        @test compare(a -> repeat(a, inner=(2, 1, 3)), AT, xmat)
+        @test compare(a -> repeat(a, outer=(2, 1, 3)), AT, xmat)
+        @test compare(a -> repeat(a, inner=(2, 1, 3), outer=(2, 2, 3)), AT, xmat)
     end
 
     @testset "permutedims" begin

--- a/test/testsuite/base.jl
+++ b/test/testsuite/base.jl
@@ -216,7 +216,7 @@ end
             # Test inputs.
             x = rand(Float32, 10)
             xmat = rand(Float32, 2, 10)
-            arr = rand(Float32, 3, 2, 10)
+            xarr = rand(Float32, 3, 2, 10)
 
             # Inner.
             @test compare(a -> repeat(a, inner=(2, )), AT, x)

--- a/test/testsuite/base.jl
+++ b/test/testsuite/base.jl
@@ -211,6 +211,34 @@ end
         @test compare(a-> repeat(a, 0),     AT, rand(Float32, 10))
         @test compare(a-> repeat(a, 0),     AT, rand(Float32, 5, 4))
         @test compare(a-> repeat(a, 4, 0),  AT, rand(Float32, 10, 15))
+
+        if VERSION ≥ v"1.6"
+            # Test inputs.
+            x = rand(Float32, 10)
+            xmat = rand(Float32, 2, 10)
+            arr = rand(Float32, 3, 2, 10)
+
+            # Inner.
+            @test compare(a -> repeat(a, inner=(2, )), AT, x)
+            @test compare(a -> repeat(a, inner=(2, 3)), AT, xmat)
+            @test compare(a -> repeat(a, inner=(2, 3, 4)), AT, xarr)
+            # Outer.
+            @test compare(a -> repeat(a, outer=(2, )), AT, x)
+            @test compare(a -> repeat(a, outer=(2, 3)), AT, xmat)
+            @test compare(a -> repeat(a, outer=(2, 3, 4)), AT, xarr)
+            # Both.
+            @test compare(a -> repeat(a, inner=(2, ), outer=(2, )), AT, x)
+            @test compare(a -> repeat(a, inner=(2, 3), outer=(2, 3)), AT, xmat)
+            @test compare(a -> repeat(a, inner=(2, 3, 4), outer=(2, 1, 4)), AT, xarr)
+            # Repeat which expands dimensionality.
+            @test compare(a -> repeat(a, inner=(2, 1, 3)), AT, x)
+            @test compare(a -> repeat(a, outer=(2, 1, 3)), AT, x)
+            @test compare(a -> repeat(a, inner=(2, 1, 3), outer=(2, 2, 3)), AT, x)
+
+            @test compare(a -> repeat(a, inner=(2, 1, 3)), AT, xmat)
+            @test compare(a -> repeat(a, outer=(2, 1, 3)), AT, xmat)
+            @test compare(a -> repeat(a, inner=(2, 1, 3), outer=(2, 2, 3)), AT, xmat)
+        end
     end
 
     @testset "permutedims" begin


### PR DESCRIPTION
This PR builds on the work of @torfjelde in #357 and the associated comments.

Notable changes:

- Rebased on top of the [v8.3.1](https://github.com/JuliaGPU/GPUArrays.jl/commit/37158348ef247542f939a5d6c8fcdbb67b7a7c7e) commit
    - c5a16b2 updates #357 code to use `elements` instead of `total_threads`
    - Locally all tests pass with this version
- Launch threads over the input array instead of the output array (32a6c4d)
    - Eliminates the duplicate reads per input element
    - Locally all tests pass

Best,

Alex