### PR TITLE
Allow scalar iteration in the REPL on 1.9+.

### DIFF
--- a/lib/GPUArraysCore/src/GPUArraysCore.jl
+++ b/lib/GPUArraysCore/src/GPUArraysCore.jl
@@ -97,7 +97,7 @@ end
 Assert that a certain operation `op` performs scalar indexing. If this is not allowed, an
 error will be thrown ([`allowscalar`](@ref)).
 """
-function assertscalar(op = "operation")
+function assertscalar(op::String)
     behavior = get(task_local_storage(), :ScalarIndexing, nothing)
     if behavior === nothing
         behavior = requested_scalar_indexing[]

--- a/lib/GPUArraysCore/src/GPUArraysCore.jl
+++ b/lib/GPUArraysCore/src/GPUArraysCore.jl
@@ -117,7 +117,7 @@ function assertscalar(op = "operation")
 end
 
 @noinline function _assertscalar(op, behavior)
-    desc = """Invocation of $op resulted in scalar indexing of a GPU array.
+    desc = """Invocation of '$op' resulted in scalar indexing of a GPU array.
               This is typically caused by calling an iterating implementation of a method.
               Such implementations *do not* execute on the GPU, but very slowly on the CPU,
               and therefore should be avoided.

--- a/lib/GPUArraysCore/src/GPUArraysCore.jl
+++ b/lib/GPUArraysCore/src/GPUArraysCore.jl
@@ -28,6 +28,7 @@ const AnyGPUArray{T,N} = Union{AbstractGPUArray{T,N}, WrappedGPUArray{T,N}}
 const AnyGPUVector{T} = AnyGPUArray{T, 1}
 const AnyGPUMatrix{T} = AnyGPUArray{T, 2}
 
+
 ## broadcasting
 
 """
@@ -37,6 +38,7 @@ Downstream implementations should provide a concrete array style type that inher
 this supertype.
 """
 abstract type AbstractGPUArrayStyle{N} <: Base.Broadcast.AbstractArrayStyle{N} end
+
 
 ## scalar iteration
 
@@ -49,56 +51,36 @@ export allowscalar, @allowscalar, assertscalar
 const default_scalar_indexing = Ref{Union{Nothing,ScalarIndexing}}(nothing)
 
 """
-    allowscalar() do
-        # code that can use scalar indexing
-    end
-
-Denote which operations can use scalar indexing.
-
-See also: [`@allowscalar`](@ref).
-"""
-function allowscalar(f::Base.Callable)
-    task_local_storage(f, :ScalarIndexing, ScalarAllowed)
-end
-
-"""
-    allowscalar(::Bool)
-
-Calling this with `false` replaces the default warning about scalar indexing
-(show once per session) with an error.
-
-Instead of calling this with `true`, the preferred style is to allow this locally.
-This can be done with the `allowscalar(::Function)` method (with a `do` block)
-or with the [`@allowscalar`](@ref) macro.
-
-Writes to `task_local_storage` for `:ScalarIndexing`. The default is `:ScalarWarn`,
-and this function sets `:ScalarAllowed` or `:ScalarDisallowed`.
-"""
-function allowscalar(allow::Bool=true)
-    if allow
-        Base.depwarn("allowscalar([true]) is deprecated, use `allowscalar() do end` or `@allowscalar` to denote exactly which operations can use scalar operations.", :allowscalar)
-    end
-    setting = allow ? ScalarAllowed : ScalarDisallowed
-    task_local_storage(:ScalarIndexing, setting)
-    default_scalar_indexing[] = setting
-    return
-end
-
-"""
     assertscalar(op::String)
 
 Assert that a certain operation `op` performs scalar indexing. If this is not allowed, an
 error will be thrown ([`allowscalar`](@ref)).
 """
 function assertscalar(op = "operation")
+    # try to detect the REPL
+    @static if VERSION >= v"1.10.0-DEV.444" || v"1.9-beta4" <= VERSION < v"1.10-"
+        if isdefined(Base, :active_repl) && current_task() == Base.active_repl.frontend_task
+            # we always allow scalar iteration on the REPL's frontend task,
+            # where we often trigger scalar indexing by displaying GPU objects.
+            return false
+        end
+        default_behavior = ScalarDisallowed
+    else
+        # we can't detect the REPL, but it will only be used in interactive sessions,
+        # so default to allowing scalar indexing there (but warn).
+        default_behavior = isinteractive() ? ScalarWarn : ScalarDisallowed
+    end
+
     val = get!(task_local_storage(), :ScalarIndexing) do
-        something(default_scalar_indexing[], isinteractive() ? ScalarWarn : ScalarDisallowed)
+        something(default_scalar_indexing[], default_behavior)
     end
     desc = """Invocation of $op resulted in scalar indexing of a GPU array.
               This is typically caused by calling an iterating implementation of a method.
               Such implementations *do not* execute on the GPU, but very slowly on the CPU,
-              and therefore are only permitted from the REPL for prototyping purposes.
-              If you did intend to index this array, annotate the caller with @allowscalar."""
+              and therefore should be avoided.
+
+              If you want to allow scalar iteration, use `allowscalar` or `@allowscalar`
+              to enable scalar iteration globally or for the operations in question."""
     if val == ScalarDisallowed
         error("""Scalar indexing is disallowed.
                  $desc""")
@@ -121,6 +103,34 @@ macro __tryfinally(ex, fin)
 end
 
 """
+    allowscalar([true])
+    allowscalar([true]) do
+        ...
+    end
+
+Use this function to allow or disallow scalar indexing, either globall or for the
+duration of the do block.
+
+See also: [`@allowscalar`](@ref).
+"""
+allowscalar
+
+function allowscalar(f::Base.Callable)
+    task_local_storage(f, :ScalarIndexing, ScalarAllowed)
+end
+
+function allowscalar(allow::Bool=true)
+    if allow
+        @warn """It's not recommended to use allowscalar([true]) to allow scalar indexing.
+                 Instead, use `allowscalar() do end` or `@allowscalar` to denote exactly which operations can use scalar operations.""" maxlog=1
+    end
+    setting = allow ? ScalarAllowed : ScalarDisallowed
+    task_local_storage(:ScalarIndexing, setting)
+    default_scalar_indexing[] = setting
+    return
+end
+
+"""
     @allowscalar() begin
         # code that can use scalar indexing
     end
@@ -138,6 +148,9 @@ macro allowscalar(ex)
                                            : task_local_storage(:ScalarIndexing, tls_value))
     end
 end
+
+
+## other
 
 """
     backend(T::Type)


### PR DESCRIPTION
Thanks to https://github.com/JuliaLang/julia/pull/48400, we can now detect the REPL task and tweak how scalar indexing is treated. Specifically, I think we should allow scalar iteration in the REPL's frontend task, which is only going to be used to render objects (a common source of scalar iteration). Current GPUArrays already tried to do this by checking `isinteractive()`, but since that may be a false positive, we were still warning about scalar iteration.

Old behavior, with JLArrays' output functions disabled (and `show` hence triggering scalar iteration):

```# trigger scalar iteration on a REPL task
julia> jl([1])
1-element JLArray{Int64, 1}:
┌ Warning: Performing scalar indexing on task Task (runnable) @0x00007f0e401b4650.
│ Invocation of getindex resulted in scalar indexing of a GPU array.
│ This is typically caused by calling an iterating implementation of a method.
│ Such implementations *do not* execute on the GPU, but very slowly on the CPU,
│ and therefore should be avoided.
│
│ If you want to allow scalar iteration, use `allowscalar` or `@allowscalar`
│ to enable scalar iteration globally or for the operations in question.
└ @ GPUArraysCore ~/Julia/pkg/GPUArrays/lib/GPUArraysCore/src/GPUArraysCore.jl:85
 1

# trigger scalar iteration on a non-REPL task
julia> jl([1])[1]
┌ Warning: Performing scalar indexing on task Task (runnable) @0x00007f10049fc010.
│ Invocation of getindex resulted in scalar indexing of a GPU array.
│ This is typically caused by calling an iterating implementation of a method.
│ Such implementations *do not* execute on the GPU, but very slowly on the CPU,
│ and therefore should be avoided.
│
│ If you want to allow scalar iteration, use `allowscalar` or `@allowscalar`
│ to enable scalar iteration globally or for the operations in question.
└ @ GPUArraysCore ~/Julia/pkg/GPUArrays/lib/GPUArraysCore/src/GPUArraysCore.jl:85
1

# do that again (to show that the warning is only emitted once)
julia> jl([1])[1]
1
```

New behavior:

```
julia> jl([1])
1-element JLArray{Int64, 1}:
 1

julia> jl([1])[1]
ERROR: Scalar indexing is disallowed.
Invocation of getindex resulted in scalar indexing of a GPU array.
This is typically caused by calling an iterating implementation of a method.
Such implementations *do not* execute on the GPU, but very slowly on the CPU,
and therefore should be avoided.

If you want to allow scalar iteration, use `allowscalar` or `@allowscalar`
to enable scalar iteration globally or for the operations in question.
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] assertscalar(op::String)
   @ GPUArraysCore ~/Julia/pkg/GPUArrays/lib/GPUArraysCore/src/GPUArraysCore.jl:82
 [3] getindex(xs::JLArray{Int64, 1}, I::Int64)
   @ GPUArrays ~/Julia/pkg/GPUArrays/src/host/indexing.jl:9
 [4] top-level scope
   @ REPL[3]:1
```

Fixes https://github.com/JuliaGPU/GPUArrays.jl/issues/446