### PR TITLE
Specialize `LinearAlgebra.mul!` on `Diagonal` for `GPUArrays`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+
+# editor generated files
+.*.swp
+.*.swo
+*~

--- a/src/host/abstractarray.jl
+++ b/src/host/abstractarray.jl
@@ -42,6 +42,12 @@ Base.collect(X::AnyGPUArray) = collect_to_cpu(X)
 
 # memory copying
 
+function Base.copy!(dst::AbstractGPUVector, src::AbstractGPUVector)
+    axes(dst) == axes(src) || throw(ArgumentError(
+    "arrays must have the same axes for `copy!`. consider using `copyto!` instead"))
+    copyto!(dst, src)
+end
+
 ## basic linear copies of identically-typed memory
 
 # expects the GPU array type to have linear `copyto!` methods (i.e. accepting an integer

--- a/src/host/abstractarray.jl
+++ b/src/host/abstractarray.jl
@@ -44,7 +44,7 @@ Base.collect(X::AnyGPUArray) = collect_to_cpu(X)
 
 function Base.copy!(dst::AbstractGPUVector, src::AbstractGPUVector)
     axes(dst) == axes(src) || throw(ArgumentError(
-    "arrays must have the same axes for copy! (consider using `copyto!`)"))
+    "arrays must have the same axes for `copy!`. consider using `copyto!` instead"))
     copyto!(dst, src)
 end
 

--- a/src/host/abstractarray.jl
+++ b/src/host/abstractarray.jl
@@ -44,7 +44,7 @@ Base.collect(X::AnyGPUArray) = collect_to_cpu(X)
 
 function Base.copy!(dst::AbstractGPUVector, src::AbstractGPUVector)
     axes(dst) == axes(src) || throw(ArgumentError(
-    "arrays must have the same axes for `copy!`. consider using `copyto!` instead"))
+    "arrays must have the same axes for copy! (consider using `copyto!`)"))
     copyto!(dst, src)
 end
 

--- a/src/host/linalg.jl
+++ b/src/host/linalg.jl
@@ -173,6 +173,36 @@ if VERSION < v"1.8-"
         return B
     end
 else
+    function LinearAlgebra.mul!(B::AbstractGPUVecOrMat,
+                                D::Diagonal{<:Any, <:AbstractGPUArray},
+                                A::AbstractGPUVecOrMat)
+        dd = D.diag
+        d = length(dd)
+        m, n = size(A, 1), size(A, 2)
+        m′, n′ = size(B, 1), size(B, 2)
+        m == d || throw(DimensionMismatch("right hand side has $m rows but D is $d by $d"))
+        (m, n) == (m′, n′) || throw(DimensionMismatch("expect output to be $m by $n, but got $m′ by $n′"))
+        @. B = dd * A
+
+        B
+    end
+
+    function LinearAlgebra.mul!(B::AbstractGPUVecOrMat,
+                                D::Diagonal{<:Any, <:AbstractGPUArray},
+                                A::AbstractGPUVecOrMat,
+                                α::Number,
+                                β::Number)
+        dd = D.diag
+        d = length(dd)
+        m, n = size(A, 1), size(A, 2)
+        m′, n′ = size(B, 1), size(B, 2)
+        m == d || throw(DimensionMismatch("right hand side has $m rows but D is $d by $d"))
+        (m, n) == (m′, n′) || throw(DimensionMismatch("expect output to be $m by $n, but got $m′ by $n′"))
+        @. B = α * dd* A + β * B
+
+        B
+    end
+
     function LinearAlgebra.ldiv!(B::AbstractGPUVecOrMat,
                                  D::Diagonal{<:Any, <:AbstractGPUArray},
                                  A::AbstractGPUVecOrMat)

--- a/test/testsuite/base.jl
+++ b/test/testsuite/base.jl
@@ -26,6 +26,19 @@ function ntuple_closure(ctx, result, ::Val{N}, testval) where N
 end
 
 @testsuite "base" (AT, eltypes)->begin
+    @testset "copy!" begin
+        for (dst, src,) in (
+                            (rand(Float32, (10,)),   rand(Float32, (10,))),   # vectors
+                            (rand(Float32, (10,20)), rand(Float32, (10,20))), # multidim
+                            )
+            dst = AT(dst)
+            src = AT(src)
+            
+            copy!(dst, src)
+            @test dst == src
+        end
+    end
+
     @testset "copyto!" begin
         x = fill(0f0, (10, 10))
         y = rand(Float32, (20, 10))

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -153,6 +153,23 @@
             @test_throws SingularException D \ B
         end
 
+        @testset "mul! + Diagonal" begin
+            n = 128
+            d = AT(rand(Float32, n))
+            D = Diagonal(d)
+            B = AT(rand(Float32, n, n))
+            X = AT(zeros(Float32, n, n))
+            Y = zeros(Float32, n, n)
+            α = rand(Float32)
+            β = rand(Float32)
+            mul!(X, D, B)
+            mul!(Y, Diagonal(collect(d)), collect(B))
+            @test collect(X) ≈ Y
+            mul!(X, D, B, α, β)
+            mul!(Y, Diagonal(collect(d)), collect(B), α, β)
+            @test collect(X) ≈ Y
+        end
+
         @testset "ldiv! + Diagonal" begin
             n = 128
             d = AT(rand(Float32, n))


### PR DESCRIPTION
Currently, `LinearAlgebra.mul!(v::CuVector, D::Diagonal{<:Any,CuVector}, u::CuVector)` callsj setindex  under the hood. I am adding 3, 5 argument `mul!` based on the implementation of `ldiv!` here: https://github.com/JuliaGPU/GPUArrays.jl/blob/master/src/host/linalg.jl#L176-L193