### PR TITLE
Adapt to new LinearAlgebra.generic_*mul! interface

### DIFF
--- a/src/host/linalg.jl
+++ b/src/host/linalg.jl
@@ -372,7 +372,7 @@ function generic_matmatmul!(C::AbstractArray{R}, A::AbstractArray{T}, B::Abstrac
     C
 end
 
-if VERSION < v"1.12.0-"
+@static if VERSION < v"1.12.0-"
 function LinearAlgebra.generic_matvecmul!(C::AbstractGPUVector, tA::AbstractChar, A::AbstractGPUMatrix, B::AbstractGPUVector, _add::MulAddMul = MulAddMul())
     generic_matmatmul!(C, wrap(A, tA), B, _add)
 end


### PR DESCRIPTION
This is a companion PR to https://github.com/JuliaLang/julia/pull/52439. There, we avoid constructing `MulAddMul`  objects, which are, however, used here in the most generic multiplication kernel. Along the way, I rearranged the call chain slightly to avoid unpacking already existing `MulAddMul`  objects, just to reconstruct it within the multiplication kernel.