### PR TITLE
Introduce `AsyncNumber` to lazily copy numeric `mapreduce` results to the host

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
+AbstractNumbers = "0.2"
 Adapt = "4.0"
 GPUArraysCore = "= 0.1.6"
 LLVM = "3.9, 4, 5, 6, 7, 8"

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
 version = "10.2.3"
 
 [deps]
+AbstractNumbers = "85c772de-338a-5e7f-b815-41e76c26ac1f"
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
 LLVM = "929cbde3-209d-540e-8aea-75f648917ca0"

--- a/src/GPUArrays.jl
+++ b/src/GPUArrays.jl
@@ -1,5 +1,7 @@
 module GPUArrays
 
+import AbstractNumbers as AN
+
 using Serialization
 using Random
 using LinearAlgebra
@@ -25,6 +27,7 @@ include("device/synchronization.jl")
 # host abstractions
 include("host/abstractarray.jl")
 include("host/construction.jl")
+include("host/gpunumber.jl")
 ## integrations and specialized methods
 include("host/base.jl")
 include("host/indexing.jl")

--- a/src/GPUArrays.jl
+++ b/src/GPUArrays.jl
@@ -1,6 +1,6 @@
 module GPUArrays
 
-import AbstractNumbers as AN
+import AbstractNumbers
 
 using Serialization
 using Random

--- a/src/host/gpunumber.jl
+++ b/src/host/gpunumber.jl
@@ -38,3 +38,5 @@ Base.isequal(v::Number, g::GPUNumber) = isequal(v, g[])
 Base.nextpow(a, x::GPUNumber) = nextpow(a, x[])
 Base.nextpow(a::GPUNumber, x) = nextpow(a[], x)
 Base.nextpow(a::GPUNumber, x::GPUNumber) = nextpow(a[], x[])
+
+Base.convert(::Type{Number}, g::GPUNumber) = g[]

--- a/src/host/gpunumber.jl
+++ b/src/host/gpunumber.jl
@@ -26,5 +26,7 @@ Base.broadcastable(g::GPUNumber) = g.val
 
 # Overload to avoid copies.
 Base.one(g::GPUNumber) = one(number_type(g))
+Base.one(::Type{GPUNumber{T}}) where T = one(eltype(T))
 Base.zero(g::GPUNumber) = zero(number_type(g))
+Base.zero(::Type{GPUNumber{T}}) where T = zero(eltype(T))
 Base.identity(g::GPUNumber) = g

--- a/src/host/gpunumber.jl
+++ b/src/host/gpunumber.jl
@@ -1,0 +1,30 @@
+# Custom GPU-compatible `Number` interface.
+struct GPUNumber{T <: AbstractGPUArray} <: AN.AbstractNumber{T}
+    val::T
+
+    function GPUNumber(val::T) where T <: AbstractGPUArray
+        length(val) != 1 && error(
+            "`GPUNumber` accepts only 1-element GPU arrays, " *
+            "instead `$(length(val))`-element array was given.")
+        new{T}(val)
+    end
+end
+
+AN.number(g::GPUNumber) = @allowscalar g.val[]
+
+maybe_number(g::GPUNumber) = AN.number(g)
+maybe_number(g) = g
+
+number_type(::GPUNumber{T}) where T = eltype(T)
+
+# When operations involve other `::Number` types,
+# do not convert back to `GPUNumber`.
+AN.like(::Type{<: GPUNumber}, x) = x
+
+# When broadcasting, just pass the array itself.
+Base.broadcastable(g::GPUNumber) = g.val
+
+# Overload to avoid copies.
+Base.one(g::GPUNumber) = one(number_type(g))
+Base.zero(g::GPUNumber) = zero(number_type(g))
+Base.identity(g::GPUNumber) = g

--- a/src/host/gpunumber.jl
+++ b/src/host/gpunumber.jl
@@ -11,7 +11,6 @@ struct GPUNumber{T <: AbstractGPUArray} <: AN.AbstractNumber{T}
 end
 
 AN.number(g::GPUNumber) = @allowscalar g.val[]
-
 maybe_number(g::GPUNumber) = AN.number(g)
 maybe_number(g) = g
 
@@ -30,3 +29,12 @@ Base.one(::Type{GPUNumber{T}}) where T = one(eltype(T))
 Base.zero(g::GPUNumber) = zero(number_type(g))
 Base.zero(::Type{GPUNumber{T}}) where T = zero(eltype(T))
 Base.identity(g::GPUNumber) = g
+
+Base.getindex(g::GPUNumber) = AN.number(g)
+
+Base.isequal(g::GPUNumber, v::Number) = isequal(g[], v)
+Base.isequal(v::Number, g::GPUNumber) = isequal(v, g[])
+
+Base.nextpow(a, x::GPUNumber) = nextpow(a, x[])
+Base.nextpow(a::GPUNumber, x) = nextpow(a[], x)
+Base.nextpow(a::GPUNumber, x::GPUNumber) = nextpow(a[], x[])

--- a/src/host/gpunumber.jl
+++ b/src/host/gpunumber.jl
@@ -1,42 +1,42 @@
 # Custom GPU-compatible `Number` interface.
-struct GPUNumber{T <: AbstractGPUArray} <: AN.AbstractNumber{T}
+struct AsyncNumber{T <: AbstractGPUArray} <: AbstractNumbers.AbstractNumber{T}
     val::T
 
-    function GPUNumber(val::T) where T <: AbstractGPUArray
+    function AsyncNumber(val::T) where T <: AbstractGPUArray
         length(val) != 1 && error(
-            "`GPUNumber` accepts only 1-element GPU arrays, " *
+            "`AsyncNumber` accepts only 1-element GPU arrays, " *
             "instead `$(length(val))`-element array was given.")
         new{T}(val)
     end
 end
 
-AN.number(g::GPUNumber) = @allowscalar g.val[]
-maybe_number(g::GPUNumber) = AN.number(g)
+AbstractNumbers.number(g::AsyncNumber) = @allowscalar g.val[]
+maybe_number(g::AsyncNumber) = AbstractNumbers.number(g)
 maybe_number(g) = g
 
-number_type(::GPUNumber{T}) where T = eltype(T)
+number_type(::AsyncNumber{T}) where T = eltype(T)
 
 # When operations involve other `::Number` types,
-# do not convert back to `GPUNumber`.
-AN.like(::Type{<: GPUNumber}, x) = x
+# do not convert back to `AsyncNumber`.
+AbstractNumbers.like(::Type{<: AsyncNumber}, x) = x
 
 # When broadcasting, just pass the array itself.
-Base.broadcastable(g::GPUNumber) = g.val
+Base.broadcastable(g::AsyncNumber) = g.val
 
 # Overload to avoid copies.
-Base.one(g::GPUNumber) = one(number_type(g))
-Base.one(::Type{GPUNumber{T}}) where T = one(eltype(T))
-Base.zero(g::GPUNumber) = zero(number_type(g))
-Base.zero(::Type{GPUNumber{T}}) where T = zero(eltype(T))
-Base.identity(g::GPUNumber) = g
+Base.one(g::AsyncNumber) = one(number_type(g))
+Base.one(::Type{AsyncNumber{T}}) where T = one(eltype(T))
+Base.zero(g::AsyncNumber) = zero(number_type(g))
+Base.zero(::Type{AsyncNumber{T}}) where T = zero(eltype(T))
+Base.identity(g::AsyncNumber) = g
 
-Base.getindex(g::GPUNumber) = AN.number(g)
+Base.getindex(g::AsyncNumber) = AbstractNumbers.number(g)
 
-Base.isequal(g::GPUNumber, v::Number) = isequal(g[], v)
-Base.isequal(v::Number, g::GPUNumber) = isequal(v, g[])
+Base.isequal(g::AsyncNumber, v::Number) = isequal(g[], v)
+Base.isequal(v::Number, g::AsyncNumber) = isequal(v, g[])
 
-Base.nextpow(a, x::GPUNumber) = nextpow(a, x[])
-Base.nextpow(a::GPUNumber, x) = nextpow(a[], x)
-Base.nextpow(a::GPUNumber, x::GPUNumber) = nextpow(a[], x[])
+Base.nextpow(a, x::AsyncNumber) = nextpow(a, x[])
+Base.nextpow(a::AsyncNumber, x) = nextpow(a[], x)
+Base.nextpow(a::AsyncNumber, x::AsyncNumber) = nextpow(a[], x[])
 
-Base.convert(::Type{Number}, g::GPUNumber) = g[]
+Base.convert(::Type{Number}, g::AsyncNumber) = g[]

--- a/src/host/indexing.jl
+++ b/src/host/indexing.jl
@@ -203,8 +203,7 @@ function Base.findfirst(f::Function, A::AnyGPUArray)
         return (false, dummy_index)
     end
 
-    res = mapreduce((x, y)->(f(x), y), reduction, A, indices;
-                    init = (false, dummy_index)) |> AN.number
+    res = mapreduce((x, y)->(f(x), y), reduction, A, indices; init = (false, dummy_index))
     if res[1]
         # out of consistency with Base.findarray, return a CartesianIndex
         # when the input is a multidimensional array
@@ -231,14 +230,14 @@ function findminmax(binop, A::AnyGPUArray; init, dims)
 
     if dims == Colon()
         res = mapreduce(tuple, reduction, A, indices;
-            init = (init, dummy_index)) |> AN.number
+            init = (init, dummy_index))
 
         # out of consistency with Base.findarray, return a CartesianIndex
         # when the input is a multidimensional array
         return (res[1], ndims(A) == 1 ? res[2] : CartesianIndices(A)[res[2]])
     else
         res = mapreduce(tuple, reduction, A, indices;
-                        init = (init, dummy_index), dims=dims) |> maybe_number
+                        init = (init, dummy_index), dims=dims)
         vals = map(x->x[1], res)
         inds = map(x->ndims(A) == 1 ? x[2] : CartesianIndices(A)[x[2]], res)
         return (vals, inds)

--- a/src/host/indexing.jl
+++ b/src/host/indexing.jl
@@ -204,7 +204,7 @@ function Base.findfirst(f::Function, A::AnyGPUArray)
     end
 
     res = mapreduce((x, y)->(f(x), y), reduction, A, indices;
-                    init = (false, dummy_index))
+                    init = (false, dummy_index)) |> AN.number
     if res[1]
         # out of consistency with Base.findarray, return a CartesianIndex
         # when the input is a multidimensional array
@@ -230,14 +230,15 @@ function findminmax(binop, A::AnyGPUArray; init, dims)
     end
 
     if dims == Colon()
-        res = mapreduce(tuple, reduction, A, indices; init = (init, dummy_index))
+        res = mapreduce(tuple, reduction, A, indices;
+            init = (init, dummy_index)) |> AN.number
 
         # out of consistency with Base.findarray, return a CartesianIndex
         # when the input is a multidimensional array
         return (res[1], ndims(A) == 1 ? res[2] : CartesianIndices(A)[res[2]])
     else
         res = mapreduce(tuple, reduction, A, indices;
-                        init = (init, dummy_index), dims=dims)
+                        init = (init, dummy_index), dims=dims) |> maybe_number
         vals = map(x->x[1], res)
         inds = map(x->ndims(A) == 1 ? x[2] : CartesianIndices(A)[x[2]], res)
         return (vals, inds)

--- a/src/host/mapreduce.jl
+++ b/src/host/mapreduce.jl
@@ -68,9 +68,9 @@ function _mapreduce(f::F, op::OP, As::Vararg{Any,N}; dims::D, init) where {F,OP,
     end
 
     if dims === Colon()
-        # Return `GPUNumber` for `Number` eltypes, otherwise - transfer to host.
+        # Return `AsyncNumber` for `Number` eltypes, otherwise - transfer to host.
         eltype(R) <: Number ?
-            GPUNumber(reshape(R, :)) :
+            AsyncNumber(reshape(R, :)) :
             @allowscalar(R[])
     else
         R

--- a/test/testsuite.jl
+++ b/test/testsuite.jl
@@ -34,6 +34,9 @@ function test_result(as::NTuple{N,Any}, bs::NTuple{N,Any}; kwargs...) where {N}
         test_result(a, b; kwargs...)
     end
 end
+# Special case for `extrema` accross all dims.
+test_result(as::NTuple{N,Any}, bs::GPUArrays.GPUNumber; kwargs...) where {N} =
+    test_result(as, GPUArrays.maybe_number(bs))
 
 function compare(f, AT::Type{<:AbstractGPUArray}, xs...; kwargs...)
     # copy on the CPU, adapt on the GPU, but keep Ref's

--- a/test/testsuite.jl
+++ b/test/testsuite.jl
@@ -34,9 +34,6 @@ function test_result(as::NTuple{N,Any}, bs::NTuple{N,Any}; kwargs...) where {N}
         test_result(a, b; kwargs...)
     end
 end
-# Special case for `extrema` accross all dims.
-test_result(as::NTuple{N,Any}, bs::GPUArrays.GPUNumber; kwargs...) where {N} =
-    test_result(as, GPUArrays.maybe_number(bs))
 
 function compare(f, AT::Type{<:AbstractGPUArray}, xs...; kwargs...)
     # copy on the CPU, adapt on the GPU, but keep Ref's


### PR DESCRIPTION
Introduce `GPUNumber` to store the resul of `mapreduce` across all `dims` (i.e. `dims = :`) instead of immediately transferring it to host.

`GPUNumber` copies its value to host when it is used as a regular number.
But if it is used for broadcasting, it passes its underlying 1-element array without device-to-host copy.

Seems to be minimally breaking change, except for the return type of `sum` and the likes.
Using AbstractNumbers.jl since it implements the whole `Number` interface conveniently.

More context: https://github.com/FluxML/Zygote.jl/issues/1513

- Before:

```julia
julia> x = AMDGPU.rand(Float32, 1024);

julia> @btime sum($x);
  64.340 μs (146 allocations: 6.11 KiB)

julia> @btime Zygote.gradient($x) do x
           sum(1f0 .- x)
       end;
  131.617 μs (368 allocations: 16.10 KiB)
```

- Now:

```julia
julia> @btime sum($x);
  15.809 μs (140 allocations: 5.84 KiB)

julia> @btime Zygote.gradient($x) do x
           sum(1f0 .- x)
       end;
  44.123 μs (356 allocations: 15.57 KiB)
```

Here's also a timeline profile for the Flux.jl model for the same region.
We can see that now there are no device-to-host copies.

||Timeline profile|
|-|-|
|Before|![image](https://github.com/JuliaGPU/GPUArrays.jl/assets/17990405/8e793720-7652-4f9a-89d7-8bb8dee57751)|
|Now|![image](https://github.com/JuliaGPU/GPUArrays.jl/assets/17990405/48c63d60-e7c9-46ed-8e26-28eb094f39bf)|