### PR TITLE
More alloc cache improvements

### DIFF
--- a/src/host/abstractarray.jl
+++ b/src/host/abstractarray.jl
@@ -82,7 +82,7 @@ function Base.copy(ref::DataRef{D}) where {D}
     return DataRef{D}(ref.rc, false)
 end
 
-function unsafe_free!(ref::DataRef, args...)
+function unsafe_free!(ref::DataRef)
     if ref.freed
         # multiple frees *of the same object* are allowed.
         # we should only ever call `release` once per object, though,
@@ -90,7 +90,7 @@ function unsafe_free!(ref::DataRef, args...)
         return
     end
     ref.freed = true
-    release(ref.rc, args...)
+    release(ref.rc)
     return
 end
 

--- a/src/host/alloc_cache.jl
+++ b/src/host/alloc_cache.jl
@@ -147,13 +147,11 @@ GPUArrays.unsafe_free!(cache)
 See [`@uncached`](@ref).
 """
 macro cached(cache, expr)
+    try_expr = :(@with $(esc(ALLOC_CACHE)) => cache $(esc(expr)))
+    fin_expr = :(free_busy!($(esc(cache))))
     return quote
-        cache = $(esc(cache))
-        GC.@preserve cache begin
-            res = @with $(esc(ALLOC_CACHE)) => cache $(esc(expr))
-            free_busy!(cache)
-            res
-        end
+        local cache = $(esc(cache))
+        GC.@preserve cache $(Expr(:tryfinally, try_expr, fin_expr))
     end
 end
 

--- a/src/host/alloc_cache.jl
+++ b/src/host/alloc_cache.jl
@@ -8,8 +8,8 @@ end
 
 mutable struct AllocCache
     lock::ReentrantLock
-    busy::Dict{UInt64, Vector{Any}} # hash(key) => GPUArray[]
-    free::Dict{UInt64, Vector{Any}}
+    busy::Dict{UInt64, Vector{DataRef}}
+    free::Dict{UInt64, Vector{DataRef}}
 
     function AllocCache()
         cache = new(
@@ -24,8 +24,8 @@ end
 function get_pool!(cache::AllocCache, pool::Symbol, uid::UInt64)
     pool = getproperty(cache, pool)
     uid_pool = get(pool, uid, nothing)
-    if uid_pool ≡ nothing
-        uid_pool = Base.@lock cache.lock pool[uid] = Any[]
+    if uid_pool === nothing
+        uid_pool = Base.@lock cache.lock pool[uid] = DataRef[]
     end
     return uid_pool
 end
@@ -33,30 +33,33 @@ end
 function cached_alloc(f, key)
     cache = ALLOC_CACHE[]
     if cache === nothing
-        return f()::AbstractGPUArray
+        return f()::DataRef
     end
 
-    x = nothing
+    ref = nothing
     uid = hash(key)
 
     busy_pool = get_pool!(cache, :busy, uid)
     free_pool = get_pool!(cache, :free, uid)
-    isempty(free_pool) && (x = f()::AbstractGPUArray)
 
-    while !isempty(free_pool) && x ≡ nothing
-        tmp = Base.@lock cache.lock pop!(free_pool)
-        # Array was manually freed via `unsafe_free!`.
-        GPUArrays.storage(tmp).freed && continue
-        x = tmp
+    if !isempty(free_pool)
+        ref = Base.@lock cache.lock pop!(free_pool)
+        @assert !ref.freed
     end
 
-    x ≡ nothing && (x = f()::AbstractGPUArray)
-    Base.@lock cache.lock push!(busy_pool, x)
-    return x
+    if ref === nothing
+        ref = f()::DataRef
+
+        # increase the refcount of the ref to prevent finalizers from freeing it
+        retain(ref.rc)
+    end
+
+    Base.@lock cache.lock push!(busy_pool, ref)
+    return ref
 end
 
 function free_busy!(cache::AllocCache)
-    for uid in cache.busy.keys
+    for uid in keys(cache.busy)
         busy_pool = get_pool!(cache, :busy, uid)
         isempty(busy_pool) && continue
 
@@ -71,14 +74,18 @@ end
 
 function unsafe_free!(cache::AllocCache)
     Base.@lock cache.lock begin
-        for (_, pool) in cache.busy
+        for pool in values(cache.busy)
             isempty(pool) || error(
                 "Invalidating allocations cache that's currently in use. " *
                     "Invalidating inside `@cached` is not allowed."
             )
         end
-        for (_, pool) in cache.free
-            map(unsafe_free!, pool)
+        for pool in values(cache.free), ref in pool
+            # release our hold on the underlying data
+            release(ref.rc)
+
+            # early-release the reference
+            unsafe_free!(ref)
         end
         empty!(cache.free)
     end

--- a/test/testsuite/alloc_cache.jl
+++ b/test/testsuite/alloc_cache.jl
@@ -2,6 +2,7 @@
     if AT <: AbstractGPUArray
         cache = GPUArrays.AllocCache()
 
+        # first allocation populates the cache
         T, dims = Float32, (1, 2, 3)
         GPUArrays.@cached cache begin
             x1 = AT(zeros(T, dims))
@@ -10,34 +11,69 @@
         key = first(keys(cache.free))
         @test length(cache.free[key]) == 1
         @test length(cache.busy[key]) == 0
-        @test x1 === cache.free[key][1]
+        @test cache.free[key][1] === GPUArrays.storage(x1)
 
-        # Second allocation hits cache.
+        # second allocation hits the cache
         GPUArrays.@cached cache begin
             x2 = AT(zeros(T, dims))
-            # Does not hit the cache.
+
+            # explicitly uncached ones don't
             GPUArrays.@uncached x_free = AT(zeros(T, dims))
         end
         @test sizeof(cache) == sizeof(T) * prod(dims)
         key = first(keys(cache.free))
         @test length(cache.free[key]) == 1
         @test length(cache.busy[key]) == 0
-        @test x2 === cache.free[key][1]
+        @test cache.free[key][1] === GPUArrays.storage(x2)
         @test x_free !== x2
 
-        # Third allocation is of different shape - allocates.
-        dims = (2, 2)
+        # compatible shapes should also hit the cache
+        dims = (3, 2, 1)
         GPUArrays.@cached cache begin
             x3 = AT(zeros(T, dims))
+        end
+        @test sizeof(cache) == sizeof(T) * prod(dims)
+        key = first(keys(cache.free))
+        @test length(cache.free[key]) == 1
+        @test length(cache.busy[key]) == 0
+        @test cache.free[key][1] === GPUArrays.storage(x3)
+
+        # as should compatible eltypes
+        T = Int32
+        GPUArrays.@cached cache begin
+            x4 = AT(zeros(T, dims))
+        end
+        @test sizeof(cache) == sizeof(T) * prod(dims)
+        key = first(keys(cache.free))
+        @test length(cache.free[key]) == 1
+        @test length(cache.busy[key]) == 0
+        @test cache.free[key][1] === GPUArrays.storage(x4)
+
+        # different shapes should trigger a new allocation
+        dims = (2, 2)
+        GPUArrays.@cached cache begin
+            x5 = AT(zeros(T, dims))
+
+            # we're allowed to early free arrays, which shouldn't release the underlying data
+            GPUArrays.unsafe_free!(x5)
         end
         _keys = collect(keys(cache.free))
         key2 = _keys[findfirst(i -> i != key, _keys)]
         @test length(cache.free[key]) == 1
         @test length(cache.free[key2]) == 1
-        @test x3 === cache.free[key2][1]
+        @test cache.free[key2][1] === GPUArrays.storage(x5)
 
-        # Freeing all memory held by cache.
+        # freeing all memory held by cache should free all allocations
+        @test !GPUArrays.storage(x1).freed
+        @test GPUArrays.storage(x5).freed
+        @test GPUArrays.storage(x5).rc.count[] == 1 # the ref appears freed, but the data isn't
+        @test !GPUArrays.storage(x_free).freed
         GPUArrays.unsafe_free!(cache)
         @test sizeof(cache) == 0
+        @test GPUArrays.storage(x1).freed
+        @test GPUArrays.storage(x1).rc.count[] == 0
+        @test GPUArrays.storage(x5).freed
+        @test GPUArrays.storage(x5).rc.count[] == 0
+        @test !GPUArrays.storage(x_free).freed
     end
 end

--- a/test/testsuite/alloc_cache.jl
+++ b/test/testsuite/alloc_cache.jl
@@ -5,75 +5,87 @@
         # first allocation populates the cache
         T, dims = Float32, (1, 2, 3)
         GPUArrays.@cached cache begin
-            x1 = AT(zeros(T, dims))
+            cached1 = AT(zeros(T, dims))
         end
-        @test sizeof(cache) == sizeof(T) * prod(dims)
+        @test sizeof(cache) == sizeof(cached1)
         key = first(keys(cache.free))
         @test length(cache.free[key]) == 1
         @test length(cache.busy[key]) == 0
-        @test cache.free[key][1] === GPUArrays.storage(x1)
+        @test cache.free[key][1] === GPUArrays.storage(cached1)
 
         # second allocation hits the cache
         GPUArrays.@cached cache begin
-            x2 = AT(zeros(T, dims))
+            cached2 = AT(zeros(T, dims))
 
             # explicitly uncached ones don't
-            GPUArrays.@uncached x_free = AT(zeros(T, dims))
+            GPUArrays.@uncached uncached = AT(zeros(T, dims))
         end
-        @test sizeof(cache) == sizeof(T) * prod(dims)
+        @test sizeof(cache) == sizeof(cached2)
         key = first(keys(cache.free))
         @test length(cache.free[key]) == 1
         @test length(cache.busy[key]) == 0
-        @test cache.free[key][1] === GPUArrays.storage(x2)
-        @test x_free !== x2
+        @test cache.free[key][1] === GPUArrays.storage(cached2)
+        @test uncached !== cached2
 
         # compatible shapes should also hit the cache
         dims = (3, 2, 1)
         GPUArrays.@cached cache begin
-            x3 = AT(zeros(T, dims))
+            cached3 = AT(zeros(T, dims))
         end
-        @test sizeof(cache) == sizeof(T) * prod(dims)
+        @test sizeof(cache) == sizeof(cached3)
         key = first(keys(cache.free))
         @test length(cache.free[key]) == 1
         @test length(cache.busy[key]) == 0
-        @test cache.free[key][1] === GPUArrays.storage(x3)
+        @test cache.free[key][1] === GPUArrays.storage(cached3)
 
         # as should compatible eltypes
         T = Int32
         GPUArrays.@cached cache begin
-            x4 = AT(zeros(T, dims))
+            cached4 = AT(zeros(T, dims))
         end
-        @test sizeof(cache) == sizeof(T) * prod(dims)
+        @test sizeof(cache) == sizeof(cached4)
         key = first(keys(cache.free))
         @test length(cache.free[key]) == 1
         @test length(cache.busy[key]) == 0
-        @test cache.free[key][1] === GPUArrays.storage(x4)
+        @test cache.free[key][1] === GPUArrays.storage(cached4)
 
         # different shapes should trigger a new allocation
         dims = (2, 2)
         GPUArrays.@cached cache begin
-            x5 = AT(zeros(T, dims))
+            cached5 = AT(zeros(T, dims))
 
-            # we're allowed to early free arrays, which shouldn't release the underlying data
-            GPUArrays.unsafe_free!(x5)
+            # we're allowed to early free arrays, which should be a no-op for cached data
+            GPUArrays.unsafe_free!(cached5)
         end
+        @test sizeof(cache) == sizeof(cached4) + sizeof(cached5)
         _keys = collect(keys(cache.free))
         key2 = _keys[findfirst(i -> i != key, _keys)]
         @test length(cache.free[key]) == 1
         @test length(cache.free[key2]) == 1
-        @test cache.free[key2][1] === GPUArrays.storage(x5)
+        @test cache.free[key2][1] === GPUArrays.storage(cached5)
+
+        # we should be able to re-use the early-freed
+        GPUArrays.@cached cache begin
+            cached5 = AT(zeros(T, dims))
+        end
 
         # freeing all memory held by cache should free all allocations
-        @test !GPUArrays.storage(x1).freed
-        @test GPUArrays.storage(x5).freed
-        @test GPUArrays.storage(x5).rc.count[] == 1 # the ref appears freed, but the data isn't
-        @test !GPUArrays.storage(x_free).freed
+        @test !GPUArrays.storage(cached1).freed
+        @test GPUArrays.storage(cached1).cached
+        @test !GPUArrays.storage(cached5).freed
+        @test GPUArrays.storage(cached5).cached
+        @test !GPUArrays.storage(uncached).freed
+        @test !GPUArrays.storage(uncached).cached
         GPUArrays.unsafe_free!(cache)
         @test sizeof(cache) == 0
-        @test GPUArrays.storage(x1).freed
-        @test GPUArrays.storage(x1).rc.count[] == 0
-        @test GPUArrays.storage(x5).freed
-        @test GPUArrays.storage(x5).rc.count[] == 0
-        @test !GPUArrays.storage(x_free).freed
+        @test GPUArrays.storage(cached1).freed
+        @test !GPUArrays.storage(cached1).cached
+        @test GPUArrays.storage(cached5).freed
+        @test !GPUArrays.storage(cached5).cached
+        @test !GPUArrays.storage(uncached).freed
+        ## test that the underlying data was freed as well
+        @test GPUArrays.storage(cached1).rc.count[] == 0
+        @test GPUArrays.storage(cached5).rc.count[] == 0
+        @test GPUArrays.storage(uncached).rc.count[] == 1
     end
 end

--- a/test/testsuite/alloc_cache.jl
+++ b/test/testsuite/alloc_cache.jl
@@ -69,6 +69,14 @@
             cached5 = AT(zeros(T, dims))
         end
 
+        # exceptions shouldn't cause issues
+        @test_throws "Allowed exception" GPUArrays.@cached cache begin
+            AT(zeros(T, dims))
+            error("Allowed exception")
+        end
+        # NOTE: this should remaint the last test before calling `unsafe_free!` below,
+        #       as it caught an erroneous assertion in the original code.
+
         # freeing all memory held by cache should free all allocations
         @test !GPUArrays.storage(cached1).freed
         @test GPUArrays.storage(cached1).cached


### PR DESCRIPTION
- cache DataRefs instead of arrays, which should be more lightweight and allow for more caching (eltype or dim mismatches)
- lock more cache ops; I don't think the current implementation was safe

The manual refcount fiddling is a bit dangerous (it should be compatible with manual `unsafe_free!`s and the GC), but I think is correct. @pxl-th Maybe test with one of your apps using this? Ideally, first adapt your back-end to key on bufsize instead of dims and remove T.