### PR TITLE
Allow non-sorted indices in sparse matrix formats

### DIFF
--- a/src/host/sparse.jl
+++ b/src/host/sparse.jl
@@ -242,9 +242,12 @@ function Base.getindex(A::AbstractGPUSparseMatrixCSC{T}, i0::Integer, i1::Intege
     r1 = Int(SparseArrays.getcolptr(A)[i1])
     r2 = Int(SparseArrays.getcolptr(A)[i1+1]-1)
     (r1 > r2) && return zero(T)
-    r1 = searchsortedfirst(SparseArrays.rowvals(A), i0, r1, r2, Base.Order.Forward)
-    (r1 > r2 || SparseArrays.rowvals(A)[r1] != i0) && return zero(T)
-    SparseArrays.nonzeros(A)[r1]
+    r0 = findfirst(i0, view(SparseArrays.rowvals(A), r1, r2))
+    if isnothing(r0)
+        return zero(T)
+    else
+        return SparseArrays.nonzeros(A)[something(r0) + r1 - 1]
+    end
 end
 
 ## copying between sparse GPU arrays


### PR DESCRIPTION
Fixes #648

I searched for `sort` in all sparse-related files and replaced where necessary. I don't think we need to fix sparse vectors since CUDA assumes those are sorted.

I'd need some help for the tests, since we need to revamp the design a little bit to construct GPU sparse matrices from inputs that are _not_ `SparseMatrixCSC`. How would you like to proceed @kshyatt?