### PR TITLE
Add direct constructors for sparse arrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "11.3.4"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+Atomix = "a9b6321e-bd34-4604-b9c9-b65b8de01458"
 GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 LLVM = "929cbde3-209d-540e-8aea-75f648917ca0"
@@ -24,6 +25,7 @@ JLD2Ext = "JLD2"
 
 [compat]
 Adapt = "4.0"
+Atomix = "1"
 GPUArraysCore = "= 0.2.0"
 JLD2 = "0.4, 0.5, 0.6"
 KernelAbstractions = "0.9.28, 0.10"

--- a/lib/JLArrays/src/JLArrays.jl
+++ b/lib/JLArrays/src/JLArrays.jl
@@ -13,7 +13,7 @@ using GPUArrays
 using Adapt
 using SparseArrays, LinearAlgebra
 
-import GPUArrays: dense_array_type
+import GPUArrays: dense_array_type, GPUSparseMatrixCSC, GPUSparseMatrixCSR
 
 import KernelAbstractions
 import KernelAbstractions: Adapt, StaticArrays, Backend, Kernel, StaticSize, DynamicSize, partition, blocks, workitems, launch_config
@@ -150,6 +150,9 @@ mutable struct JLSparseMatrixCSC{Tv, Ti} <: GPUArrays.AbstractGPUSparseMatrixCSC
         new{Tv, Ti}(colPtr, rowVal, nzVal, dims, length(nzVal))
     end
 end
+function GPUSparseMatrixCSC(colPtr::JLArray{Ti, 1}, rowVal::JLArray{Ti, 1}, nzVal::JLArray{Tv, 1}, dims::NTuple{2,<:Integer}) where {Tv, Ti <: Integer}
+    return JLSparseMatrixCSC(colPtr, rowVal, nzVal, dims)
+end
 function JLSparseMatrixCSC(colPtr::JLArray{Ti, 1}, rowVal::JLArray{Ti, 1}, nzVal::JLArray{Tv, 1}, dims::NTuple{2,<:Integer}) where {Tv, Ti <: Integer}
     return JLSparseMatrixCSC{Tv, Ti}(colPtr, rowVal, nzVal, dims)
 end
@@ -180,6 +183,9 @@ mutable struct JLSparseMatrixCSR{Tv, Ti} <: GPUArrays.AbstractGPUSparseMatrixCSR
 end
 function JLSparseMatrixCSR(rowPtr::JLArray{Ti, 1}, colVal::JLArray{Ti, 1}, nzVal::JLArray{Tv, 1}, dims::NTuple{2,<:Integer}) where {Tv, Ti <: Integer}
     return JLSparseMatrixCSR{Tv, Ti}(rowPtr, colVal, nzVal, dims)
+end
+function GPUSparseMatrixCSR(rowPtr::JLArray{Ti, 1}, colVal::JLArray{Ti, 1}, nzVal::JLArray{Tv, 1}, dims::NTuple{2,<:Integer}) where {Tv, Ti <: Integer}
+    return JLSparseMatrixCSR(rowPtr, colVal, nzVal, dims)
 end
 function SparseArrays.SparseMatrixCSC(x::JLSparseMatrixCSR) 
     x_transpose = SparseMatrixCSC(size(x, 2), size(x, 1), Array(x.rowPtr), Array(x.colVal), Array(x.nzVal))

--- a/src/GPUArrays.jl
+++ b/src/GPUArrays.jl
@@ -16,6 +16,7 @@ using Reexport
 @reexport using GPUArraysCore
 
 using KernelAbstractions
+using Atomix
 
 # device functionality
 include("device/abstractarray.jl")

--- a/src/host/sparse.jl
+++ b/src/host/sparse.jl
@@ -1,6 +1,6 @@
 using LinearAlgebra
 using LinearAlgebra: BlasFloat
-export GPUSparseMatrix, GPUSparseMatrixCSC, GPUSparseMatrixCSR, GPUSparseMatrixCOO
+export GPUSparseMatrix, GPUSparseMatrixCSC, GPUSparseMatrixCSR, GPUSparseMatrixCOO, GPUSparseMatrixBSR
 
 abstract type AbstractGPUSparseArray{Tv, Ti, N} <: AbstractSparseArray{Tv, Ti, N} end
 const AbstractGPUSparseVector{Tv, Ti} = AbstractGPUSparseArray{Tv, Ti, 1}
@@ -15,6 +15,7 @@ GPUSparseMatrix(I::AbstractGPUVector, J::AbstractGPUVector, V::AbstractGPUVector
 GPUSparseMatrixCOO(I::AbstractGPUVector, J::AbstractGPUVector, V::AbstractGPUVector, args...; kwargs...) = sparse(I, J, V, args...; kwargs...)
 function GPUSparseMatrixCSC end
 function GPUSparseMatrixCSR end
+function GPUSparseMatrixBSR end
 
 
 const AbstractGPUSparseVecOrMat = Union{AbstractGPUSparseVector,AbstractGPUSparseMatrix}

--- a/src/host/sparse.jl
+++ b/src/host/sparse.jl
@@ -1,5 +1,6 @@
 using LinearAlgebra
 using LinearAlgebra: BlasFloat
+export GPUSparseMatrix, GPUSparseMatrixCSC, GPUSparseMatrixCSR, GPUSparseMatrixCOO
 
 abstract type AbstractGPUSparseArray{Tv, Ti, N} <: AbstractSparseArray{Tv, Ti, N} end
 const AbstractGPUSparseVector{Tv, Ti} = AbstractGPUSparseArray{Tv, Ti, 1}
@@ -9,6 +10,12 @@ abstract type AbstractGPUSparseMatrixCSC{Tv, Ti} <: AbstractGPUSparseArray{Tv, T
 abstract type AbstractGPUSparseMatrixCSR{Tv, Ti} <: AbstractGPUSparseArray{Tv, Ti, 2} end
 abstract type AbstractGPUSparseMatrixCOO{Tv, Ti} <: AbstractGPUSparseArray{Tv, Ti, 2} end
 abstract type AbstractGPUSparseMatrixBSR{Tv, Ti} <: AbstractGPUSparseArray{Tv, Ti, 2} end
+
+GPUSparseMatrix(I::AbstractGPUVector, J::AbstractGPUVector, V::AbstractGPUVector, args...; kwargs...) = GPUSparseMatrixCOO(I, J, V, args...; kwargs...)
+GPUSparseMatrixCOO(I::AbstractGPUVector, J::AbstractGPUVector, V::AbstractGPUVector, args...; kwargs...) = sparse(I, J, V, args...; kwargs...)
+function GPUSparseMatrixCSC end
+function GPUSparseMatrixCSR end
+
 
 const AbstractGPUSparseVecOrMat = Union{AbstractGPUSparseVector,AbstractGPUSparseMatrix}
 

--- a/src/host/sparse.jl
+++ b/src/host/sparse.jl
@@ -11,7 +11,7 @@ abstract type AbstractGPUSparseMatrixCSR{Tv, Ti} <: AbstractGPUSparseArray{Tv, T
 abstract type AbstractGPUSparseMatrixCOO{Tv, Ti} <: AbstractGPUSparseArray{Tv, Ti, 2} end
 abstract type AbstractGPUSparseMatrixBSR{Tv, Ti} <: AbstractGPUSparseArray{Tv, Ti, 2} end
 
-GPUSparseMatrixCOO(I::AbstractGPUVector, J::AbstractGPUVector, V::AbstractGPUVector, args...; kwargs...) = sparse(I, J, V, args...; kwargs...)
+function GPUSparseMatrixCOO end
 function GPUSparseMatrixCSC end
 function GPUSparseMatrixCSR end
 function GPUSparseMatrixBSR end 

--- a/src/host/sparse.jl
+++ b/src/host/sparse.jl
@@ -11,11 +11,57 @@ abstract type AbstractGPUSparseMatrixCSR{Tv, Ti} <: AbstractGPUSparseArray{Tv, T
 abstract type AbstractGPUSparseMatrixCOO{Tv, Ti} <: AbstractGPUSparseArray{Tv, Ti, 2} end
 abstract type AbstractGPUSparseMatrixBSR{Tv, Ti} <: AbstractGPUSparseArray{Tv, Ti, 2} end
 
-GPUSparseMatrix(I::AbstractGPUVector, J::AbstractGPUVector, V::AbstractGPUVector, args...; kwargs...) = GPUSparseMatrixCOO(I, J, V, args...; kwargs...)
 GPUSparseMatrixCOO(I::AbstractGPUVector, J::AbstractGPUVector, V::AbstractGPUVector, args...; kwargs...) = sparse(I, J, V, args...; kwargs...)
 function GPUSparseMatrixCSC end
 function GPUSparseMatrixCSR end
-function GPUSparseMatrixBSR end
+function GPUSparseMatrixBSR end 
+
+function compute_sparse_pointers(indices::AbstractGPUVector{T}, n::Integer) where T
+    ptr = similar(indices, T, n + 1)
+    fill!(ptr, zero(T))
+
+    @kernel function count_indices(@Const(indices), ptr)
+        idx = @index(Global, Linear)
+        if idx == 1
+            ptr[idx] = one(T)
+        end
+        Atomix.@atomic ptr[indices[idx] + 1] += one(T)
+    end
+    
+    backend = get_backend(indices)
+    kernel! = count_indices(backend)
+    kernel!(indices, ptr, ndrange=length(indices))
+    return cumsum(ptr)
+end
+
+function GPUSparseMatrix(I::AbstractGPUVector, J::AbstractGPUVector, V::AbstractGPUVector, dims::NTuple{2, <:Integer}; format = default_sparse_format(I))
+	m, n = dims
+    if format == :coo
+		GPUSparseMatrix(Val(:coo), I, J, V, dims)
+    elseif format == :csc
+        # Create composite key for sorting
+        key = J .* (m + 1) .+ I
+        perm = sortperm(key)
+        
+        ptr = compute_sparse_pointers(J[perm], n)
+        return GPUSparseMatrix(Val(:csc), ptr, I[perm], V[perm], dims)
+    elseif format == :csr
+        # Create composite key for sorting
+        key = I .* (n + 1) .+ J
+        perm = sortperm(key)
+        
+        ptr = compute_sparse_pointers(I[perm], m)
+        return GPUSparseMatrix(Val(:csr), ptr, J[perm], V[perm], dims)
+    else
+        throw(ArgumentError("Conversion to sparse format $format is not implemented"))
+	end
+end
+
+
+GPUSparseMatrix(::Val{:coo}, I, J, V, dims) = GPUSparseMatrixCOO(I, J, V, dims)
+GPUSparseMatrix(::Val{:csc}, colPtr, rowVal, nzVal, dims) = GPUSparseMatrixCSC(colPtr, rowVal, nzVal, dims)
+GPUSparseMatrix(::Val{:csr}, rowPtr, colVal, nzVal, dims) = GPUSparseMatrixCSR(rowPtr, colVal, nzVal, dims)
+#GPUSparseMatrix(::Val{:bsr}, ...) = GPUSparseMatrixBSR(...)
 
 
 const AbstractGPUSparseVecOrMat = Union{AbstractGPUSparseVector,AbstractGPUSparseMatrix}


### PR DESCRIPTION
This PR adds direct constructors for the sparse matrix types defined in GPUArrays.jl or rather adds a function for backends to generically define methods for, see also #677.

Changes:
- Introduced a generic function for backends to define constructors for sparse formats.
- Added direct constructors for sparse matrices with a specified format.
- Added a GPUSparseMatrix convenience constructor that defaults to GPUSparseMatrixCOO, which in turn falls back to SparseArrays.sparse for completeness.
- Added tests for CSC and CSR, which can also be extended to the other formats. I was unsure if the constructor tests should also assert behaviour, so far I've only checked for appropriate array types and size.

There currently is no COO and BSR implementation for JLArrays. I could add one as well, at least for the BSR I'd need to take a look at the format first or adapt from maybe CUDA.jl
