### PR TITLE
Use linear-indexing broadcast kernel when possible

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@ steps:
   - label: "CUDA.jl"
     plugins:
       - JuliaCI/julia#v1:
-          version: 1.8
+          version: "1.10"
       - JuliaCI/julia-coverage#v1:
           codecov: true
     command: |
@@ -23,7 +23,7 @@ steps:
   - label: "oneAPI.jl"
     plugins:
       - JuliaCI/julia#v1:
-          version: 1.8
+          version: "1.10"
       - JuliaCI/julia-coverage#v1:
           codecov: true
     command: |
@@ -48,7 +48,7 @@ steps:
   - label: "Metal.jl"
     plugins:
       - JuliaCI/julia#v1:
-          version: 1.8
+          version: "1.10"
       - JuliaCI/julia-coverage#v1:
           codecov: true
     command: |

--- a/src/device/indexing.jl
+++ b/src/device/indexing.jl
@@ -64,7 +64,9 @@ macro linearidx(A, grididx=1, ctxsym=:ctx)
     quote
         x = $(esc(A))
         i = linear_index($(esc(ctxsym)), $(esc(grididx)))
-        i > length(x) && return
+        if !(1 <= i <= length(x))
+            return
+        end
         i
     end
 end
@@ -80,4 +82,31 @@ macro cartesianidx(A, grididx=1, ctxsym=:ctx)
         i = @linearidx(x, $(esc(grididx)), $(esc(ctxsym)))
         @inbounds CartesianIndices(x)[i]
     end
+end
+
+
+## utilities
+
+# indexing a CartesianIndices at run time generates an integer division, which is slow.
+# to work around this, we can use a static CartesianIndices type to avoid the division.
+# this informs LLVM and the back-end about the static iteration bounds, allowing it to
+# lower the integer divison to a series of bit shifts, dramatically improving performance.
+# also see: maleadt/StaticCartesian.jl, JuliaGPU/GPUArrays.jl#454
+
+struct StaticCartesianIndices{N, I} end
+
+StaticCartesianIndices(iter::CartesianIndices{N}) where {N} =
+    StaticCartesianIndices{N, iter.indices}()
+StaticCartesianIndices(x) = StaticCartesianIndices(CartesianIndices(x))
+
+Base.CartesianIndices(iter::StaticCartesianIndices{N, I}) where {N, I} =
+    CartesianIndices{N, typeof(I)}(I)
+
+Base.@propagate_inbounds Base.getindex(I::StaticCartesianIndices, i::Int) =
+    CartesianIndices(I)[i]
+Base.length(I::StaticCartesianIndices) = length(CartesianIndices(I))
+
+function Base.show(io::IO, I::StaticCartesianIndices)
+    print(io, "Static")
+    show(io, CartesianIndices(I))
 end

--- a/src/host/broadcast.jl
+++ b/src/host/broadcast.jl
@@ -56,7 +56,6 @@ end
             return
         end
     else
-        # XXX: we could use StaticCartesianIndices here, but that results in many compilations
         function (ctx, dest, bc, nelem)
             i = 0
             while i < nelem

--- a/src/host/broadcast.jl
+++ b/src/host/broadcast.jl
@@ -43,7 +43,7 @@ end
     isempty(dest) && return dest
     bc = Broadcast.preprocess(dest, bc)
 
-    broadcast_kernel = if ndims(bc) == 1 ||
+    broadcast_kernel = if ndims(dest) == 1 ||
                           (isa(IndexStyle(dest), IndexLinear) &&
                            isa(IndexStyle(bc), IndexLinear))
         function (ctx, dest, bc, nelem)
@@ -116,7 +116,7 @@ function Base.map!(f, dest::AnyGPUArray, xs::AbstractArray...)
     end
 
     # grid-stride kernel
-    function map_kernel(ctx, dest, Is, bc, nelem)
+    function map_kernel(ctx, dest, bc, nelem)
         i = 1
         while i <= nelem
             j = linear_index(ctx, i)

--- a/src/host/math.jl
+++ b/src/host/math.jl
@@ -2,7 +2,7 @@
 
 function Base.clamp!(A::AnyGPUArray, low, high)
     gpu_call(A, low, high) do ctx, A, low, high
-        I = @cartesianidx A
+        I = @linearidx A
         A[I] = clamp(A[I], low, high)
         return
     end


### PR DESCRIPTION
Attempt to re-land https://github.com/JuliaGPU/GPUArrays.jl/pull/454, this time using a slightly nicer implementation.

It hasn't fundamentally changed though, so should run into the same issues. Let's do this carefully.

The motivation is also unchanged: on certain platforms, like Metal.jl, the integer divisions required to go from a linear hardware index to a cartesian one for indexing the input/output containers is extremely expensive. By using static iteration bounds, the compiler can replace the `idiv` with a series of bitshifts. This improves the performance of broadcast by 3-4x on those platforms.

cc @maxwindiff