### PR TITLE
Remove unused type variables

### DIFF
--- a/src/host/linalg.jl
+++ b/src/host/linalg.jl
@@ -339,7 +339,7 @@ end
 
 ## matrix multiplication
 # legacy method
-generic_matmatmul!(C::AbstractArray, A::AbstractArray, B::AbstractArray, a::Number, b::Number) where {T,S,R} =
+generic_matmatmul!(C::AbstractArray, A::AbstractArray, B::AbstractArray, a::Number, b::Number) =
     generic_matmatmul!(C, A, B, MulAddMul(a, b))
 function generic_matmatmul!(C::AbstractArray{R}, A::AbstractArray{T}, B::AbstractArray{S}, add::MulAddMul) where {T,S,R}
     if size(A,2) != size(B,1)


### PR DESCRIPTION
Fixes the following warning:

```julia
┌ GPUArrays
│  WARNING: method definition for generic_matmatmul! at /Users/tim/Developer/GPUArrays.jl/src/host/linalg.jl:342 declares type variable R but does not use it.
│  WARNING: method definition for generic_matmatmul! at /Users/tim/Developer/GPUArrays.jl/src/host/linalg.jl:342 declares type variable S but does not use it.
│  WARNING: method definition for generic_matmatmul! at /Users/tim/Developer/GPUArrays.jl/src/host/linalg.jl:342 declares type variable T but does not use it.
└
```