### PR TITLE
Use while loop instead of for-range loop in broadcast kernel

### DIFF
--- a/src/host/broadcast.jl
+++ b/src/host/broadcast.jl
@@ -52,7 +52,9 @@ end
 
     # grid-stride kernel
     function broadcast_kernel(ctx, dest, bc′, nelem)
-        for i in 1:nelem
+        i = 0
+        while i < nelem
+            i += 1
             I = @cartesianidx(dest, i)
             @inbounds dest[I] = bc′[I]
         end


### PR DESCRIPTION
This reduces the overhead incurred by the broadcast kernel over a handwritten kernel (at sufficiently large array sizes) by 10-15%.

These benchmarks are ran on a M1 Pro laptop. Unfortunately I don't have a CUDA device.
First number is the speed of a handwritten addition kernel. Second number is the speed of `@. c = a + b`.

=== Without the patch, at [GPUArrays.jl 9de29752376109589a60a6d5656adf12818ac3af](https://github.com/JuliaGPU/GPUArrays.jl/commit/9de29752376109589a60a6d5656adf12818ac3af)

```julia
julia> include("bench.jl")
bench (generic function with 1 method)

julia> bench(1024*1000)
  281.125 μs (160 allocations: 4.16 KiB)
  338.750 μs (202 allocations: 6.05 KiB)

julia> bench(1024*10000)
  631.792 μs (160 allocations: 4.16 KiB)
  834.750 μs (202 allocations: 6.05 KiB)

julia> bench(1024*100000)
  3.620 ms (160 allocations: 4.16 KiB)
  5.547 ms (202 allocations: 6.05 KiB)
```

=== With the patch

```julia
julia> include("bench.jl")
[ Info: Precompiling Metal [dde4c033-4e86-420c-a63e-0dd931031962]
bench (generic function with 1 method)

julia> bench(1024*1000)
  280.334 μs (160 allocations: 4.16 KiB)
  334.500 μs (202 allocations: 6.05 KiB)

julia> bench(1024*10000)
  641.875 μs (160 allocations: 4.16 KiB)
  807.333 μs (202 allocations: 6.05 KiB)

julia> bench(1024*100000)
  3.581 ms (160 allocations: 4.16 KiB)
  5.268 ms (202 allocations: 6.05 KiB)
```

=== bench.jl contents

```julia
using Metal, BenchmarkTools

function setup(n)
  a = MtlArray(rand(Float16, n))
  b = MtlArray(rand(Float16, n))
  c = MtlArray(zeros(Float16, n))
  return (a, b, c)
end

function add(a, b, c)
  i = thread_position_in_grid_1d()
  c[i] = a[i] + b[i]
  return
end

function kernel_add(a, b, c, n)
  @Metal.sync begin
    @metal threads=1024 grid=Int(n/1024) add(a, b, c)
  end
end

function broadcast_add(a, b, c)
  @Metal.sync begin
    @. c = a + b
  end
end

function bench(n)
  a, b, c = setup(n)
  @btime kernel_add($a, $b, $c, $n)
  @btime broadcast_add($a, $b, $c)
  return
end
```