### PR TITLE
Fix right-hand side multiplication by complex Diagonal matrix

### DIFF
--- a/src/host/linalg.jl
+++ b/src/host/linalg.jl
@@ -212,7 +212,7 @@ else
         m′, n′ = size(B, 1), size(B, 2)
         n == d || throw(DimensionMismatch("left hand side has $n columns but D is $d by $d"))
         (m, n) == (m′, n′) || throw(DimensionMismatch("expect output to be $m by $n, but got $m′ by $n′"))
-        @. B' = dd * A'
+        B .= A .* transpose(dd)
 
         B
     end
@@ -228,7 +228,7 @@ else
         m′, n′ = size(B, 1), size(B, 2)
         n == d || throw(DimensionMismatch("left hand side has $n columns but D is $d by $d"))
         (m, n) == (m′, n′) || throw(DimensionMismatch("expect output to be $m by $n, but got $m′ by $n′"))
-        @. B' = α * dd * A' + β * B'
+        B .= α * A .* transpose(dd) + β * B
 
         B
     end

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -154,26 +154,28 @@
         end
 
         @testset "mul! + Diagonal" begin
-            n = 128
-            d = AT(rand(Float32, n))
-            D = Diagonal(d)
-            B = AT(rand(Float32, n, n))
-            X = AT(zeros(Float32, n, n))
-            Y = zeros(Float32, n, n)
-            α = rand(Float32)
-            β = rand(Float32)
-            mul!(X, D, B)
-            mul!(Y, Diagonal(collect(d)), collect(B))
-            @test collect(X) ≈ Y
-            mul!(X, D, B, α, β)
-            mul!(Y, Diagonal(collect(d)), collect(B), α, β)
-            @test collect(X) ≈ Y
-            mul!(X, B, D)
-            mul!(Y, collect(B), Diagonal(collect(d)))
-            @test collect(X) ≈ Y
-            mul!(X, B, D, α, β)
-            mul!(Y, collect(B), Diagonal(collect(d)), α, β)
-            @test collect(X) ≈ Y
+            for elty in (Float32, ComplexF32)
+                n = 128
+                d = AT(rand(elty, n))
+                D = Diagonal(d)
+                B = AT(rand(elty, n, n))
+                X = AT(zeros(elty, n, n))
+                Y = zeros(elty, n, n)
+                α = rand(elty)
+                β = rand(elty)
+                mul!(X, D, B)
+                mul!(Y, Diagonal(collect(d)), collect(B))
+                @test collect(X) ≈ Y
+                mul!(X, D, B, α, β)
+                mul!(Y, Diagonal(collect(d)), collect(B), α, β)
+                @test collect(X) ≈ Y
+                mul!(X, B, D)
+                mul!(Y, collect(B), Diagonal(collect(d)))
+                @test collect(X) ≈ Y
+                mul!(X, B, D, α, β)
+                mul!(Y, collect(B), Diagonal(collect(d)), α, β)
+                @test collect(X) ≈ Y
+            end
         end
 
         @testset "ldiv! + Diagonal" begin


### PR DESCRIPTION
I noticed this bug when working on [this issue](https://github.com/JuliaGPU/CUDA.jl/pull/1683).
Currently, multiplying on the right by a Diagonal complex matrix yields the wrong result on julia 1.8. This is because, when adding compatibility for this version in https://github.com/JuliaGPU/GPUArrays.jl/pull/425, right-hand side multiplication was defined as
`B' = dd * A'`
This means that `B = A * dd'`: currently, computing `A*D` where `D` is diagonal actually returns `A*adjoint(D)`. Although this is fine for real numbers, this means we compute the wrong result for complex matrices. This PR aims to fix this, by using transpose instead of adjoint.

I also added a few tests: currently, only real matrices are tested, hence why this bug hasn't been detected. Now, we test for both complex and floats.