### PR TITLE
Preserve 0-dim GPU arrays in `map`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GPUArrays"
 uuid = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
-version = "11.2.2"
+version = "11.3.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/host/broadcast.jl
+++ b/src/host/broadcast.jl
@@ -85,7 +85,7 @@ allequal(x, y, z...) = x == y && allequal(y, z...)
 function Base.map(f, xs::AnyGPUArray...)
     # if argument sizes match, their shape needs to be preserved
     if allequal(size.(xs)...)
-         return f.(xs...)
+         return Broadcast.broadcast_preserving_zero_d(f, xs...)
     end
 
     # if not, treat them as iterators

--- a/test/testsuite/broadcasting.jl
+++ b/test/testsuite/broadcasting.jl
@@ -158,6 +158,11 @@ function broadcasting(AT, eltypes)
             @test compare(AT, rand(ET, 2,2), rand(ET, 2)) do x,y
                 map(+, x, y)
             end
+            ############
+            # issue #598
+            @test compare(AT, rand(ET, ()), rand(ET, ())) do x,y
+                map(+, x, y)
+            end
         end
     end
 


### PR DESCRIPTION
Preserve 0-dim GPU arrays in `map`. Fixes #598.