### PR TITLE
Mark arrays as free before releasing the data.

### DIFF
--- a/src/host/abstractarray.jl
+++ b/src/host/abstractarray.jl
@@ -87,8 +87,8 @@ function unsafe_free!(ref::DataRef, args...)
         # as multiple releases of the underlying data is not allowed.
         return
     end
-    release(ref.rc, args...)
     ref.freed = true
+    release(ref.rc, args...)
     return
 end
 


### PR DESCRIPTION
Otherwise the GC can call unsafe_free while we were performing a manual unsafe_free.

We _could_ make the `freed` field of `DataRef` atomic, but currently operations on the parent object aren't supposed to be thread-safe. Only the contained `RefCounted` is.

Fixes https://github.com/JuliaGPU/GPUArrays.jl/issues/503