### PR TITLE
Support KernelAbstractions 0.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [compat]
 Adapt = "4.0"
 GPUArraysCore = "= 0.2.0"
-KernelAbstractions = "0.9.28"
+KernelAbstractions = "0.9.28, 0.10.0"
 LLVM = "3.9, 4, 5, 6, 7, 8, 9"
 LinearAlgebra = "1"
 Printf = "1"

--- a/lib/JLArrays/Project.toml
+++ b/lib/JLArrays/Project.toml
@@ -12,6 +12,6 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 [compat]
 Adapt = "2.0, 3.0, 4.0"
 GPUArrays = "11.1"
-KernelAbstractions = "0.9"
+KernelAbstractions = "0.9, 0.10"
 Random = "1"
 julia = "1.8"


### PR DESCRIPTION
All the breaking changes will be on the CPU backend side,
the kernel interface itself is unchanged. 

- [ ] Replace JLBackend with POCLBackend
