### PR TITLE
Add vector-vector and matrix-matrix Kronecker product

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ Manifest.toml
 
 # MacOS generated files
 *.DS_Store
+
+/.vscode

--- a/src/host/linalg.jl
+++ b/src/host/linalg.jl
@@ -745,9 +745,7 @@ function LinearAlgebra.kron!(z::AbstractGPUVector{T1}, x::AbstractGPUVector{T2},
     @kernel function kron_kernel!(z, @Const(x), @Const(y))
         i, j = @index(Global, NTuple)
     
-        ly = length(y)
-    
-        @inbounds z[(i - 1) * ly + j] = x[i] * y[j]
+        @inbounds z[(i - 1) * length(y) + j] = x[i] * y[j]
     end
 
     backend = KernelAbstractions.get_backend(z)

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -310,6 +310,12 @@
         @test iszero(A)
         @test isone(A) == false
     end
+
+    @testset "kron" begin
+        for T in eltypes
+            @test compare(kron, AT, rand(T, 32), rand(T, 64))
+        end
+    end
 end
 
 @testsuite "linalg/mul!/vector-matrix" (AT, eltypes)->begin

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -314,6 +314,7 @@
     @testset "kron" begin
         for T in eltypes
             @test compare(kron, AT, rand(T, 32), rand(T, 64))
+            @test compare(kron, AT, rand(T, 32, 64), rand(T, 128, 16))
         end
     end
 end

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -314,7 +314,9 @@
     @testset "kron" begin
         for T in eltypes
             @test compare(kron, AT, rand(T, 32), rand(T, 64))
-            @test compare(kron, AT, rand(T, 32, 64), rand(T, 128, 16))
+            for opa in (identity, transpose, adjoint), opb in (identity, transpose, adjoint)
+                @test compare(kron, AT, opa(rand(T, 32, 64)), opb(rand(T, 128, 16)))
+            end
         end
     end
 end


### PR DESCRIPTION
The `kron` method between two `AbstractGPUVector` or two `AbstractGPUMatrix` was missing. 

This should fix [this issue](https://github.com/JuliaGPU/CUDA.jl/issues/2591) in CUDA.jl. It fixes also #558 .