### PR TITLE
Restore map! behaviour

### DIFF
--- a/src/host/broadcast.jl
+++ b/src/host/broadcast.jl
@@ -103,7 +103,7 @@ function Base.map(f, xs::AnyGPUArray...)
     return map!(f, dest, xs...)
 end
 
-function Base.map!(f, dest::AnyGPUArray, xs::AnyGPUArray...)
+function Base.map!(f, dest::AnyGPUArray, xs::AbstractArray...)
     # custom broadcast, ignoring the container size mismatches
     # (avoids the reshape + view that our mapreduce impl has to do)
     indices = LinearIndices.((dest, xs...))

--- a/test/testsuite/broadcasting.jl
+++ b/test/testsuite/broadcasting.jl
@@ -143,7 +143,7 @@ function broadcasting(AT, eltypes)
             @test compare(AT, rand(ET, 2,2), rand(ET, 2)) do x,y
                 map!(+, x, y)
             end
-            @test compare(AT, rand(ET, 2), 1:2) do x,y
+            @test compare(AT, rand(ET, 2), 1:2) do x, y
                 map!(+, x, y)
             end
         end

--- a/test/testsuite/broadcasting.jl
+++ b/test/testsuite/broadcasting.jl
@@ -143,6 +143,9 @@ function broadcasting(AT, eltypes)
             @test compare(AT, rand(ET, 2,2), rand(ET, 2)) do x,y
                 map!(+, x, y)
             end
+            @test compare(AT, rand(ET, 2), 1:2) do x,y
+                map!(+, x, y)
+            end
         end
 
         @testset "map $ET" begin


### PR DESCRIPTION
Partially fix for #580, since we have a destination that is unambigous for `map!`.
