### PR TITLE
Overlaod `Base.copy!` for `AbstractGPUArray`s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+
+# editor generated files
+.*.swp
+.*.swo
+*~

--- a/src/host/abstractarray.jl
+++ b/src/host/abstractarray.jl
@@ -42,6 +42,12 @@ Base.collect(X::AnyGPUArray) = collect_to_cpu(X)
 
 # memory copying
 
+function Base.copy!(dst::AbstractGPUVector, src::AbstractGPUVector)
+    axes(dst) == axes(src) || throw(ArgumentError(
+    "arrays must have the same axes for copy! (consider using `copyto!`)"))
+    copyto!(dst, src)
+end
+
 ## basic linear copies of identically-typed memory
 
 # expects the GPU array type to have linear `copyto!` methods (i.e. accepting an integer


### PR DESCRIPTION
closes https://github.com/JuliaGPU/CUDA.jl/issues/1555

`Base.copy!(::AbstractVector, ::AbstractVector)` calls `setindex!`. We can workaround by doing a axes check and calling `copyto!`.