### PR TITLE
Aligning broadcasting errors between GPU and CPU

### DIFF
--- a/src/host/indexing.jl
+++ b/src/host/indexing.jl
@@ -65,16 +65,16 @@ Base.setindex!(A::AbstractGPUArray, v, I...) = _setindex!(A, v, to_indices(A, I)
 
 function _setindex!(dest::AbstractGPUArray, src, Is...)
     isempty(Is) && return dest
-    if length(dest)!=length(src)
-        if length(src)==1
-            throw(ArgumentError("indexed assignment with a single value to possibly many locations is not supported; perhaps use broadcasting `.=` instead?"))
-        else
-            throw(ArgumentError("indexed assignment with different lengths not supported; array sizes "*string(size(src))*" and "*string(size(dest)))) 
-        end
-    end
     idims = length.(Is)
     len = prod(idims)
     len==0 && return dest
+    if length(dest)!=len
+        if length(src)==1
+            throw(ArgumentError("indexed assignment with a single value to possibly many locations is not supported; perhaps use broadcasting `.=` instead?"))
+        else
+            throw(ArgumentError("indexed assignment with different lengths not supported; array sizes "*string(length(src))*" and "*string(len))) 
+        end
+    end
 
     AT = typeof(dest).name.wrapper
     # NOTE: we are pretty liberal here supporting non-GPU sources and indices...

--- a/src/host/indexing.jl
+++ b/src/host/indexing.jl
@@ -65,6 +65,13 @@ Base.setindex!(A::AbstractGPUArray, v, I...) = _setindex!(A, v, to_indices(A, I)
 
 function _setindex!(dest::AbstractGPUArray, src, Is...)
     isempty(Is) && return dest
+    if length(dest)!=length(src)
+        if length(src)==1
+            throw(ArgumentError("indexed assignment with a single value to possibly many locations is not supported; perhaps use broadcasting `.=` instead?"))
+        else
+            throw(ArgumentError("indexed assignment with different lengths not supported; verify array sizes")) 
+        end
+    end
     idims = length.(Is)
     len = prod(idims)
     len==0 && return dest

--- a/src/host/indexing.jl
+++ b/src/host/indexing.jl
@@ -68,7 +68,7 @@ function _setindex!(dest::AbstractGPUArray, src, Is...)
     idims = length.(Is)
     len = prod(idims)
     len==0 && return dest
-    if length(dest)!=len
+    if length(src)!=len
         if length(src)==1
             throw(ArgumentError("indexed assignment with a single value to possibly many locations is not supported; perhaps use broadcasting `.=` instead?"))
         else

--- a/src/host/indexing.jl
+++ b/src/host/indexing.jl
@@ -69,7 +69,7 @@ function _setindex!(dest::AbstractGPUArray, src, Is...)
     len = prod(idims)
     len==0 && return dest
     if length(src) != len
-        if length(src)==1
+        if length(src) == 1
             throw(ArgumentError("indexed assignment with a single value to possibly many locations is not supported; perhaps use broadcasting `.=` instead?"))
         else
             throw(DimensionMismatch("dimensions must match: a has "*string(length(src))*" elements, b has  "*string(len)))

--- a/src/host/indexing.jl
+++ b/src/host/indexing.jl
@@ -68,7 +68,7 @@ function _setindex!(dest::AbstractGPUArray, src, Is...)
     idims = length.(Is)
     len = prod(idims)
     len==0 && return dest
-    if length(src)!=len
+    if length(src) != len
         if length(src)==1
             throw(ArgumentError("indexed assignment with a single value to possibly many locations is not supported; perhaps use broadcasting `.=` instead?"))
         else

--- a/src/host/indexing.jl
+++ b/src/host/indexing.jl
@@ -69,7 +69,7 @@ function _setindex!(dest::AbstractGPUArray, src, Is...)
         if length(src)==1
             throw(ArgumentError("indexed assignment with a single value to possibly many locations is not supported; perhaps use broadcasting `.=` instead?"))
         else
-            throw(ArgumentError("indexed assignment with different lengths not supported; verify array sizes")) 
+            throw(ArgumentError("indexed assignment with different lengths not supported; array sizes "*string(length(src))*" and "*string(length(dest)))) 
         end
     end
     idims = length.(Is)

--- a/src/host/indexing.jl
+++ b/src/host/indexing.jl
@@ -72,7 +72,7 @@ function _setindex!(dest::AbstractGPUArray, src, Is...)
         if length(src)==1
             throw(ArgumentError("indexed assignment with a single value to possibly many locations is not supported; perhaps use broadcasting `.=` instead?"))
         else
-            throw(ArgumentError("indexed assignment with different lengths not supported; array sizes "*string(length(src))*" and "*string(len))) 
+            throw(DimensionMismatch("dimensions must match: a has "*string(length(src))*" elements, b has  "*string(len)))
         end
     end
 

--- a/src/host/indexing.jl
+++ b/src/host/indexing.jl
@@ -69,7 +69,7 @@ function _setindex!(dest::AbstractGPUArray, src, Is...)
         if length(src)==1
             throw(ArgumentError("indexed assignment with a single value to possibly many locations is not supported; perhaps use broadcasting `.=` instead?"))
         else
-            throw(ArgumentError("indexed assignment with different lengths not supported; array sizes "*string(length(src))*" and "*string(length(dest)))) 
+            throw(ArgumentError("indexed assignment with different lengths not supported; array sizes "*string(size(src))*" and "*string(size(dest)))) 
         end
     end
     idims = length.(Is)

--- a/test/testsuite/indexing.jl
+++ b/test/testsuite/indexing.jl
@@ -123,7 +123,7 @@ end
         x = AT(zeros(T, (10, 10, 10, 10)))
         @test_throws ArgumentError x[1, :, :, :] = 0
         y = AT(rand(T, (5, 5, 5, 5)))
-        @test_throws ArgumentError x[1:9,1:9,:,:] = y
+        @test_throws DimensionMismatch x[1:9,1:9,:,:] = y
     end
 
 end

--- a/test/testsuite/indexing.jl
+++ b/test/testsuite/indexing.jl
@@ -118,6 +118,12 @@ end
     @testset "JuliaGPU/CUDA.jl#461: sliced setindex" begin
         @test compare((X,Y)->(X[1,:] = Y), AT, zeros(Float32, 2,2), ones(Float32, 2))
     end
+
+    @testset "Broadcasting exceptions" begin
+        x = AT(zeros(T, (10, 10, 10, 10)))
+        @test_throws ArgumentError x[1, :, :, :] = 0
+    end
+
 end
 
 @testsuite "indexing find" (AT, eltypes)->begin

--- a/test/testsuite/indexing.jl
+++ b/test/testsuite/indexing.jl
@@ -119,9 +119,11 @@ end
         @test compare((X,Y)->(X[1,:] = Y), AT, zeros(Float32, 2,2), ones(Float32, 2))
     end
 
-    @testset "Broadcasting exceptions" begin
+    @testset "Broadcasting exceptions" for T in eltypes
         x = AT(zeros(T, (10, 10, 10, 10)))
         @test_throws ArgumentError x[1, :, :, :] = 0
+        y = AT(rand(T, (5, 5, 5, 5)))
+        @test_throws ArgumentError x .= y
     end
 
 end

--- a/test/testsuite/indexing.jl
+++ b/test/testsuite/indexing.jl
@@ -123,7 +123,7 @@ end
         x = AT(zeros(T, (10, 10, 10, 10)))
         @test_throws ArgumentError x[1, :, :, :] = 0
         y = AT(rand(T, (5, 5, 5, 5)))
-        @test_throws ArgumentError x .= y
+        @test_throws ArgumentError x[1:9,1:9,:,:] = y
     end
 
 end


### PR DESCRIPTION
Broadcasting errors differ on GPU and CPU:

```
a=rand(5,3,2)
a[1,:,:] = 0
```

Results in `ERROR: ArgumentError: indexed assignment with a single value to possibly many locations is not supported;  perhaps use broadcasting `.=` instead?`

```
a=CUDA.rand(5,3,2)
a[1,:,:] = 0
```

Results in `ERROR: KernelException: exception thrown during kernel execution on device NVIDIA GPU.`

Added a check for length checks in _setindex multidimensional.
