### PR TITLE
Port storage handling + wrapper materialization from CUDA.jl.

### DIFF
--- a/src/host/abstractarray.jl
+++ b/src/host/abstractarray.jl
@@ -15,9 +15,10 @@ export DataRef
 # - `ref[]`: get the data;
 # - `copy(ref)`: create a new reference, increasing the reference count;
 # - `unsafe_free!(ref)`: decrease the reference count, and free the data if it reaches 0.
-# Do not use the contained directly.
+#
+# The contained RefCounted struct should not be used directly.
 
-# structure shared across objects that reference the same data
+# shared, reference-counted state.
 mutable struct RefCounted{D}
   obj::D
   finalizer
@@ -50,8 +51,9 @@ function Base.getindex(rc::RefCounted)
     rc.obj
 end
 
-# per-object structure; `freed` here indicates whether the *object* has been freed.
-# this is separate from the contained refcount, which protects the underlying data.
+# per-object state, with a flag to indicate whether the object has been freed.
+# this is to support multiple calls to `unsafe_free!` on the same object,
+# while only lowering the referene count of the underlying data once.
 mutable struct DataRef{D}
     rc::RefCounted{D}
     freed::Bool

--- a/src/host/abstractarray.jl
+++ b/src/host/abstractarray.jl
@@ -32,13 +32,13 @@ function retain(rc::RefCounted)
     return
 end
 
-function release(rc::RefCounted)
+function release(rc::RefCounted, args...)
     if rc.count[] == 0
         throw(ArgumentError("Attempt to release freed data."))
     end
     refcount = Threads.atomic_add!(rc.count, -1)
     if refcount == 1 && rc.finalizer !== nothing
-        rc.finalizer(rc.obj)
+        rc.finalizer(rc.obj, args...)
     end
     return
 end

--- a/src/host/base.jl
+++ b/src/host/base.jl
@@ -121,6 +121,7 @@ function _RepeatInnerOuter.repeat_outer(xs::AnyGPUArray{<:Any, 2}, dims::NTuple{
     return repeat_outer(xs, dims)
 end
 
+
 ## PermutedDimsArrays
 
 using Base: PermutedDimsArrays
@@ -131,6 +132,7 @@ function PermutedDimsArrays._copy!(dest::PermutedDimsArray{T,N,<:Any,<:Any,<:Abs
     dest
 end
 
+
 ## concatenation
 
 # hacky overloads to make simple vcat and hcat with numbers work as expected.
@@ -140,3 +142,199 @@ end
     vcat(fill!(similar(b, typeof(a), (1,size(b)[2:end]...)), a), b)
 @inline Base.hcat(a::Number, b::AbstractGPUArray) =
     hcat(fill!(similar(b, typeof(a), (size(b)[1:end-1]...,1)), a), b)
+
+
+## reshape
+
+function Base.reshape(a::AbstractGPUArray{T,M}, dims::NTuple{N,Int}) where {T,N,M}
+  if prod(dims) != length(a)
+      throw(DimensionMismatch("new dimensions $(dims) must be consistent with array size $(size(a))"))
+  end
+
+  if N == M && dims == size(a)
+      return a
+  end
+
+  derive(T, N, a, dims, 0)
+end
+
+
+## reinterpret
+
+function Base.reinterpret(::Type{T}, a::AbstractGPUArray{S,N}) where {T,S,N}
+  err = _reinterpret_exception(T, a)
+  err === nothing || throw(err)
+
+  if sizeof(T) == sizeof(S) # for N == 0
+    osize = size(a)
+  else
+    isize = size(a)
+    size1 = div(isize[1]*sizeof(S), sizeof(T))
+    osize = tuple(size1, Base.tail(isize)...)
+  end
+
+  return derive(T, N, a, osize, 0)
+end
+
+function _reinterpret_exception(::Type{T}, a::AbstractArray{S,N}) where {T,S,N}
+  if !isbitstype(T) || !isbitstype(S)
+    return ReinterpretBitsTypeError{T,typeof(a)}()
+  end
+  if N == 0 && sizeof(T) != sizeof(S)
+    return ReinterpretZeroDimError{T,typeof(a)}()
+  end
+  if N != 0 && sizeof(S) != sizeof(T)
+      ax1 = axes(a)[1]
+      dim = length(ax1)
+      if Base.rem(dim*sizeof(S),sizeof(T)) != 0
+        return ReinterpretDivisibilityError{T,typeof(a)}(dim)
+      end
+      if first(ax1) != 1
+        return ReinterpretFirstIndexError{T,typeof(a),typeof(ax1)}(ax1)
+      end
+  end
+  return nothing
+end
+
+struct ReinterpretBitsTypeError{T,A} <: Exception end
+function Base.showerror(io::IO, ::ReinterpretBitsTypeError{T, <:AbstractArray{S}}) where {T, S}
+  print(io, "cannot reinterpret an `$(S)` array to `$(T)`, because not all types are bitstypes")
+end
+
+struct ReinterpretZeroDimError{T,A} <: Exception end
+function Base.showerror(io::IO, ::ReinterpretZeroDimError{T, <:AbstractArray{S,N}}) where {T, S, N}
+  print(io, "cannot reinterpret a zero-dimensional `$(S)` array to `$(T)` which is of a different size")
+end
+
+struct ReinterpretDivisibilityError{T,A} <: Exception
+  dim::Int
+end
+function Base.showerror(io::IO, err::ReinterpretDivisibilityError{T, <:AbstractArray{S,N}}) where {T, S, N}
+  dim = err.dim
+  print(io, """
+      cannot reinterpret an `$(S)` array to `$(T)` whose first dimension has size `$(dim)`.
+      The resulting array would have non-integral first dimension.
+      """)
+end
+
+struct ReinterpretFirstIndexError{T,A,Ax1} <: Exception
+  ax1::Ax1
+end
+function Base.showerror(io::IO, err::ReinterpretFirstIndexError{T, <:AbstractArray{S,N}}) where {T, S, N}
+  ax1 = err.ax1
+  print(io, "cannot reinterpret a `$(S)` array to `$(T)` when the first axis is $ax1. Try reshaping first.")
+end
+
+
+## reinterpret(reshape)
+
+function Base.reinterpret(::typeof(reshape), ::Type{T}, a::AbstractGPUArray) where {T}
+  N, osize = _base_check_reshape_reinterpret(T, a)
+  return derive(T, N, a, osize, 0)
+end
+
+# taken from reinterpretarray.jl
+# TODO: move these Base definitions out of the ReinterpretArray struct for reuse
+function _base_check_reshape_reinterpret(::Type{T}, a::AbstractGPUArray{S}) where {T,S}
+  isbitstype(T) || throwbits(S, T, T)
+  isbitstype(S) || throwbits(S, T, S)
+  if sizeof(S) == sizeof(T)
+      N = ndims(a)
+      osize = size(a)
+  elseif sizeof(S) > sizeof(T)
+      d, r = divrem(sizeof(S), sizeof(T))
+      r == 0 || throwintmult(S, T)
+      N = ndims(a) + 1
+      osize = (d, size(a)...)
+  else
+      d, r = divrem(sizeof(T), sizeof(S))
+      r == 0 || throwintmult(S, T)
+      N = ndims(a) - 1
+      N > -1 || throwsize0(S, T, "larger")
+      axes(a, 1) == Base.OneTo(sizeof(T) ÷ sizeof(S)) || throwsize1(a, T)
+      osize = size(a)[2:end]
+  end
+  return N, osize
+end
+
+@noinline function throwbits(S::Type, T::Type, U::Type)
+  throw(ArgumentError("cannot reinterpret `$(S)` as `$(T)`, type `$(U)` is not a bits type"))
+end
+
+@noinline function throwintmult(S::Type, T::Type)
+  throw(ArgumentError("`reinterpret(reshape, T, a)` requires that one of `sizeof(T)` (got $(sizeof(T))) and `sizeof(eltype(a))` (got $(sizeof(S))) be an integer multiple of the other"))
+end
+
+@noinline function throwsize0(S::Type, T::Type, msg)
+  throw(ArgumentError("cannot reinterpret a zero-dimensional `$(S)` array to `$(T)` which is of a $msg size"))
+end
+
+@noinline function throwsize1(a::AbstractArray, T::Type)
+    throw(ArgumentError("`reinterpret(reshape, $T, a)` where `eltype(a)` is $(eltype(a)) requires that `axes(a, 1)` (got $(axes(a, 1))) be equal to 1:$(sizeof(T) ÷ sizeof(eltype(a))) (from the ratio of element sizes)"))
+end
+
+
+## views
+
+struct Contiguous end
+struct NonContiguous end
+
+# NOTE: this covers more cases than the I<:... in Base.FastContiguousSubArray
+GPUIndexStyle() = Contiguous()
+GPUIndexStyle(I...) = NonContiguous()
+GPUIndexStyle(::Union{Base.ScalarIndex, CartesianIndex}...) = Contiguous()
+GPUIndexStyle(i1::Colon, ::Union{Base.ScalarIndex, CartesianIndex}...) = Contiguous()
+GPUIndexStyle(i1::AbstractUnitRange, ::Union{Base.ScalarIndex, CartesianIndex}...) = Contiguous()
+GPUIndexStyle(i1::Colon, I...) = GPUIndexStyle(I...)
+
+viewlength() = ()
+@inline viewlength(::Real, I...) = viewlength(I...) # skip scalar
+
+if VERSION >= v"1.8.0-DEV.120"
+@inline viewlength(i1::AbstractUnitRange, I...) = (Base.length(i1), viewlength(I...)...)
+@inline viewlength(i1::AbstractUnitRange, ::Base.ScalarIndex...) = (Base.length(i1),)
+else
+@inline viewlength(i1::AbstractUnitRange, I...) = (length(i1), viewlength(I...)...)
+@inline viewlength(i1::AbstractUnitRange, ::Base.ScalarIndex...) = (length(i1),)
+end
+
+# adaptor to upload an array to the GPU
+struct ToGPU
+    array::AbstractGPUArray
+end
+function Adapt.adapt_storage(to::ToGPU, xs::Array)
+    arr = similar(to.array, eltype(xs), size(xs))
+    copyto!(arr, xs)
+    arr
+end
+
+# we don't really want an array, so don't call `adapt(Array, ...)`,
+# but just want GPUArray indices to get downloaded back to the CPU.
+# this makes sure we preserve array-like containers, like Base.Slice.
+struct BackToCPU end
+Adapt.adapt_storage(::BackToCPU, xs::AbstractGPUArray) = convert(Array, xs)
+
+@inline function Base.view(A::AbstractGPUArray, I::Vararg{Any,N}) where {N}
+    J = to_indices(A, I)
+    @boundscheck begin
+        # Base's boundscheck accesses the indices, so make sure they reside on the CPU.
+        # this is expensive, but it's a bounds check after all.
+        J_cpu = map(j->adapt(BackToCPU(), j), J)
+        checkbounds(A, J_cpu...)
+    end
+    J_gpu = map(j->adapt(ToGPU(A), j), J)
+    unsafe_view(A, J_gpu, GPUIndexStyle(I...))
+end
+
+@inline function unsafe_view(A, I, ::Contiguous)
+    unsafe_contiguous_view(Base._maybe_reshape_parent(A, Base.index_ndims(I...)), I, viewlength(I...))
+end
+@inline function unsafe_contiguous_view(a::AbstractGPUArray{T}, I::NTuple{N,Base.ViewIndex}, dims::NTuple{M,Integer}) where {T,N,M}
+    offset = Base.compute_offset1(a, 1, I)
+
+    derive(T, M, a, dims, offset)
+end
+
+@inline function unsafe_view(A, I, ::NonContiguous)
+    Base.unsafe_view(Base._maybe_reshape_parent(A, Base.index_ndims(I...)), I...)
+end

--- a/src/host/construction.jl
+++ b/src/host/construction.jl
@@ -58,3 +58,87 @@ end
 
 Base.one(x::AbstractGPUMatrix{T}) where {T} = _one(one(T), x)
 Base.oneunit(x::AbstractGPUMatrix{T}) where {T} = _one(oneunit(T), x)
+
+
+## type checking
+
+export contains_eltype, explain_allocatedinline
+
+# back-ends often do not support all kinds of element types, so provide some helpers
+# to detect unsupported caes
+
+function hasfieldcount(@nospecialize(dt))
+    try
+        fieldcount(dt)
+    catch
+        return false
+    end
+    return true
+end
+
+# for finding specific element types, e.g., when Float64 is unsupported
+function contains_eltype(T, typ)
+    if T === typ
+      return true
+    elseif T isa Union
+        for U in Base.uniontypes(T)
+            contains_eltype(U, typ) && return true
+        end
+    elseif hasfieldcount(T)
+        for U in fieldtypes(T)
+            contains_eltype(U, typ) && return true
+        end
+    end
+    return false
+end
+
+# Types that are allocated inline include:
+# 1. plain bitstypes (`Int`, `(Float16, Float32)`, plain immutable structs, etc).
+#    these are simply stored contiguously in the buffer.
+# 2. structs of unions (`struct Foo; x::Union{Int, Float32}; end`)
+#    these are stored with a selector at the end (handled by Julia).
+# 3. bitstype unions (`Union{Int, Float32}`, etc)
+#    these are stored contiguously and require a selector array (handled by us)
+#
+# This function explains why a type is not allocated inline.
+function explain_allocatedinline(@nospecialize(T), depth=0; maxdepth=10)
+    depth > maxdepth && return ""
+
+    if T isa Union
+      msg = "  "^depth * "$T is a union that's not allocated inline\n"
+      for U in Base.uniontypes(T)
+        if !Base.allocatedinline(U)
+          msg *= explain_eltype(U, depth+1)
+        end
+      end
+    elseif Base.ismutabletype(T)
+      msg = "  "^depth * "$T is a mutable type\n"
+    elseif hasfieldcount(T)
+      msg = "  "^depth * "$T is a struct that's not allocated inline\n"
+      for U in fieldtypes(T)
+          if !Base.allocatedinline(U)
+              msg *= explain_nonisbits(U, depth+1)
+          end
+      end
+    else
+      msg = "  "^depth * "$T is not allocated inline\n"
+    end
+    return msg
+end
+
+
+## derived arrays
+
+# to avoid needless array wrappers (which make it harder to write generic wrappers) we
+# materialize several kinds of operations:
+# - contiguous views
+# - reinterpret
+# - reshape
+#
+# For this functionality to be reusable, we expect the back-end to provide a `derive`
+# operation that makes it possible to create a new array object, with a different type or
+# size, but backed by the same data. The `additional_offset` is the number of elements
+# to offset the new array from the original array.
+
+derive(::Type, N::Int, a::AbstractGPUArray, osize::Dims, additional_offset::Int) =
+    error("Not implemented")

--- a/test/testsuite/base.jl
+++ b/test/testsuite/base.jl
@@ -300,13 +300,13 @@ end
     end
 
     @testset "view" begin
-      @test compare(AT, rand(5)) do x
+      @test compare(AT, rand(Float32, 5)) do x
         y = x[2:4]
         y .= 1
         x
       end
 
-      @test compare(AT, rand(5)) do x
+      @test compare(AT, rand(Float32, 5)) do x
         y = view(x, 2:4)
         y .= 1
         x
@@ -325,7 +325,7 @@ end
       end
 
       # bug in conversion of indices (#506)
-      show(devnull, AT(view(ones(1), [1])))
+      show(devnull, AT(view(ones(Float32, 1), [1])))
 
       # performance loss due to Array indices
       let x = AT{Int}(undef, 1)
@@ -336,14 +336,14 @@ end
       end
 
       @testset "GPU array source" begin
-          a = rand(3)
+          a = rand(Float32, 3)
           i = rand(1:3, 2)
           @test compare(view, AT, a, i)
           @test compare(view, AT, a, view(i, 2:2))
       end
 
       @testset "CPU array source" begin
-          a = rand(3)
+          a = rand(Float32, 3)
           i = rand(1:3, 2)
           @test compare(view, AT, a, i)
           @test compare(view, AT, a, view(i, 2:2))

--- a/test/testsuite/base.jl
+++ b/test/testsuite/base.jl
@@ -298,4 +298,131 @@ end
                 occursin(Regex("^1×1 adjoint\\(::$AT{Int64,\\s?1.*}\\) with eltype Int64:\n 1\$"), msg)
         end
     end
+
+    @testset "view" begin
+      @test compare(AT, rand(5)) do x
+        y = x[2:4]
+        y .= 1
+        x
+      end
+
+      @test compare(AT, rand(5)) do x
+        y = view(x, 2:4)
+        y .= 1
+        x
+      end
+
+      @test compare(x->view(x, :, 1:4, 3), AT, rand(Float32, 5, 4, 3))
+
+      let x = AT(rand(Float32, 5, 4, 3))
+        @test_throws BoundsError view(x, :, :, 1:10)
+      end
+
+      # bug in parentindices conversion
+      let x = AT{Int}(undef, 1, 1)
+        x[1,:] .= 42
+        @test Array(x)[1,1] == 42
+      end
+
+      # bug in conversion of indices (#506)
+      show(devnull, AT(view(ones(1), [1])))
+
+      # performance loss due to Array indices
+      let x = AT{Int}(undef, 1)
+        i = [1]
+        y = view(x, i)
+        @test parent(y) isa AT
+        @test parentindices(y) isa Tuple{<:AT}
+      end
+
+      @testset "GPU array source" begin
+          a = rand(3)
+          i = rand(1:3, 2)
+          @test compare(view, AT, a, i)
+          @test compare(view, AT, a, view(i, 2:2))
+      end
+
+      @testset "CPU array source" begin
+          a = rand(3)
+          i = rand(1:3, 2)
+          @test compare(view, AT, a, i)
+          @test compare(view, AT, a, view(i, 2:2))
+      end
+    end
+
+    @testset "reshape" begin
+      A = [1 2 3 4
+           5 6 7 8]
+      gA = reshape(AT(A),1,8)
+      _A = reshape(A,1,8)
+      _gA = Array(gA)
+      @test all(_A .== _gA)
+      A = [1,2,3,4]
+      gA = reshape(AT(A),4)
+    end
+
+    @testset "reinterpret" begin
+      A = Int32[-1,-2,-3]
+      dA = AT(A)
+      dB = reinterpret(UInt32, dA)
+      @test reinterpret(UInt32, A) == Array(dB)
+
+      @test collect(reinterpret(Int32, AT(fill(1f0))))[] == reinterpret(Int32, 1f0)
+
+      @testset "reinterpret(reshape)" begin
+        a = AT(ComplexF32[1.0f0+2.0f0*im, 2.0f0im, 3.0f0im])
+        b = reinterpret(reshape, Float32, a)
+        @test a isa AT{ComplexF32, 1}
+        if AT <: AbstractGPUArray
+          # only GPUArrays materialize the reinterpret(reshape) wrapper
+          @test b isa AT{Float32, 2}
+        end
+        @test Array(b) == [1.0 0.0 0.0; 2.0 2.0 3.0]
+
+        a = AT(Float32[1.0 0.0 0.0; 2.0 2.0 3.0])
+        b = reinterpret(reshape, ComplexF32, a)
+        @test Array(b) == ComplexF32[1.0f0+2.0f0*im, 2.0f0im, 3.0f0im]
+      end
+
+      if AT <: AbstractGPUArray
+        @testset "exception: non-isbits" begin
+          local err
+          @test try
+            reinterpret(Float64, AT([1,nothing]))
+            nothing
+          catch err′
+            err = err′
+          end isa Exception
+          @test occursin(
+            "cannot reinterpret an `Union{Nothing, Int64}` array to `Float64`, because not all types are bitstypes",
+            sprint(showerror, err))
+        end
+
+        @testset "exception: 0-dim" begin
+          local err
+          @test try
+            reinterpret(Int128, AT(fill(1f0)))
+            nothing
+          catch err′
+            err = err′
+          end isa Exception
+          @test occursin(
+            "cannot reinterpret a zero-dimensional `Float32` array to `Int128` which is of a different size",
+            sprint(showerror, err))
+        end
+
+        @testset "exception: divisibility" begin
+          local err
+          @test try
+            reinterpret(Int128, AT(ones(Float32, 3)))
+            nothing
+          catch err′
+            err = err′
+          end isa Exception
+          @test occursin(
+            "cannot reinterpret an `Float32` array to `Int128` whose first dimension has size `3`.",
+            sprint(showerror, err))
+        end
+      end
+    end
 end


### PR DESCRIPTION
This PR ports 3 pieces of functionality from CUDA.jl:

- a buffer refcount type (`ArrayStorage` in CUDA.jl) so that we can create array objects that share data;
- using that, functionality to represent simple views/reshapes/reinterprets without using Base wrappers;
- and unrelated, reusable functionality for reporting on unsupported element types.


## Motivation

The goal of these changes is to make CUDA.jl's array wrapper optimization available for all back-ends. It consists of avoiding common array wrappers, as they complicate wrappers (necessitating complex Union-typed arguments). It's not great that we have to do this, but sadly that's the reality with Julia's array types; extending every method to use a Dense array alias that covers contiguous views/reshapes/reinterprets is just not practical, leading to ambiguities and slow method insertion times. Essentially, the following Union will now just be represented by the array type itself:

> DenseJLArray (alias for Union{JLArray{T, N}, Base.ReinterpretArray{T, N, S, A} where {A<:Union{SubArray{T, N, A, I, true} where {T, N, A<:JLArray, I<:Union{Tuple{Vararg{Real}}, Tuple{AbstractUnitRange, Vararg{Any}}}}, JLArray}, S}, Base.ReshapedArray{T, N, A} where A<:Union{Base.ReinterpretArray{T, N, S, A} where {T, N, A<:Union{SubArray{T, N, A, I, true} where {T, N, A<:JLArray, I<:Union{Tuple{Vararg{Real}}, Tuple{AbstractUnitRange, Vararg{Any}}}}, JLArray}, S}, SubArray{T, N, A, I, true} where {T, N, A<:JLArray, I<:Union{Tuple{Vararg{Real}}, Tuple{AbstractUnitRange, Vararg{Any}}}}, JLArray}, SubArray{T, N, A, I, true} where {A<:Union{Base.ReinterpretArray{T, N, S, A} where {T, N, A<:Union{SubArray{T, N, A, I, true} where {T, N, A<:JLArray, I<:Union{Tuple{Vararg{Real}}, Tuple{AbstractUnitRange, Vararg{Any}}}}, JLArray}, S}, Base.ReshapedArray{T, N, A} where {T, N, A<:Union{Base.ReinterpretArray{T, N, S, A} where {T, N, A<:Union{SubArray{T, N, A, I, true} where {T, N, A<:JLArray, I<:Union{Tuple{Vararg{Real}}, Tuple{AbstractUnitRange, Vararg{Any}}}}, JLArray}, S}, SubArray{T, N, A, I, true} where {T, N, A<:JLArray, I<:Union{Tuple{Vararg{Real}}, Tuple{AbstractUnitRange, Vararg{Any}}}}, JLArray}}, JLArray}, I<:Union{Tuple{Vararg{Real}}, Tuple{AbstractUnitRange, Vararg{Any}}}}} where {T, N})


## API changes

To make this possible, array back-ends will need to wrap their data in a `DataRef` and call `GPUArrays.unsafe_free!` instead of the actual finalizer, which is now registered with the `DataRef`:

```julia
buf = ...
managed_buf = DataRef(buf) do buf
  free(buf)
end
obj = new(managed_buf)
finalizer(GPUArrays.unsafe_free!, obj)
```

To get a hold of the underlying data, call `getindex`, i.e., `managed_buf[]`. To create a new reference that shares the underlying data, call `copy(managed_buf)`.

The second big part is a new interface method, `GPUArrays.derive(::Type{T}, N::Int, a::AbstractGPUArray, osize::Dims, offset::Int)`. This method is used by the view/reshape/reinterpret functionality to create a derived array, so this method will need to call `copy(::DataRef)`. Also note the new `offset` parameter, which will need to be added to the array structure, keeping track of the offset (in number of elements) for the purpose of implementing views. A simple implementation of this method could be:

```julia
function GPUArrays.derive(::Type{T}, N::Int, a::MyGPUArray, dims::Dims, offset::Int) where {T}
    data = copy(a.data)
    offset = (a.offset * Base.elsize(a)) ÷ sizeof(T) + offset
    MyGPUArray{T,N}(data, dims; offset)
end
```

---

Fixes https://github.com/JuliaGPU/Metal.jl/issues/149

cc @jpsamaroo