### PR TITLE
Fix CI warnings

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
-          file: lcov.info
+          files: lcov.info
   opencl:
     name: OpenCL.jl
     runs-on: ubuntu-latest
@@ -90,7 +90,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
-          file: lcov.info
+          files: lcov.info
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -16,13 +16,11 @@ jobs:
       matrix:
         version: ['1.10', '1.11', '^1.12.0-0', 'nightly']
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        arch: [default]
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v2
       - name: Develop subpackages
         run: |
@@ -48,7 +46,6 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: '1.10'
-          arch: x64
       - uses: julia-actions/cache@v2
       - name: Run tests
         run: |

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -9,14 +9,14 @@ on:
 
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         version: ['1.10', '1.11', '^1.12.0-0', 'nightly']
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        arch: [x64]
+        arch: [default]
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
Success means no warning about `file` not being a valid option, and macos-latest not complaining about x64 being requested