### PR TITLE
Test OpenCL with julia 1.11

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
-          version: '1.10'
+          version: '1.11'
       - uses: julia-actions/cache@v2
       - name: Run tests
         run: |


### PR DESCRIPTION
So the latesst SPIRVIntrinsics is picked up. Another solution if we want to stick with 1.10 is shown as a suggestion.