### PR TITLE
Make sure diagonal elements are non-zero

### DIFF
--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -126,12 +126,8 @@
 
         @testset "cholesky + Diagonal" begin
             n = 128
-            
-            # To prevent failures due to random numbers being zero
-            d = AT(zeros(Float32, n))
-            while any(iszero, d)
-                d = AT(rand(Float32, n))
-            end
+            # Add one in order prevent failures due to random numbers being zero
+            d = AT(zeros(Float32, n) .+ one(Float32))
             D = Diagonal(d)
             F = collect(D)
             @test collect(cholesky(D).U) ≈ collect(cholesky(F).U)

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -126,7 +126,12 @@
 
         @testset "cholesky + Diagonal" begin
             n = 128
-            d = AT(rand(Float32, n))
+            
+            # To prevent failures due to random numbers being zero
+            d = AT(zeros(Float32, n))
+            while any(iszero, d)
+                d = AT(rand(Float32, n))
+            end
             D = Diagonal(d)
             F = collect(D)
             @test collect(cholesky(D).U) ≈ collect(cholesky(F).U)


### PR DESCRIPTION
This addresses item no. 2 of #434. Previously, the test assumed that all random numbers would be positive, which occasionally was not the case. By repeatedly re-generating the numbers until all are positive, this should not happen again.

There may be a random number generator issue behind this.