### PR TITLE
Avoid cartesian iteration where possible.

### DIFF
--- a/src/host/math.jl
+++ b/src/host/math.jl
@@ -2,7 +2,7 @@
 
 function Base.clamp!(A::AnyGPUArray, low, high)
     gpu_call(A, low, high) do ctx, A, low, high
-        I = @cartesianidx A
+        I = @linearidx A
         A[I] = clamp(A[I], low, high)
         return
     end


### PR DESCRIPTION
Re-land #454, which turned out problematic: Broke Flux.jl (https://github.com/FluxML/Flux.jl/issues/2214), CUDA.jl (https://buildkite.com/julialang/cuda-dot-jl/builds/3750), and causes excessive compilation with Transformers.jl (https://github.com/JuliaGPU/GPUArrays.jl/pull/454#issuecomment-1475116479).

TODO: look into these failures.

cc @maxwindiff 