### PR TITLE
move `backend` to `GPUArraysCore.jl`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 Adapt = "2.0, 3.0"
-GPUArraysCore = "= 0.1.1"
+GPUArraysCore = "= 0.1.2"
 LLVM = "3.9, 4"
 Reexport = "1"
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GPUArrays"
 uuid = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
-version = "8.4.2"
+version = "8.4.3"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/lib/GPUArraysCore/Project.toml
+++ b/lib/GPUArraysCore/Project.toml
@@ -1,7 +1,7 @@
 name = "GPUArraysCore"
 uuid = "46192b85-c4d5-4398-a991-12ede77f4527"
 authors = ["Tim Besard <tim.besard@gmail.com>"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/lib/GPUArraysCore/src/GPUArraysCore.jl
+++ b/lib/GPUArraysCore/src/GPUArraysCore.jl
@@ -111,5 +111,13 @@ macro allowscalar(ex)
     end
 end
 
+"""
+    backend(T::Type)
+    backend(x)
+
+Gets the GPUArrays back-end responsible for managing arrays of type `T`.
+"""
+backend(::Type) = error("This object is not a GPU array") # COV_EXCL_LINE
+backend(x) = backend(typeof(x))
 
 end # module GPUArraysCore

--- a/lib/GPUArraysCore/src/GPUArraysCore.jl
+++ b/lib/GPUArraysCore/src/GPUArraysCore.jl
@@ -111,10 +111,6 @@ macro allowscalar(ex)
     end
 end
 
-## backend
-
-export backend
-
 """
     backend(T::Type)
     backend(x)

--- a/lib/GPUArraysCore/src/GPUArraysCore.jl
+++ b/lib/GPUArraysCore/src/GPUArraysCore.jl
@@ -111,6 +111,10 @@ macro allowscalar(ex)
     end
 end
 
+## backend
+
+export backend
+
 """
     backend(T::Type)
     backend(x)

--- a/lib/JLArrays/Project.toml
+++ b/lib/JLArrays/Project.toml
@@ -1,7 +1,7 @@
 name = "JLArrays"
 uuid = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
 authors = ["Tim Besard <tim.besard@gmail.com>"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
@@ -10,5 +10,5 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 Adapt = "2.0, 3.0"
-GPUArrays = "8.4.1"
+GPUArrays = "~8.4.1"
 julia = "1.6"

--- a/src/device/execution.jl
+++ b/src/device/execution.jl
@@ -6,6 +6,8 @@ abstract type AbstractGPUBackend end
 
 abstract type AbstractKernelContext end
 
+import GPUArraysCore: backend
+
 """
     gpu_call(kernel::Function, arg0, args...; kwargs...)
 

--- a/src/device/execution.jl
+++ b/src/device/execution.jl
@@ -6,14 +6,7 @@ abstract type AbstractGPUBackend end
 
 abstract type AbstractKernelContext end
 
-"""
-    backend(T::Type)
-    backend(x)
-
-Gets the GPUArrays back-end responsible for managing arrays of type `T`.
-"""
-backend(::Type) = error("This object is not a GPU array") # COV_EXCL_LINE
-backend(x) = backend(typeof(x))
+import GPUArraysCore: backend
 
 """
     gpu_call(kernel::Function, arg0, args...; kwargs...)

--- a/src/device/execution.jl
+++ b/src/device/execution.jl
@@ -6,8 +6,6 @@ abstract type AbstractGPUBackend end
 
 abstract type AbstractKernelContext end
 
-import GPUArraysCore: backend
-
 """
     gpu_call(kernel::Function, arg0, args...; kwargs...)
 


### PR DESCRIPTION
Second take of https://github.com/JuliaGPU/Adapt.jl/pull/50.
This PR wants to move `backend` to `GPUArraysCore.jl`, which would help us to implement broadcast for `StructArray` on gpu. (see https://github.com/JuliaArrays/StructArrays.jl/pull/215)
I hope it's also useful for other arraywrappers.
(I only bump `GPUArraysCore`'s version as we haven't registered a new `GPUArrays`.)