### PR TITLE
add example to `@allowscalar` docstring

### DIFF
--- a/lib/GPUArraysCore/src/GPUArraysCore.jl
+++ b/lib/GPUArraysCore/src/GPUArraysCore.jl
@@ -116,6 +116,8 @@ end
     end
 
 Denote which operations can use scalar indexing.
+              
+Example: `x = @allowscalar a[1]`.
 
 See also: [`allowscalar`](@ref).
 """


### PR DESCRIPTION
I got a hard-to-find bug by doing `@allowscalar x = a[1]` and then having `x` undefined. My intuition about what the scope of `@allowscalar` ought to be is clearly different from what the scope actually is. This addition to the docstring should help.