### PR TITLE
Add previously missing @test macro to math/power tests

### DIFF
--- a/test/testsuite/math.jl
+++ b/test/testsuite/math.jl
@@ -17,7 +17,7 @@ end
 @testsuite "math/power" (AT, eltypes)->begin
     for ET in eltypes
         for p in 0:5
-            compare(x->x^p, AT, rand(ET, 2,2))
+            @test compare(x->x^p, AT, rand(ET, 2,2))
         end
     end
 end


### PR DESCRIPTION
I noticed that math/power always had no tests run so I checked it out and the @test macro was missing.