### PR TITLE
Add a GPU version of copytrito!

### DIFF
--- a/src/host/linalg.jl
+++ b/src/host/linalg.jl
@@ -129,7 +129,7 @@ end
 ## copy a triangular part of a matrix to another matrix
 
 if isdefined(LinearAlgebra, :copytrito!)
-    function copytrito!(B::AbstractGPUMatrix, A::AbstractGPUMatrix, uplo::AbstractChar)
+    function LinearAlgebra.copytrito!(B::AbstractGPUMatrix, A::AbstractGPUMatrix, uplo::AbstractChar)
         LinearAlgebra.BLAS.chkuplo(uplo)
         m,n = size(A)
         m1,n1 = size(B)

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -77,6 +77,17 @@
             end
         end
 
+        if isdefined(LinearAlgebra, :copytrito!)
+            @testset "copytrito!" begin
+                @testset for T in eltypes, uplo in ('L', 'U')
+                    n = 16
+                    A = rand(T,n,n)
+                    B = zeros(T,n,n)
+                    @test compare(copytrito!, AT, B, A, uplo)
+                end
+            end
+        end
+
         @testset "copyto! for triangular" begin
             for TR in (UpperTriangular, LowerTriangular)
                 @test compare(transpose!, AT, Array{Float32}(undef, 128, 32), rand(Float32, 32, 128))


### PR DESCRIPTION
@michel2323
I added a function in Julia (https://github.com/JuliaLang/julia/pull/51909/) to easily copy the triangular part of a matrix.
This PR adds a fallback for GPU matrices.
