### PR TITLE
Add a generic dot for GPUArrays

### DIFF
--- a/src/host/linalg.jl
+++ b/src/host/linalg.jl
@@ -441,6 +441,9 @@ function Base.similar(A::Hermitian{<:Any,<:AbstractGPUArray}, ::Type{T}) where T
     return Hermitian(B, ifelse(A.uplo == 'U', :U, :L))
 end
 
+## dot
+
+LinearAlgebra.dot(x::AbstractGPUArray, y::AbstractGPUArray) = mapreduce(dot, +, x, y)
 
 ## axp{b}y
 

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -225,8 +225,14 @@
         alpha, beta = 0.5, 2.0
         x = T.([2,4,6])
         y = T.([3,4,5])
-        @test axpby!(alpha,x,beta,y) ≈ T.([7,10,13])
-        @test axpy!(alpha,x,y) ≈ T.([8,12,16])
+        @test axpby!(alpha,AT(x),beta,AT(y)) ≈ T.([7,10,13])
+        @test axpy!(alpha,AT(x),AT(y)) ≈ T.([8,12,16])
+    end
+
+    @testset "dot" for T in eltypes
+        x = rand(T, 5)
+        y = rand(T, 5)
+        @test dot(AT(x), AT(y)) ≈ dot(x, y)
     end
 
     @testset "iszero and isone" for T in eltypes

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -221,12 +221,12 @@
         @test compare(lmul!, AT, Ref(rand(T)), rand(T, b))
     end
 
-    @testset "axp{b}y" for T in (Float32, ComplexF32)
+    @testset "axp{b}y" for T in eltypes
         @test compare(axpby!, AT, Ref(rand(T)), rand(T,5), Ref(rand(T)), rand(T,5))
         @test compare(axpy!, AT, Ref(rand(T)), rand(T,5), rand(T,5))
     end
 
-    @testset "dot" for T in (Float32, ComplexF32)
+    @testset "dot" for T in eltypes
         @test compare(dot, AT, rand(T,5), rand(T, 5))
     end
 

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -222,17 +222,12 @@
     end
 
     @testset "axp{b}y" for T in eltypes
-        alpha, beta = 0.5, 2.0
-        x = T.([2,4,6])
-        y = T.([3,4,5])
-        @test axpby!(alpha,AT(x),beta,AT(y)) ≈ T.([7,10,13])
-        @test axpy!(alpha,AT(x),AT(y)) ≈ T.([8,12,16])
+        @test compare(axpby!, AT, Ref(rand(T)), rand(T,5), Ref(rand(T)), rand(T,5))
+        @test compare(axpy!, AT, Ref(rand(T)), rand(T,5), rand(T,5))
     end
 
     @testset "dot" for T in eltypes
-        x = rand(T, 5)
-        y = rand(T, 5)
-        @test dot(AT(x), AT(y)) ≈ dot(x, y)
+        @test compare(dot, AT, rand(T,5), rand(T, 5))
     end
 
     @testset "iszero and isone" for T in eltypes

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -221,12 +221,12 @@
         @test compare(lmul!, AT, Ref(rand(T)), rand(T, b))
     end
 
-    @testset "axp{b}y" for T in eltypes
+    @testset "axp{b}y" for T in (Float32, ComplexF32)
         @test compare(axpby!, AT, Ref(rand(T)), rand(T,5), Ref(rand(T)), rand(T,5))
         @test compare(axpy!, AT, Ref(rand(T)), rand(T,5), rand(T,5))
     end
 
-    @testset "dot" for T in eltypes
+    @testset "dot" for T in (Float32, ComplexF32)
         @test compare(dot, AT, rand(T,5), rand(T, 5))
     end
 


### PR DESCRIPTION
`dot(x,y)` is not working with `oneVector` and `MtlVector` types.
This PR add a generic fallback.

I also fixed the tests with `axpy!` / `axpby!` functions.