### PR TITLE
Remove special-casing of Ref in broadcast.

### DIFF
--- a/test/testsuite/broadcasting.jl
+++ b/test/testsuite/broadcasting.jl
@@ -156,21 +156,6 @@ function broadcasting(AT, eltypes)
                 map(+, x, y)
             end
         end
-
-        @testset "Ref" begin
-            # as first arg, 0d broadcast
-            @test compare(x->getindex.(Ref(x), 1), AT, ET[0])
-
-            void_setindex!(args...) = (setindex!(args...); return)
-            @test compare(x->(void_setindex!.(Ref(x), ET(1)); x), AT, ET[0])
-
-            # regular broadcast
-            a = AT(rand(ET, 10))
-            b = AT(rand(ET, 10))
-            cpy(i,a,b) = (a[i] = b[i]; return)
-            cpy.(1:10, Ref(a), Ref(b))
-            @test Array(a) == Array(b)
-        end
     end
 
     @testset "stackoverflow in copy(::Broadcast)" begin


### PR DESCRIPTION
In https://github.com/JuliaGPU/GPUArrays.jl/pull/240 / https://github.com/JuliaGPU/GPUArrays.jl/commit/7807069d1fcc843e4889df5600a2425c95fa8cb2, I added the ability to broadcast with `Ref`s of GPU arrays and still use the GPU broadcast style. This is convenient to be able to access elements 'outside' of what's being broadcasted:

```julia
julia> lookup_table = jl(rand(10));
julia> data = jl(rand(1:10, 2, 2));

julia> broadcast(data, Ref(lookup_table)) do x, lookup_table
           lookup_table[x]
       end
2×2 JLArray{Float64, 2}:
 0.42458  0.407246
 0.42458  0.482623
```

(Ab)using `Ref` like that isn't great, though. For one, it breaks the ability to broadcast with GPU array objects on the CPU, as noted by @ToucheSir:

```julia
julia> x = jl([1])
1-element JLArray{Int64, 1}:
 1

julia> xs = [copy(x)]
1-element Vector{JLArray{Int64, 1}}:
 [1]

julia> xs .= Ref(x)
ERROR: This object is not a GPU array
```

Furthermore, there's nowadays a simpler way to accomplish the above behavior, namely by capturing additional arrays outside of the broadcast:

```julia
julia> function demo()
           lookup_table = jl(rand(10))
           data = jl(rand(1:10, 2, 2))
           broadcast(data) do x
               lookup_table[x]
           end
       end

julia> demo()
2×2 JLArray{Float64, 2}:
 0.42458  0.407246
 0.42458  0.482623
```

So in this PR, I remove the special `Ref` behavior. That's a breaking change, so may require changes downstream. Looking at the original PR, I feel like I may have added this at the request of @ChrisRackauckas, so it may be prudent to check the SciML stack uses this pattern, and if it could be updated to use captures instead.

Fixes https://github.com/JuliaGPU/GPUArrays.jl/issues/505