### PR TITLE
Implement `isequal`

### DIFF
--- a/src/host/mapreduce.jl
+++ b/src/host/mapreduce.jl
@@ -86,6 +86,7 @@ Base.count(pred::Function, A::AnyGPUArray; dims=:, init=0) =
     mapreduce(pred, Base.add_sum, A; init=init, dims=dims)
 
 Base.:(==)(A::AnyGPUArray, B::AnyGPUArray) = Bool(mapreduce(==, &, A, B))
+Base.isequal(A::AnyGPUArray, B::AnyGPUArray) = mapreduce(isequal, &, A, B)
 
 # avoid calling into `initarray!`
 for (fname, op) in [(:sum, :(Base.add_sum)), (:prod, :(Base.mul_prod)),

--- a/test/testsuite/reductions.jl
+++ b/test/testsuite/reductions.jl
@@ -155,3 +155,29 @@ end
         @test A != B
     end
 end
+
+@testsuite "reductions/== isequal" (AT, eltypes)->begin
+    @testset "$ET" for ET in eltypes
+        range = ET <: Real ? (ET(1):ET(10)) : ET
+        for sz in [(10,), (10,10), (10,10,10), (0,)]
+            @test compare((A, B) -> A == B, AT, rand(range, sz), rand(range, sz))
+            @test compare((A, B) -> isequal(A, B), AT, rand(range, sz), rand(range, sz))
+            Ac = rand(range, sz)
+            @test compare((A, B) -> A == B, AT, Ac, Ac)
+            @test compare((A, B) -> isequal(A, B), AT, Ac, Ac)
+            if isfloattype(ET) && length(Ac) > 0
+                # Test cases where == and isequal behave differently
+                Bc = copy(Ac)
+                # 0.0 == -0.0 but !isequal(0.0, -0.0)
+                Ac[1] = zero(ET)
+                Bc[1] = -zero(ET)
+                @test compare((A, B) -> A == B, AT, Ac, Bc)
+                @test compare((A, B) -> isequal(A, B), AT, Ac, Bc)
+                # NaN != NaN but isequal(NaN, NaN)
+                Ac[1] = Bc[1] = ET(NaN)
+                @test compare((A, B) -> A == B, AT, Ac, Bc)
+                @test compare((A, B) -> isequal(A, B), AT, Ac, Bc)
+            end
+        end
+    end
+end


### PR DESCRIPTION
I thought maybe it would be good to have `isequal` work for GPU arrays? The AbstractArray fallback contains an explicit loop, so without this PR, `isequal(::AnyGPUArray, ::AnyGPUArray)` hits scalar indexing.

I also added some tests for `==` and `isequal`, including edge cases where they differ.

PS. Note that `isapprox` is also broken for GPU arrays whenever `isfinite(norm(A - B)) == false` (e.g., when the arrays contain Infs or NaNs) because the elementwise fallback iterates sequentially. I've proposed that this be fixed in base: JuliaLang/julia#44893. However, if this is rejected on account of performance I guess GPUArrays.jl should get it's own `isapprox` as well.