### PR TITLE
Remove the N argument from GPUArrays.derive.

### DIFF
--- a/lib/JLArrays/src/JLArrays.jl
+++ b/lib/JLArrays/src/JLArrays.jl
@@ -190,7 +190,7 @@ function typed_data(x::JLArray{T}) where {T}
     unsafe_wrap(Array, pointer(x), x.dims)
 end
 
-function GPUArrays.derive(::Type{T}, N::Int, a::JLArray, dims::Dims, offset::Int) where {T}
+function GPUArrays.derive(::Type{T}, a::JLArray, dims::Dims{N}, offset::Int) where {T,N}
     ref = copy(a.data)
     offset = (a.offset * Base.elsize(a)) ÷ sizeof(T) + offset
     JLArray{T,N}(ref, dims; offset)

--- a/src/host/construction.jl
+++ b/src/host/construction.jl
@@ -140,5 +140,5 @@ end
 # size, but backed by the same data. The `additional_offset` is the number of elements
 # to offset the new array from the original array.
 
-derive(::Type, N::Int, a::AbstractGPUArray, osize::Dims, additional_offset::Int) =
+derive(::Type, a::AbstractGPUArray, osize::Dims, additional_offset::Int) =
     error("Not implemented")


### PR DESCRIPTION
Forgot to remove this as part of the just-released v10... I'm going to sneak this in as no back-end has adapted to GPUArrays v10.0 yet, as right now the default `derive` implementation is a major performance trap.