### PR TITLE
Set :ScalarIndexing to the proper value in `@allowscalar`

### DIFF
--- a/src/host/indexing.jl
+++ b/src/host/indexing.jl
@@ -71,7 +71,7 @@ See also: [`allowscalar`](@ref).
 """
 macro allowscalar(ex)
     quote
-        task_local_storage(:ScalarIndexing, true) do
+        task_local_storage(:ScalarIndexing, ScalarAllowed) do
             $(esc(ex))
         end
     end


### PR DESCRIPTION
Yet another outcome of staring at code. I think this is how you meant for `:ScalarIndexing` to be used.

That said, `@allowscalar` has been working regardless because `true != ScalarDisallowed` and `true != ScalarWarn`, resulting in the desired fall-through behavior in `assertscalar`.