### PR TITLE
Add GPU-compatible iszero for sparse arrays

### DIFF
--- a/src/host/sparse.jl
+++ b/src/host/sparse.jl
@@ -36,6 +36,11 @@ Base.Array(x::AbstractGPUSparseMatrixCSR) = collect(SparseMatrixCSC(x))
 Base.Array(x::AbstractGPUSparseMatrixBSR) = collect(SparseMatrixCSC(x))
 Base.Array(x::AbstractGPUSparseMatrixCOO) = collect(SparseMatrixCSC(x))
 
+# iszero that avoids scalar indexing by using GPU-compatible reduction
+# nnz(A) == 0 means no stored elements, so it's definitely zero
+# all(iszero, nonzeros(A)) uses GPU reduction to check stored values
+Base.iszero(A::AbstractGPUSparseArray) = SparseArrays.nnz(A) == 0 || all(iszero, SparseArrays.nonzeros(A))
+
 SparseArrays.SparseVector(x::AbstractGPUSparseVector) = SparseVector(length(x), Array(SparseArrays.nonzeroinds(x)), Array(SparseArrays.nonzeros(x)))
 SparseArrays.SparseMatrixCSC(x::AbstractGPUSparseMatrixCSC) = SparseMatrixCSC(size(x)..., Array(SparseArrays.getcolptr(x)), Array(SparseArrays.rowvals(x)), Array(SparseArrays.nonzeros(x)))
 

--- a/test/testsuite/sparse.jl
+++ b/test/testsuite/sparse.jl
@@ -5,12 +5,14 @@
             vector(sparse_AT, eltypes)
             vector_construction(sparse_AT, eltypes)
             broadcasting_vector(sparse_AT, eltypes)
+            iszero_vector(sparse_AT, eltypes)
         elseif sparse_AT <: AbstractSparseMatrix
             matrix(sparse_AT, eltypes)
             matrix_construction(sparse_AT, eltypes)
             broadcasting_matrix(sparse_AT, eltypes)
             mapreduce_matrix(sparse_AT, eltypes)
             linalg(sparse_AT, eltypes)
+            iszero_matrix(sparse_AT, eltypes)
        end
     end
 end
@@ -358,6 +360,65 @@ function linalg(AT, eltypes)
                     @test_throws ArgumentError opnorm(dA, 2)
                 end
             end
+        end
+    end
+end
+
+function iszero_vector(AT, eltypes)
+    for ET in eltypes
+        @testset "iszero SparseVector($ET)" begin
+            m = 25
+
+            # Test non-zero sparse vector
+            x = sprand(ET, m, 0.5)
+            while iszero(x)
+                x = sprand(ET, m, 0.5)
+            end
+            d_x = AT(x)
+            @test iszero(d_x) == iszero(x)
+            @test iszero(d_x) == false
+
+            # Test zero sparse vector (no stored elements)
+            z = spzeros(ET, m)
+            d_z = AT(z)
+            @test iszero(d_z) == iszero(z)
+            @test iszero(d_z) == true
+
+            # Test sparse vector with stored zeros (e.g., after operations)
+            # Create a sparse vector then multiply by zero
+            x_zeros = x .* zero(ET)
+            d_x_zeros = d_x .* zero(ET)
+            @test iszero(d_x_zeros) == iszero(x_zeros)
+            @test iszero(d_x_zeros) == true
+        end
+    end
+end
+
+function iszero_matrix(AT, eltypes)
+    for ET in eltypes
+        @testset "iszero SparseMatrix($ET)" begin
+            m, n = 10, 10
+
+            # Test non-zero sparse matrix
+            A = sprand(ET, m, n, 0.5)
+            while iszero(A)
+                A = sprand(ET, m, n, 0.5)
+            end
+            dA = AT(A)
+            @test iszero(dA) == iszero(A)
+            @test iszero(dA) == false
+
+            # Test zero sparse matrix (no stored elements)
+            ZA = spzeros(ET, m, n)
+            dZA = AT(ZA)
+            @test iszero(dZA) == iszero(ZA)
+            @test iszero(dZA) == true
+
+            # Test sparse matrix with stored zeros
+            A_zeros = A .* zero(ET)
+            dA_zeros = dA .* zero(ET)
+            @test iszero(dA_zeros) == iszero(A_zeros)
+            @test iszero(dA_zeros) == true
         end
     end
 end


### PR DESCRIPTION
## Summary

- Add `Base.iszero` method for `AbstractGPUSparseArray` that avoids scalar indexing
- Implementation uses GPU-compatible operations: `nnz(A) == 0 || all(iszero, nonzeros(A))`
- Benefits all GPU backends (CUDA, AMDGPU, Metal) through the abstract type

## Motivation

This addresses https://github.com/JuliaGPU/CUDA.jl/pull/2997#issuecomment-3664406274 where @kshyatt suggested implementing `iszero` in GPUArrays.jl rather than just CUDA.jl, so all GPU backends can benefit.

The problem: `Base.iszero(A::AbstractArray) = all(iszero, A)` triggers scalar indexing errors on GPU arrays when scalar indexing is disabled. Packages like SciMLOperators.jl call `iszero` on operators during arithmetic, causing failures.

The solution:
```julia
Base.iszero(A::AbstractGPUSparseArray) = SparseArrays.nnz(A) == 0 || all(iszero, SparseArrays.nonzeros(A))
```

This works because:
1. `nnz(A) == 0` is a simple integer comparison (no GPU access)
2. `nonzeros(A)` returns the GPU array of stored values
3. `all(iszero, GPUArray)` uses GPU-compatible reduction from GPUArrays

## Test plan

- [x] Added tests for sparse vectors (`iszero_vector`)
- [x] Added tests for sparse matrices (`iszero_matrix`)
- [x] Tests cover: non-zero arrays, zero arrays (no stored elements), arrays with stored zeros
- [x] Verified locally with JLArrays backend

Related:
- Fixes https://github.com/SciML/SciMLOperators.jl/issues/338
- Ref: https://github.com/JuliaGPU/CUDA.jl/pull/2997

🤖 Generated with [Claude Code](https://claude.com/claude-code)