### PR TITLE
Test-suite improvements.

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,10 +47,9 @@ include("setup.jl")     # make sure everything is precompiled
 # choose tests
 const tests = []
 const test_runners = Dict()
-## GPUArrays testsuite
 for AT in (JLArray, Array), name in keys(TestSuite.tests)
-    push!(tests, "$(AT)$(Base.Filesystem.path_separator)$name")
-    test_runners["$(AT)$(Base.Filesystem.path_separator)$name"] = ()->TestSuite.tests[name](AT)
+    push!(tests, "$(AT)/$name")
+    test_runners["$(AT)/$name"] = ()->TestSuite.tests[name](AT)
 end
 unique!(tests)
 

--- a/test/testsuite.jl
+++ b/test/testsuite.jl
@@ -15,9 +15,6 @@ using Test
 
 using Adapt
 
-struct ArrayAdaptor{AT} end
-Adapt.adapt_storage(::ArrayAdaptor{AT}, xs::AbstractArray) where {AT} = AT(xs)
-
 test_result(a::Number, b::Number; kwargs...) = ≈(a, b; kwargs...)
 test_result(a::Missing, b::Missing; kwargs...) = true
 test_result(a::Number, b::Missing; kwargs...) = false
@@ -39,7 +36,7 @@ end
 function compare(f, AT::Type{<:AbstractGPUArray}, xs...; kwargs...)
     # copy on the CPU, adapt on the GPU, but keep Ref's
     cpu_in = map(x -> isa(x, Base.RefValue) ? x[] : deepcopy(x), xs)
-    gpu_in = map(x -> isa(x, Base.RefValue) ? x[] : adapt(ArrayAdaptor{AT}(), x), xs)
+    gpu_in = map(x -> isa(x, Base.RefValue) ? x[] : adapt(AT, x), xs)
 
     cpu_out = f(cpu_in...)
     gpu_out = f(gpu_in...)


### PR DESCRIPTION
The most important change here is to rely on `adapt(AT, x)` instead of rolling our own adaptor that uses the array type constructor, since the former may have some more functionality registered with it. Specifically:

```julia
julia> x = view(rand(Float32, 100, 100), 2:99, 2:99);

julia> typeof(x)
SubArray{Float32, 2, Matrix{Float32}, Tuple{UnitRange{Int64}, UnitRange{Int64}}, false}

julia> x isa StridedArray
true
```

```julia
julia> struct ArrayAdaptor{AT} end

julia> Adapt.adapt_storage(::ArrayAdaptor{AT}, xs::AbstractArray) where {AT} = AT(xs)

julia> y = adapt(ArrayAdaptor{CuArray}(), x);

julia> typeof(y)
SubArray{Float32, 2, CuArray{Float32, 2, CUDA.DeviceMemory}, Tuple{CuArray{Int64, 1, CUDA.DeviceMemory}, CuArray{Int64, 1, CUDA.DeviceMemory}}, false}

julia> y isa StridedCuArray
false
```

```julia
julia> z = adapt(CuArray, x);

julia> typeof(z)
SubArray{Float32, 2, CuArray{Float32, 2, CUDA.DeviceMemory}, Tuple{UnitRange{Int64}, UnitRange{Int64}}, false}

julia> z isa StridedCuArray
true
```

This may also be a bug we need to fix in Adapt, but it seems fine to rely more on `adapt(AT, x)` anyway.