### PR TITLE
Speed up fill for high dimensional arrays

### DIFF
--- a/src/host/construction.jl
+++ b/src/host/construction.jl
@@ -19,7 +19,7 @@ function Base.fill!(A::AnyGPUArray{T}, x) where T
 
     # ndims check for 0D support
     kernel = fill_kernel!(get_backend(A))
-    kernel(A, x; ndrange = ndims(A) > 0 ? length(A) : (1,))
+    kernel(A, x; ndrange = length(A))
     A
 end
 

--- a/src/host/construction.jl
+++ b/src/host/construction.jl
@@ -19,7 +19,7 @@ function Base.fill!(A::AnyGPUArray{T}, x) where T
 
     # ndims check for 0D support
     kernel = fill_kernel!(get_backend(A))
-    kernel(A, x; ndrange = ndims(A) > 0 ? size(A) : (1,))
+    kernel(A, x; ndrange = ndims(A) > 0 ? length(A) : (1,))
     A
 end
 


### PR DESCRIPTION
Fix the following issue:
https://github.com/ArrogantGao/benchmark_tropical_tensornetwork/issues/1

After fix, it has 20x speed up on high dimensional arrays:
```julia
julia> @btime CUDA.@sync fill!($(CUDA.zeros(TropicalF32, fill(2, 20)...)), zero(TropicalF32));
  15.316 μs (57 allocations: 1.52 KiB)
```