### PR TITLE
Fix resize! for JLVector

### DIFF
--- a/lib/JLArrays/src/JLArrays.jl
+++ b/lib/JLArrays/src/JLArrays.jl
@@ -375,7 +375,10 @@ Base.copyto!(dest::DenseJLArray{T}, source::DenseJLArray{T}) where {T} =
 function Base.resize!(a::DenseJLVector{T}, nl::Integer) where {T}
     a_resized = JLVector{T}(undef, nl)
     copyto!(a_resized, 1, a, 1, min(length(a), nl))
-    a.data = a_resized.data
+    # Free old memory and increase reference count of the resized array, to avoid new memory
+    # from being freed after we leave this function.
+    finalize(a)
+    a.data = copy(a_resized.data)  # this copies the pointer and increments the reference count
     a.offset = 0
     a.dims = size(a_resized)
     return a

--- a/lib/JLArrays/src/JLArrays.jl
+++ b/lib/JLArrays/src/JLArrays.jl
@@ -377,7 +377,7 @@ function Base.resize!(a::DenseJLVector{T}, nl::Integer) where {T}
     copyto!(a_resized, 1, a, 1, min(length(a), nl))
     # Free old memory and increase reference count of the resized array, to avoid new memory
     # from being freed after we leave this function.
-    finalize(a)
+    unsafe_free!(a)
     a.data = copy(a_resized.data)  # this copies the pointer and increments the reference count
     a.offset = 0
     a.dims = size(a_resized)

--- a/lib/JLArrays/src/JLArrays.jl
+++ b/lib/JLArrays/src/JLArrays.jl
@@ -169,7 +169,9 @@ mutable struct JLArray{T, N} <: AbstractGPUArray{T, N}
         check_eltype(T)
         maxsize = prod(dims) * sizeof(T)
         data = Vector{UInt8}(undef, maxsize)
-        ref = DataRef(data)
+        ref = DataRef(data) do data
+            resize!(data, 0)
+        end
         obj = new{T,N}(ref, 0, dims)
         finalizer(unsafe_free!, obj)
     end
@@ -373,14 +375,18 @@ Base.copyto!(dest::DenseJLArray{T}, source::DenseJLArray{T}) where {T} =
     copyto!(dest, 1, source, 1, length(source))
 
 function Base.resize!(a::DenseJLVector{T}, nl::Integer) where {T}
-    a_resized = JLVector{T}(undef, nl)
-    copyto!(a_resized, 1, a, 1, min(length(a), nl))
-    # Free old memory and increase reference count of the resized array, to avoid new memory
-    # from being freed after we leave this function.
+    # JLArrays aren't performance critical, so simply allocate a new one
+    # instead of duplicating the underlying data allocation from the ctor.
+    b = JLVector{T}(undef, nl)
+    copyto!(b, 1, a, 1, min(length(a), nl))
+
+    # replace the data, freeing the old one and increasing the refcount of the new one
+    # to avoid it from being freed when we leave this function.
     unsafe_free!(a)
-    a.data = copy(a_resized.data)  # this copies the pointer and increments the reference count
-    a.offset = 0
-    a.dims = size(a_resized)
+    a.data = copy(b.data)
+
+    a.offset = b.offset
+    a.dims = b.dims
     return a
 end
 


### PR DESCRIPTION
This fixes a reference counting issue when using `resize!` on a `JLVector`.

The issue is illustrated by the following example:

```julia
using JLArrays

u = JLArray{Float64}(undef, 0)
data_prev = u.data
resize!(u, 16)
data = u.data

GC.gc()
data_prev.rc.count[]  # should be 0 (old data was freed)
data.rc.count[]       # should be 1 (new data is still available)
```

Without this PR, the last two lines incorrectly give 1 and 0 when it should be the opposite.

This means in particular that doing things like `copy(u)` after `resize!` failed with `ArgumentError: Attempt to use a freed reference.`.