### PR TITLE
feat: Implement issorted for AbstractGPUArray without scalar indexing.

### DIFF
--- a/test/testsuite/base.jl
+++ b/test/testsuite/base.jl
@@ -48,13 +48,13 @@ end
 
         # order keyword normalization
         @test compare(
-            x -> issorted(x; order = Base.Order.ReverseOrdering()),
+            x -> issorted(x; order = Base.Order.Reverse),
             AT,
             [3, 2, 1],
         )
 
         @test compare(
-            x -> !issorted(x; order = Base.Order.ReverseOrdering()),
+            x -> !issorted(x; order = Base.Order.Reverse),
             AT,
             [1, 2, 3],
         )


### PR DESCRIPTION
Fix for #635 

`Base.issorted` on AbstractGPUArray currently falls back to scalar iteration, which triggers scalar indexing errors and prevents correct usage on GPU-backed arrays.

This PR introduces a GPU-native implementation of `issorted` using a kernel-based approach, ensuring the operation executes entirely on the device.

### Tests

(GPUArrays with base as `test_args`)

<img width="1080" height="145" alt="image" src="https://github.com/user-attachments/assets/22e640bc-bf27-4a90-a325-91f86f81042d" />

---

(GPUArrays)
<img width="544" height="124" alt="Screenshot 2026-01-15 181343" src="https://github.com/user-attachments/assets/59215956-fc2a-45f1-b6ab-f7e91ee66e80" />
