### PR TITLE
2-arg show for GPUArray

### DIFF
--- a/src/host/abstractarray.jl
+++ b/src/host/abstractarray.jl
@@ -27,12 +27,21 @@ Base.print_array(io::IO, X::AnyGPUArray) =
     Base.print_array(io, adapt(ToArray(), X))
 
 # show
-Base._show_nonempty(io::IO, X::AnyGPUArray, prefix::String) =
+function Base._show_nonempty(io::IO, X::AnyGPUArray, prefix::String)
+    print(io, typeof(X).name.name, "(")
     Base._show_nonempty(io, adapt(ToArray(), X), prefix)
-Base._show_empty(io::IO, X::AnyGPUArray) =
+    print(io, ")")
+end
+function Base._show_empty(io::IO, X::AnyGPUArray)
+    print(io, typeof(X).name.name, "(")
     Base._show_empty(io, adapt(ToArray(), X))
-Base.show_vector(io::IO, v::AnyGPUArray, args...) =
+    print(io, ")")
+end
+function Base.show_vector(io::IO, v::AnyGPUArray, args...)
+    print(io, typeof(v).name.name, "(")
     Base.show_vector(io, adapt(ToArray(), v), args...)
+    print(io, ")")
+end
 
 ## collect to CPU (discarding wrapper type)
 

--- a/src/host/abstractarray.jl
+++ b/src/host/abstractarray.jl
@@ -142,12 +142,21 @@ Base.print_array(io::IO, @nospecialize(X::AnyGPUArray)) =
     Base.print_array(io, adapt(ToArray(), X))
 
 # show
-Base._show_nonempty(io::IO, @nospecialize(X::AnyGPUArray), prefix::String) =
+function Base._show_nonempty(io::IO, @nospecialize(X::AnyGPUArray), prefix::String)
+    print(io, typeof(X).name.name, "(")
     Base._show_nonempty(io, adapt(ToArray(), X), prefix)
-Base._show_empty(io::IO, @nospecialize(X::AnyGPUArray)) =
+    print(io, ")")
+end
+function Base._show_empty(io::IO, @nospecialize(X::AnyGPUArray))
+    print(io, typeof(X).name.name, "(")
     Base._show_empty(io, adapt(ToArray(), X))
-Base.show_vector(io::IO, @nospecialize(v::AnyGPUArray), args...) =
+    print(io, ")")
+end
+function Base.show_vector(io::IO, @nospecialize(v::AnyGPUArray), args...)
+    print(io, typeof(v).name.name, "(")
     Base.show_vector(io, adapt(ToArray(), v), args...)
+    print(io, ")")
+end
 
 ## collect to CPU (discarding wrapper type)
 

--- a/test/testsuite/base.jl
+++ b/test/testsuite/base.jl
@@ -283,13 +283,13 @@ end
             # due to different definition of `Int` type
             # print([1]) shows as [1] on 64bit but Int64[1] on 32bit
             msg = showstr(A)
-            @test occursin("[1]", msg) || occursin("Int64[1]", msg)
+            @test occursin("([1])", msg) || occursin("(Int64[1])", msg)
 
             msg = replstr(B)
             @test occursin(Regex("^2×2 $AT{Int64,\\s?2.*}:\n 1  2\n 3  4\$"), msg)
 
             msg = showstr(B)
-            @test occursin("[1 2; 3 4]", msg) || occursin("Int64[1 2; 3 4]", msg)
+            @test occursin("([1 2; 3 4])", msg) || occursin("(Int64[1 2; 3 4])", msg)
 
             # the printing of Adjoint depends on global state
             msg = replstr(A')

--- a/test/testsuite/base.jl
+++ b/test/testsuite/base.jl
@@ -283,13 +283,13 @@ end
             # due to different definition of `Int` type
             # print([1]) shows as [1] on 64bit but Int64[1] on 32bit
             msg = showstr(A)
-            @test occursin(msg, "[1]") || occursin(msg, "Int64[1]")
+            @test occursin("[1]", msg) || occursin("Int64[1]", msg)
 
             msg = replstr(B)
             @test occursin(Regex("^2×2 $AT{Int64,\\s?2.*}:\n 1  2\n 3  4\$"), msg)
 
             msg = showstr(B)
-            @test occursin(msg, "[1 2; 3 4]") || occursin(msg, "Int64[1 2; 3 4]")
+            @test occursin("[1 2; 3 4]", msg) || occursin("Int64[1 2; 3 4]", msg)
 
             # the printing of Adjoint depends on global state
             msg = replstr(A')

--- a/test/testsuite/base.jl
+++ b/test/testsuite/base.jl
@@ -283,13 +283,13 @@ end
             # due to different definition of `Int` type
             # print([1]) shows as [1] on 64bit but Int64[1] on 32bit
             msg = showstr(A)
-            @test msg == "[1]" || msg == "Int64[1]"
+            @test occursin(msg, "[1]") || occursin(msg, "Int64[1]")
 
             msg = replstr(B)
             @test occursin(Regex("^2×2 $AT{Int64,\\s?2.*}:\n 1  2\n 3  4\$"), msg)
 
             msg = showstr(B)
-            @test msg == "[1 2; 3 4]" || msg == "Int64[1 2; 3 4]"
+            @test occursin(msg, "[1 2; 3 4]") || occursin(msg, "Int64[1 2; 3 4]")
 
             # the printing of Adjoint depends on global state
             msg = replstr(A')

--- a/test/testsuite/base.jl
+++ b/test/testsuite/base.jl
@@ -367,13 +367,13 @@ end
             # due to different definition of `Int` type
             # print([1]) shows as [1] on 64bit but Int64[1] on 32bit
             msg = showstr(A)
-            @test occursin("[1]", msg) || occursin("Int64[1]", msg)
+            @test occursin("([1])", msg) || occursin("(Int64[1])", msg)
 
             msg = replstr(B)
             @test occursin(Regex("^2×2 $AT{Int64,\\s?2.*}:\n 1  2\n 3  4\$"), msg)
 
             msg = showstr(B)
-            @test occursin("[1 2; 3 4]", msg) || occursin("Int64[1 2; 3 4]", msg)
+            @test occursin("([1 2; 3 4])", msg) || occursin("(Int64[1 2; 3 4])", msg)
 
             # the printing of Adjoint depends on global state
             msg = replstr(A')

--- a/test/testsuite/base.jl
+++ b/test/testsuite/base.jl
@@ -367,13 +367,13 @@ end
             # due to different definition of `Int` type
             # print([1]) shows as [1] on 64bit but Int64[1] on 32bit
             msg = showstr(A)
-            @test occursin("([1])", msg) || occursin("(Int64[1])", msg)
+            AT != Array && @test occursin("([1])", msg) || occursin("(Int64[1])", msg)
 
             msg = replstr(B)
             @test occursin(Regex("^2×2 $AT{Int64,\\s?2.*}:\n 1  2\n 3  4\$"), msg)
 
             msg = showstr(B)
-            @test occursin("([1 2; 3 4])", msg) || occursin("(Int64[1 2; 3 4])", msg)
+            AT != Array && @test occursin("([1 2; 3 4])", msg) || occursin("(Int64[1 2; 3 4])", msg)
 
             # the printing of Adjoint depends on global state
             msg = replstr(A')
@@ -406,7 +406,7 @@ end
       @testset "selectdim" begin
         @test compare(x -> selectdim(x, 3, 1), AT, rand(Float32, 2, 2, 2))
         let x = AT(rand(Float32, 5, 4, 3))
-          @test typeof(selectdim(x, 3, 1)) == typeof(view(x, :, :, 1))         
+          @test typeof(selectdim(x, 3, 1)) == typeof(view(x, :, :, 1))
           @test typeof(selectdim(x, 2, 1)) == typeof(view(x, :, 1, :))
         end
       end

--- a/test/testsuite/base.jl
+++ b/test/testsuite/base.jl
@@ -367,13 +367,13 @@ end
             # due to different definition of `Int` type
             # print([1]) shows as [1] on 64bit but Int64[1] on 32bit
             msg = showstr(A)
-            @test msg == "[1]" || msg == "Int64[1]"
+            @test occursin(msg, "[1]") || occursin(msg, "Int64[1]")
 
             msg = replstr(B)
             @test occursin(Regex("^2×2 $AT{Int64,\\s?2.*}:\n 1  2\n 3  4\$"), msg)
 
             msg = showstr(B)
-            @test msg == "[1 2; 3 4]" || msg == "Int64[1 2; 3 4]"
+            @test occursin(msg, "[1 2; 3 4]") || occursin(msg, "Int64[1 2; 3 4]")
 
             # the printing of Adjoint depends on global state
             msg = replstr(A')

--- a/test/testsuite/base.jl
+++ b/test/testsuite/base.jl
@@ -367,13 +367,13 @@ end
             # due to different definition of `Int` type
             # print([1]) shows as [1] on 64bit but Int64[1] on 32bit
             msg = showstr(A)
-            @test occursin(msg, "[1]") || occursin(msg, "Int64[1]")
+            @test occursin("[1]", msg) || occursin("Int64[1]", msg)
 
             msg = replstr(B)
             @test occursin(Regex("^2×2 $AT{Int64,\\s?2.*}:\n 1  2\n 3  4\$"), msg)
 
             msg = showstr(B)
-            @test occursin(msg, "[1 2; 3 4]") || occursin(msg, "Int64[1 2; 3 4]")
+            @test occursin("[1 2; 3 4]", msg) || occursin("Int64[1 2; 3 4]", msg)
 
             # the printing of Adjoint depends on global state
             msg = replstr(A')


### PR DESCRIPTION
Replaces https://github.com/JuliaGPU/CUDA.jl/pull/1197 with a more generic version:
```julia
julia> using JLArrays

julia> (x=[1.0], y=[2f0 3f0])  # Arrays
(x = [1.0], y = Float32[2.0 3.0])

julia> map(jl, ans)  # previously looked identical
(x = JLArray([1.0]), y = JLArray(Float32[2.0 3.0]))
```

This sort-of assumes `typeof(A).name.name` is a reasonable constructor. 

Unlike https://github.com/JuliaGPU/CUDA.jl/pull/1197, this is going to print `CuArray(Float32[2.0 3.0])` rather than shortening to `cu([2.0 3.0])`.