### PR TITLE
Defer BroadcastStyle construction to back-ends.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['1.8', '1.9', '1.10.0-beta2', 'nightly']
+        version: ['1.8', '1.9', '1.10.0-rc2', 'nightly']
         os: [ubuntu-latest, macOS-latest, windows-latest]
         arch: [x64]
     steps:
       - uses: actions/checkout@v4
-        with:
-          path: "GPUArrays"
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
@@ -36,16 +34,16 @@ jobs:
             ${{ runner.os }}-test-
             ${{ runner.os }}-
       - name: Develop subpackages
-        run: julia --project=GPUArrays -e "using Pkg; Pkg.develop(ARGS)" GPUArraysCore JLArrays
-        env:
-          JULIA_PKG_DEVDIR: ${{ github.workspace }}
+        run: |
+          julia --project -e "
+            using Pkg
+            Pkg.develop([PackageSpec(; name=basename(path), path) for path in ARGS])
+          " lib/GPUArraysCore lib/JLArrays
       - uses: julia-actions/julia-runtest@v1
-        with:
-          project: GPUArrays
         continue-on-error: ${{ matrix.version == 'nightly' }}
       - uses: julia-actions/julia-processcoverage@v1
         with:
-          directories: GPUArrays/src,GPUArrays/lib
+          directories: src,lib
       - uses: codecov/codecov-action@v3
         with:
           file: lcov.info
@@ -54,19 +52,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          path: "GPUArrays"
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1.8'
       - name: Develop packages
-        run: julia -e "using Pkg; Pkg.develop(ARGS)" GPUArrays GPUArraysCore
-        env:
-          JULIA_PKG_DEVDIR: ${{ github.workspace }}
+        run: |
+          julia -e "
+            using Pkg
+            Pkg.develop([PackageSpec(; name=basename(splitext(path)[1]), path) for path in ARGS])
+          " ../GPUArrays.jl lib/GPUArraysCore
       - name: Install dependencies
-        run: julia --project=GPUArrays/docs/ -e 'using Pkg; Pkg.instantiate()'
+        run: julia --project=docs/ -e 'using Pkg; Pkg.instantiate()'
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-        run: julia --project=GPUArrays/docs/ GPUArrays/docs/make.jl
+        run: julia --project=docs/ docs/make.jl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,9 @@ jobs:
         arch: [x64]
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@latest
+        with:
+          path: "GPUArrays"
+      - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
@@ -33,13 +35,17 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
-      - uses: julia-actions/julia-buildpkg@latest
-      - run: |
-          git config --global user.name Tester
-          git config --global user.email te@st.er
-      - uses: julia-actions/julia-runtest@latest
+      - name: Develop subpackages
+        run: julia --project=GPUArrays -e "using Pkg; Pkg.develop(ARGS)" GPUArraysCore JLArrays
+        env:
+          JULIA_PKG_DEVDIR: ${{ github.workspace }}
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          project: GPUArrays
         continue-on-error: ${{ matrix.version == 'nightly' }}
       - uses: julia-actions/julia-processcoverage@v1
+        with:
+          directories: GPUArrays/src,GPUArrays/lib
       - uses: codecov/codecov-action@v3
         with:
           file: lcov.info
@@ -48,13 +54,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@latest
+        with:
+          path: "GPUArrays"
+      - uses: julia-actions/setup-julia@v1
         with:
           version: '1.8'
+      - name: Develop packages
+        run: julia -e "using Pkg; Pkg.develop(ARGS)" GPUArrays GPUArraysCore
+        env:
+          JULIA_PKG_DEVDIR: ${{ github.workspace }}
       - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+        run: julia --project=GPUArrays/docs/ -e 'using Pkg; Pkg.instantiate()'
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-        run: julia --project=docs/ docs/make.jl
+        run: julia --project=GPUArrays/docs/ GPUArrays/docs/make.jl

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GPUArrays"
 uuid = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
-version = "9.1.0"
+version = "10.0.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
@@ -14,7 +14,7 @@ Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-Adapt = "2.0, 3.0"
+Adapt = "4"
 GPUArraysCore = "= 0.1.5"
 LLVM = "3.9, 4, 5, 6"
 LinearAlgebra = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-Adapt = "4"
+Adapt = "4.0"
 GPUArraysCore = "= 0.1.5"
 LLVM = "3.9, 4, 5, 6"
 LinearAlgebra = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 Adapt = "4.0"
-GPUArraysCore = "= 0.1.5"
+GPUArraysCore = "= 0.1.6"
 LLVM = "3.9, 4, 5, 6"
 LinearAlgebra = "1"
 Printf = "1"

--- a/lib/GPUArraysCore/Project.toml
+++ b/lib/GPUArraysCore/Project.toml
@@ -7,5 +7,5 @@ version = "0.1.5"
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 
 [compat]
-Adapt = "4"
+Adapt = "4.0"
 julia = "1.6"

--- a/lib/GPUArraysCore/Project.toml
+++ b/lib/GPUArraysCore/Project.toml
@@ -7,5 +7,5 @@ version = "0.1.5"
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 
 [compat]
-Adapt = "2.0, 3.0"
+Adapt = "4"
 julia = "1.6"

--- a/lib/GPUArraysCore/Project.toml
+++ b/lib/GPUArraysCore/Project.toml
@@ -1,7 +1,7 @@
 name = "GPUArraysCore"
 uuid = "46192b85-c4d5-4398-a991-12ede77f4527"
 authors = ["Tim Besard <tim.besard@gmail.com>"]
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/lib/GPUArraysCore/src/GPUArraysCore.jl
+++ b/lib/GPUArraysCore/src/GPUArraysCore.jl
@@ -217,14 +217,15 @@ end
 ## other
 
 """
-    backend(T::Type)
     backend(x)
+    backend(T::Type)
 
 Gets the GPUArrays back-end responsible for managing arrays of type `T`.
 """
 backend(::Type) = error("This object is not a GPU array") # COV_EXCL_LINE
 backend(x) = backend(typeof(x))
 
-backend(::Type{WA}) where WA<:WrappedArray = backend(parent(WA)) # WrappedArray from Adapt for Base wrappers.
+# WrappedArray from Adapt for Base wrappers.
+backend(::Type{WA}) where WA<:WrappedArray = backend(unwrap_type(WA))
 
 end # module GPUArraysCore

--- a/lib/JLArrays/Project.toml
+++ b/lib/JLArrays/Project.toml
@@ -9,7 +9,7 @@ GPUArrays = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
-Adapt = "2.0, 3.0"
-GPUArrays = "9"
+Adapt = "2.0, 3.0, 4.0"
+GPUArrays = "10"
 julia = "1.8"
 Random = "1"

--- a/lib/JLArrays/Project.toml
+++ b/lib/JLArrays/Project.toml
@@ -1,7 +1,7 @@
 name = "JLArrays"
 uuid = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
 authors = ["Tim Besard <tim.besard@gmail.com>"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/lib/JLArrays/src/JLArrays.jl
+++ b/lib/JLArrays/src/JLArrays.jl
@@ -311,16 +311,15 @@ Base.convert(::Type{T}, x::T) where T <: JLArray = x
 using Base.Broadcast: BroadcastStyle, Broadcasted
 
 struct JLArrayStyle{N} <: AbstractGPUArrayStyle{N} end
-JLArrayStyle(::Val{N}) where N = JLArrayStyle{N}()
 JLArrayStyle{M}(::Val{N}) where {N,M} = JLArrayStyle{N}()
 
-BroadcastStyle(::Type{JLArray{T,N}}) where {T,N} = JLArrayStyle{N}()
+# identify the broadcast style of a (wrapped) array
+BroadcastStyle(::Type{<:JLArray{T,N}}) where {T,N} = JLArrayStyle{N}()
+BroadcastStyle(::Type{<:AnyJLArray{T,N}}) where {T,N} = JLArrayStyle{N}()
 
-# Allocating the output container
-Base.similar(bc::Broadcasted{JLArrayStyle{N}}, ::Type{T}) where {N,T} =
-    similar(JLArray{T}, axes(bc))
-Base.similar(bc::Broadcasted{JLArrayStyle{N}}, ::Type{T}, dims) where {N,T} =
-    JLArray{T}(undef, dims)
+# allocation of output arrays
+Base.similar(bc::Broadcasted{JLArrayStyle{N}}, ::Type{T}, dims) where {T,N} =
+    similar(JLArray{T}, dims)
 
 
 ## memory operations

--- a/src/host/broadcast.jl
+++ b/src/host/broadcast.jl
@@ -7,11 +7,6 @@ import Base.Broadcast: BroadcastStyle, Broadcasted, AbstractArrayStyle, instanti
 const BroadcastGPUArray{T} = Union{AnyGPUArray{T},
                                    Base.RefValue{<:AbstractGPUArray{T}}}
 
-# Wrapper types otherwise forget that they are GPU compatible
-# NOTE: don't directly use GPUArrayStyle here not to lose downstream customizations.
-BroadcastStyle(W::Type{<:WrappedGPUArray})= BroadcastStyle(Adapt.parent(W){Adapt.eltype(W), Adapt.ndims(W)})
-backend(W::Type{<:WrappedGPUArray}) = backend(Adapt.parent(W){Adapt.eltype(W), Adapt.ndims(W)})
-
 # Ref is special: it's not a real wrapper, so not part of Adapt,
 # but it is commonly used to bypass broadcasting of an argument
 # so we need to preserve its dimensionless properties.

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+JLArrays = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,18 +3,11 @@ using GPUArrays, Test, Pkg
 include("testsuite.jl")
 
 @testset "JLArray" begin
-    # install the JLArrays subpackage in a temporary environment
-    old_project = Base.active_project()
-    Pkg.activate(; temp=true)
-    Pkg.develop(path=joinpath(dirname(@__DIR__), "lib", "JLArrays"))
-
     using JLArrays
 
     jl([1])
 
     TestSuite.test(JLArray)
-
-    Pkg.activate(old_project)
 end
 
 @testset "Array" begin


### PR DESCRIPTION
To fix https://github.com/JuliaGPU/CUDA.jl/issues/2191, where broadcasting a CuArray backed by unified memory results in a CuArray in device memory (i.e. the buffer type is lost), I want to make the `CuArrayStyle` broadcast style include the buffer type so that we can preserve it. That's currently impossible, as the style is constructed by GPUArrays, by doing the very cursed `Adapt.parent(W){Adapt.eltype(W), Adapt.ndims(W)}` constructor call (`Adapt.parent` currently returns an unordained typename), which both does not know about the additional buffer typevar, and calls a specific constructor without setting the buffer typevar.

Instead, in https://github.com/JuliaGPU/Adapt.jl/pull/75 I make it so that `Adapt.parent` (renamed to `Adapt.parent_type` to avoid confusion with `Base.parent`, which doesn't work on types) returns the full type, including the buffer typevar. Then, in this PR, I make it so that the back-end is not responsible for providing the `BroadcastStyle` methods, so that additional information can be put in there.

Changes to back-ends should be minimal, see the JLArrays diff in here, or https://github.com/JuliaGPU/CUDA.jl/pull/2203. It is however a breaking change.

cc @vchuravy @jpsamaroo @pxl-th