### PR TITLE
Make stats tests numerically more stable for oneAPI

### DIFF
--- a/test/testsuite/statistics.jl
+++ b/test/testsuite/statistics.jl
@@ -5,7 +5,8 @@ using Statistics
         if !(ET in [Float16, Float32, Float64])
             continue
         end
-        range = ET <: Real ? (ET(1):ET(100)) : ET
+        # Larger range for Float16 to avoid numerical instability
+        range = ET == Float16 ? (ET(1):ET(100)) : ET
 
         @testset "std" begin
             @test compare(std, AT, rand(range, 10))
@@ -40,7 +41,8 @@ using Statistics
         if !(ET in [Float32, Float64, Float16, ComplexF64])
             continue
         end
-        range = ET <: Real ? (ET(1):ET(100)) : ET
+        # Larger range for Float16 to avoid numerical instability
+        range = ET == Float16 ? (ET(1):ET(100)) : ET
 
         @testset "cov" begin
             s = 100


### PR DESCRIPTION
On oneAPI.jl, the cor(A; dims=2) test failed for `Float16` (one some GPUs), caused by numerical instability when computing the variance of rows with only 2 elements drawn from [0, 1). This leads to subnormal variances, which are flushed to zero on the CPU (causing NaN or -1 results) but preserved on the oneAPI GPU (causing valid results), resulting in a mismatch. 

Now I'm not a stats person, and I don't want to fix anything deeper in Intel oneAPI, but it seems to be fixed with an extended range. I saw that there was already such a special case for `Real`.  Unfortunately, that still doesn't fix the `ComplexF32` case.