### PR TITLE
Move `AbstractGPUArrayStyle` to `GPUArraysCore`?

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 Adapt = "2.0, 3.0"
-GPUArraysCore = "0.1.1"
+GPUArraysCore = "= 0.1.1"
 LLVM = "3.9, 4"
 Reexport = "1"
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GPUArrays"
 uuid = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
-version = "8.4.1"
+version = "8.4.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
@@ -15,7 +15,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 Adapt = "2.0, 3.0"
-GPUArraysCore = "0.1"
+GPUArraysCore = "0.1.1"
 LLVM = "3.9, 4"
 Reexport = "1"
 julia = "1.6"

--- a/lib/GPUArraysCore/Project.toml
+++ b/lib/GPUArraysCore/Project.toml
@@ -1,7 +1,7 @@
 name = "GPUArraysCore"
 uuid = "46192b85-c4d5-4398-a991-12ede77f4527"
 authors = ["Tim Besard <tim.besard@gmail.com>"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/lib/GPUArraysCore/src/GPUArraysCore.jl
+++ b/lib/GPUArraysCore/src/GPUArraysCore.jl
@@ -6,7 +6,7 @@ using Adapt
 ## essential types
 
 export AbstractGPUArray, AbstractGPUVector, AbstractGPUMatrix, AbstractGPUVecOrMat,
-       WrappedGPUArray, AnyGPUArray
+       WrappedGPUArray, AnyGPUArray, AbstractGPUArrayStyle
 
 """
     AbstractGPUArray{T, N} <: DenseArray{T, N}
@@ -25,6 +25,15 @@ const AbstractGPUVecOrMat{T} = Union{AbstractGPUArray{T, 1}, AbstractGPUArray{T,
 const WrappedGPUArray{T,N} = WrappedArray{T,N,AbstractGPUArray,AbstractGPUArray{T,N}}
 const AnyGPUArray{T,N} = Union{AbstractGPUArray{T,N}, WrappedGPUArray{T,N}}
 
+## broadcasting
+
+"""
+Abstract supertype for GPU array styles. The `N` parameter is the dimensionality.
+
+Downstream implementations should provide a concrete array style type that inherits from
+this supertype.
+"""
+abstract type AbstractGPUArrayStyle{N} <: Base.Broadcast.AbstractArrayStyle{N} end
 
 ## scalar iteration
 

--- a/src/host/broadcast.jl
+++ b/src/host/broadcast.jl
@@ -1,21 +1,11 @@
 # broadcasting operations
 
-export AbstractGPUArrayStyle
-
 using Base.Broadcast
 
 import Base.Broadcast: BroadcastStyle, Broadcasted, AbstractArrayStyle, instantiate
 
 const BroadcastGPUArray{T} = Union{AnyGPUArray{T},
                                    Base.RefValue{<:AbstractGPUArray{T}}}
-
-"""
-Abstract supertype for GPU array styles. The `N` parameter is the dimensionality.
-
-Downstream implementations should provide a concrete array style type that inherits from
-this supertype.
-"""
-abstract type AbstractGPUArrayStyle{N} <: AbstractArrayStyle{N} end
 
 # Wrapper types otherwise forget that they are GPU compatible
 # NOTE: don't directly use GPUArrayStyle here not to lose downstream customizations.

--- a/src/host/broadcast.jl
+++ b/src/host/broadcast.jl
@@ -7,6 +7,11 @@ import Base.Broadcast: BroadcastStyle, Broadcasted, AbstractArrayStyle, instanti
 const BroadcastGPUArray{T} = Union{AnyGPUArray{T},
                                    Base.RefValue{<:AbstractGPUArray{T}}}
 
+# These duplicate definitions in GPUArraysCore right now, to simulate on CI the clash of having
+# both the old GPUArrays and the new GPUArraysCore.
+export AbstractGPUArrayStyle
+abstract type AbstractGPUArrayStyle{N} <: Base.Broadcast.AbstractArrayStyle{N} end
+
 # Wrapper types otherwise forget that they are GPU compatible
 # NOTE: don't directly use GPUArrayStyle here not to lose downstream customizations.
 BroadcastStyle(W::Type{<:WrappedGPUArray})= BroadcastStyle(Adapt.parent(W){Adapt.eltype(W), Adapt.ndims(W)})

--- a/src/host/broadcast.jl
+++ b/src/host/broadcast.jl
@@ -7,11 +7,6 @@ import Base.Broadcast: BroadcastStyle, Broadcasted, AbstractArrayStyle, instanti
 const BroadcastGPUArray{T} = Union{AnyGPUArray{T},
                                    Base.RefValue{<:AbstractGPUArray{T}}}
 
-# These duplicate definitions in GPUArraysCore right now, to simulate on CI the clash of having
-# both the old GPUArrays and the new GPUArraysCore.
-export AbstractGPUArrayStyle
-abstract type AbstractGPUArrayStyle{N} <: Base.Broadcast.AbstractArrayStyle{N} end
-
 # Wrapper types otherwise forget that they are GPU compatible
 # NOTE: don't directly use GPUArrayStyle here not to lose downstream customizations.
 BroadcastStyle(W::Type{<:WrappedGPUArray})= BroadcastStyle(Adapt.parent(W){Adapt.eltype(W), Adapt.ndims(W)})


### PR DESCRIPTION
RFC, I guess. But it would be useful to be able to dispatch on this, as for example here:

https://github.com/FluxML/Zygote.jl/blob/master/src/lib/broadcast.jl#L270

What order to tag things in may need careful thought. Does the main package needs an upper bound on the core in order not to create a clash, or can that be avoided somehow?