### PR TITLE
Add size check for `isequal` and `==`

### DIFF
--- a/src/host/mapreduce.jl
+++ b/src/host/mapreduce.jl
@@ -85,11 +85,10 @@ Base.all(f::Function, A::AnyGPUArray) = mapreduce(f, &, A)
 Base.count(pred::Function, A::AnyGPUArray; dims=:, init=0) =
     mapreduce(pred, Base.add_sum, A; init=init, dims=dims)
 
-# specialize to arrays of Numbers to avoid dealing with "missing" (PR#410)
 _equal(A, B) = (A === B) || (axes(A) == axes(B) && mapreduce(==, &, A, B))
-Base.:(==)(A::AnyGPUArray{<:Number}, B::AnyGPUArray{<:Number}) = _equal(A, B)
-Base.isequal(A::AnyGPUArray{<:Number}, B::AnyGPUArray{<:Number}) =  _equal(A, B)
-Base.:(==)(A::AnyGPUArray{<:Ptr{Nothing}}, B::AnyGPUArray{<:Ptr{Nothing}}) = _equal(A, B)
+Base.:(==)(A::AnyGPUArray, B::AnyGPUArray) = _equal(A, B)
+# specialize to arrays of Numbers to avoid dealing with "missing" (PR#410)
+Base.isequal(A::AnyGPUArray{<:Number}, B::AnyGPUArray{<:Number}) = _equal(A, B)
 
 # avoid calling into `initarray!`
 for (fname, op) in [(:sum, :(Base.add_sum)), (:prod, :(Base.mul_prod)),

--- a/src/host/mapreduce.jl
+++ b/src/host/mapreduce.jl
@@ -85,11 +85,11 @@ Base.all(f::Function, A::AnyGPUArray) = mapreduce(f, &, A)
 Base.count(pred::Function, A::AnyGPUArray; dims=:, init=0) =
     mapreduce(pred, Base.add_sum, A; init=init, dims=dims)
 
-# specialize to arrays of Numbers to avoid dealing with "missing"
-Base.:(==)(A::AnyGPUArray{<:Number}, B::AnyGPUArray{<:Number}) = 
-    (A === B) || (axes(A) == axes(B) && mapreduce(==, &, A, B))
-Base.isequal(A::AnyGPUArray{<:Number}, B::AnyGPUArray{<:Number}) = 
-    (A === B) || (axes(A) == axes(B) && mapreduce(isequal, &, A, B))
+# specialize to arrays of Numbers to avoid dealing with "missing" (PR#410)
+_equal(A, B) = (A === B) || (axes(A) == axes(B) && mapreduce(==, &, A, B))
+Base.:(==)(A::AnyGPUArray{<:Number}, B::AnyGPUArray{<:Number}) = _equal(A, B)
+Base.isequal(A::AnyGPUArray{<:Number}, B::AnyGPUArray{<:Number}) =  _equal(A, B)
+Base.:(==)(A::AnyGPUArray{<:Ptr{Nothing}}, B::AnyGPUArray{<:Ptr{Nothing}}) = _equal(A, B)
 
 # avoid calling into `initarray!`
 for (fname, op) in [(:sum, :(Base.add_sum)), (:prod, :(Base.mul_prod)),

--- a/src/host/mapreduce.jl
+++ b/src/host/mapreduce.jl
@@ -12,8 +12,8 @@ Base.mapreducedim!(f, op, R::AnyGPUArray, A::Broadcast.Broadcasted) = mapreduced
 
 neutral_element(op, T) =
     error("""GPUArrays.jl needs to know the neutral element for your operator `$op`.
-             Please pass it as an explicit argument to `GPUArrays.mapreducedim!` (if possible),
-             or register it globally your operator by defining `GPUArrays.neutral_element(::typeof($op), T)`.""")
+             Please pass it as an explicit argument to `GPUArrays.mapreducedim!`,
+             or register it globally by defining `GPUArrays.neutral_element(::typeof($op), T)`.""")
 neutral_element(::typeof(Base.:(|)), T) = zero(T)
 neutral_element(::typeof(Base.:(+)), T) = zero(T)
 neutral_element(::typeof(Base.add_sum), T) = zero(T)
@@ -110,7 +110,7 @@ function Base.isequal(A::AnyGPUArray, B::AnyGPUArray)
     mapreduce(isequal, &, A, B; init=true)
 end
 
-# fails when missing values are involved
+# returns `missing` when missing values are involved
 function Base.:(==)(A::AnyGPUArray, B::AnyGPUArray)
     if axes(A) != axes(B)
         return false

--- a/src/host/mapreduce.jl
+++ b/src/host/mapreduce.jl
@@ -85,8 +85,11 @@ Base.all(f::Function, A::AnyGPUArray) = mapreduce(f, &, A)
 Base.count(pred::Function, A::AnyGPUArray; dims=:, init=0) =
     mapreduce(pred, Base.add_sum, A; init=init, dims=dims)
 
-Base.:(==)(A::AnyGPUArray, B::AnyGPUArray) = Bool(mapreduce(==, &, A, B))
-Base.isequal(A::AnyGPUArray, B::AnyGPUArray) = mapreduce(isequal, &, A, B)
+# specialize to arrays of Numbers to avoid dealing with "missing"
+Base.:(==)(A::AnyGPUArray{<:Number}, B::AnyGPUArray{<:Number}) = 
+    (A === B) || (axes(A) == axes(B) && mapreduce(==, &, A, B))
+Base.isequal(A::AnyGPUArray{<:Number}, B::AnyGPUArray{<:Number}) = 
+    (A === B) || (axes(A) == axes(B) && mapreduce(isequal, &, A, B))
 
 # avoid calling into `initarray!`
 for (fname, op) in [(:sum, :(Base.add_sum)), (:prod, :(Base.mul_prod)),

--- a/src/host/mapreduce.jl
+++ b/src/host/mapreduce.jl
@@ -85,10 +85,11 @@ Base.all(f::Function, A::AnyGPUArray) = mapreduce(f, &, A)
 Base.count(pred::Function, A::AnyGPUArray; dims=:, init=0) =
     mapreduce(pred, Base.add_sum, A; init=init, dims=dims)
 
-_equal(A, B) = (A === B) || (axes(A) == axes(B) && mapreduce(==, &, A, B))
-Base.:(==)(A::AnyGPUArray, B::AnyGPUArray) = _equal(A, B)
+Base.:(==)(A::AnyGPUArray, B::AnyGPUArray) = 
+    (A === B) || (axes(A) == axes(B) && mapreduce(==, &, A, B))
 # specialize to arrays of Numbers to avoid dealing with "missing" (PR#410)
-Base.isequal(A::AnyGPUArray{<:Number}, B::AnyGPUArray{<:Number}) = _equal(A, B)
+Base.isequal(A::AnyGPUArray{<:Number}, B::AnyGPUArray{<:Number}) =
+    (A === B) || (axes(A) == axes(B) && mapreduce(isequal, &, A, B))
 
 # avoid calling into `initarray!`
 for (fname, op) in [(:sum, :(Base.add_sum)), (:prod, :(Base.mul_prod)),

--- a/test/testsuite.jl
+++ b/test/testsuite.jl
@@ -18,6 +18,9 @@ struct ArrayAdaptor{AT} end
 Adapt.adapt_storage(::ArrayAdaptor{AT}, xs::AbstractArray) where {AT} = AT(xs)
 
 test_result(a::Number, b::Number; kwargs...) = ≈(a, b; kwargs...)
+test_result(a::Missing, b::Missing; kwargs...) = true
+test_result(a::Number, b::Missing; kwargs...) = false
+test_result(a::Missing, b::Number; kwargs...) = false
 function test_result(a::AbstractArray{T}, b::AbstractArray{T}; kwargs...) where {T<:Number}
     ≈(collect(a), collect(b); kwargs...)
 end

--- a/test/testsuite/reductions.jl
+++ b/test/testsuite/reductions.jl
@@ -159,6 +159,12 @@ end
 @testsuite "reductions/== isequal" (AT, eltypes)->begin
     @testset "$ET" for ET in eltypes
         range = ET <: Real ? (ET(1):ET(10)) : ET
+
+        # different sizes should trip up both (CUDA.jl#1524)
+        @test compare((A, B) -> A == B, AT, rand(range, (2,3)), rand(range, 6))
+        @test compare((A, B) -> isequal(A, B), AT, rand(range, (2,3)), rand(range, 6))
+
+        # equal sizes depend on values
         for sz in [(10,), (10,10), (10,10,10), (0,)]
             @test compare((A, B) -> A == B, AT, rand(range, sz), rand(range, sz))
             @test compare((A, B) -> isequal(A, B), AT, rand(range, sz), rand(range, sz))
@@ -179,5 +185,9 @@ end
                 @test compare((A, B) -> isequal(A, B), AT, Ac, Bc)
             end
         end
+
+        # missing values should only trip up ==
+        @test compare((A, B) -> A == B, AT, [missing], [missing])
+        @test compare((A, B) -> isequal(A, B), AT, [missing], [missing])
     end
 end


### PR DESCRIPTION
This PR is a refinement of #405 that fixes https://github.com/JuliaGPU/CUDA.jl/issues/1524 by adding a size check (more precisely an `axes` check).  Two arrays can be equal only if their axes match.

This PR also specializes `==` and `isequal` to GPUArrays of `Number`s because those two methods (in general) are supposed to produce different results if the arrays have any `missing` values per the manual:
https://docs.julialang.org/en/v1/base/math/#Base.:==

GPUArrays presumably are mainly for use with numeric types, so specializing to Numbers saves us the trouble of dealing with `missing` elements here; if someone happens to have a GPUArray with `missing` elements then it can fall back to the Base versions of those methods.

I did not add any tests because I could not understand the `@testsuite` infrastructure.