### PR TITLE
Return early (don't kernel launch) for copytrito and zero-sized arrays

### DIFF
--- a/src/host/linalg.jl
+++ b/src/host/linalg.jl
@@ -164,6 +164,7 @@ if isdefined(LinearAlgebra, :copytrito!)
             else
                 (m1 < m || n1 < n) && throw(DimensionMismatch("B of size ($m1,$n1) should have at least size ($m,$n)"))
             end
+            length(A) == 0 && return B
             @kernel function U_kernel!(_A, _B)
                 I = @index(Global, Cartesian)
                 i, j = Tuple(I)
@@ -178,6 +179,7 @@ if isdefined(LinearAlgebra, :copytrito!)
             else
                 (m1 < m || n1 < n) && throw(DimensionMismatch("B of size ($m1,$n1) should have at least size ($m,$n)"))
             end
+            length(A) == 0 && return B
             @kernel function L_kernel!(_A, _B)
                 I = @index(Global, Cartesian)
                 i, j = Tuple(I)


### PR DESCRIPTION
This was getting hit at https://buildkite.com/julialang/cuda-dot-jl/builds/6739#019ab523-924c-4308-8219-1305d58116da. Not sure why the existing buildkite tests didn't detect it.