### PR TITLE
mapreduce: don't use broadcast when only dealing with a single arg.

### DIFF
--- a/src/host/broadcast.jl
+++ b/src/host/broadcast.jl
@@ -95,9 +95,8 @@ end
 allequal(x) = true
 allequal(x, y, z...) = x == y && allequal(y, z...)
 
-function Base.map(f, x::AnyGPUArray, xs::AbstractArray...)
+function Base.map(f, xs::AnyGPUArray...)
     # if argument sizes match, their shape needs to be preserved
-    xs = (x, xs...)
     if allequal(size.(xs)...)
          return f.(xs...)
     end
@@ -112,12 +111,12 @@ function Base.map(f, x::AnyGPUArray, xs::AbstractArray...)
         # see `broadcast`
         ElType = BrokenBroadcast{ElType}
     end
-    dest = similar(x, ElType, common_length)
+    dest = similar(first(xs), ElType, common_length)
 
     return map!(f, dest, xs...)
 end
 
-function Base.map!(f, dest::AnyGPUArray, xs::AbstractArray...)
+function Base.map!(f, dest::AnyGPUArray, xs::AnyGPUArray...)
     # custom broadcast, ignoring the container size mismatches
     # (avoids the reshape + view that our mapreduce impl has to do)
     indices = LinearIndices.((dest, xs...))


### PR DESCRIPTION
This should speed up common calls like `sum`.

```patch
 conversion:
   %3 = load float, float addrspace(1)* %0, align 4
   %4 = bitcast { i8 addrspace(1)*, [2 x i64] } addrspace(1)* %1 to float addrspace(1)* addrspace(1)*
-  %.unpack9 = load float addrspace(1)*, float addrspace(1)* addrspace(1)* %4, align 8
-  %.unpack5.elt = getelementptr inbounds { i8 addrspace(1)*, [2 x i64] }, { i8 addrspace(1)*, [2 x i64] } addrspace(1)* %1, i64 0, i32 1, i64 0
-  %.unpack5.unpack = load i64, i64 addrspace(1)* %.unpack5.elt, align 8
-  %5 = bitcast { [1 x { i8 addrspace(1)*, [1 x i64] }], [1 x [1 x i64]] } addrspace(1)* %2 to float addrspace(1)* addrspace(1)*
-  %.unpack.unpack.unpack19 = load float addrspace(1)*, float addrspace(1)* addrspace(1)* %5, align 8
+  %.unpack10 = load float addrspace(1)*, float addrspace(1)* addrspace(1)* %4, align 8
+  %.unpack6.elt = getelementptr inbounds { i8 addrspace(1)*, [2 x i64] }, { i8 addrspace(1)*, [2 x i64] } addrspace(1)* %1, i64 0, i32 1, i64 0
+  %.unpack6.unpack = load i64, i64 addrspace(1)* %.unpack6.elt, align 8
+  %5 = bitcast { i8 addrspace(1)*, [1 x i64] } addrspace(1)* %2 to float addrspace(1)* addrspace(1)*
+  %.unpack14 = load float addrspace(1)*, float addrspace(1)* addrspace(1)* %5, align 8
   %6 = add i32 %thread_position_in_threadgroup, 1
   %7 = zext i32 %threads_per_threadgroup to i64
   %8 = add i32 %threadgroup_position_in_grid, 1
   %9 = zext i32 %8 to i64
   %10 = fadd float %3, %3
   %11 = zext i32 %6 to i64
   %12 = add nsw i64 %9, -1
   %13 = mul i64 %12, %7
   %14 = add i64 %13, %11
   %15 = add i64 %14, -1
-  %.not19.not = icmp eq i64 %14, 0
-  br i1 %.not19.not, label %L225, label %L103.lr.ph
+  %.not14.not = icmp eq i64 %14, 0
+  br i1 %.not14.not, label %L183, label %L103.lr.ph
 
 L103.lr.ph:                                       ; preds = %conversion
-  %16 = getelementptr inbounds { [1 x { i8 addrspace(1)*, [1 x i64] }], [1 x [1 x i64]] }, { [1 x { i8 addrspace(1)*, [1 x i64] }], [1 x [1 x i64]] } addrspace(1)* %2, i64 0, i32 0, i64 0, i32 1, i64 0
-  %.unpack.unpack.unpack14.unpack = load i64, i64 addrspace(1)* %16, align 8
-  %.sroa.02.sroa.2.0.copyload.fr = freeze i64 %.unpack.unpack.unpack14.unpack
-  %.not12 = icmp eq i64 %.sroa.02.sroa.2.0.copyload.fr, 1
-  %17 = icmp ugt i64 %14, 10
-  br i1 %.not12, label %L103.lr.ph.split.us, label %L103.lr.ph.split
-
-L103.lr.ph.split.us:                              ; preds = %L103.lr.ph
-  br i1 %17, label %L99.L225_crit_edge, label %L114.us
-
-L114.us:                                          ; preds = %L103.lr.ph.split.us
-  %18 = load float, float addrspace(1)* %.unpack.unpack.unpack19, align 4
-  br label %L99.L225_crit_edge
-
-L103.lr.ph.split:                                 ; preds = %L103.lr.ph
-  br i1 %17, label %L99.L225_crit_edge, label %L114
+  %16 = icmp ugt i64 %14, 10
+  br i1 %16, label %L180, label %L114
 
```