### PR TITLE
Remove inconsistent `Base.copy!` method

### DIFF
--- a/src/host/abstractarray.jl
+++ b/src/host/abstractarray.jl
@@ -160,12 +160,6 @@ Base.collect(X::AnyGPUArray) = collect_to_cpu(X)
 # expects the GPU array type to have linear `copyto!` methods (i.e. accepting an integer
 # offset and length) from and to CPU arrays and between GPU arrays.
 
-function Base.copy!(dst::AbstractGPUVector, src::AbstractGPUVector)
-    axes(dst) == axes(src) || throw(ArgumentError(
-    "arrays must have the same axes for `copy!`. consider using `copyto!` instead"))
-    copyto!(dst, src)
-end
-
 for (D, S) in ((AnyGPUArray, Array),
                (Array, AnyGPUArray),
                (AnyGPUArray, AnyGPUArray))

--- a/test/testsuite/base.jl
+++ b/test/testsuite/base.jl
@@ -84,6 +84,26 @@ end
             copy!(dst, src)
             @test dst == src
         end
+        @testset "copy! with differently sized vectors will resize the dst" begin
+            dst = AT(rand(Float32, (5,)))
+            src = AT(rand(Float32, (10,)))
+            copy!(dst, src)
+            @test length(dst) == 10
+            @test dst == src
+
+            dst = AT(rand(Float32, (10,)))
+            src = AT(rand(Float32, (5,)))
+            copy!(dst, src)
+            @test length(dst) == 5
+            @test dst == src
+        end
+
+        @testset "copy! with differently sized higher dim arrays will error." begin
+            dst = AT(rand(Float32, (10, 1)))
+            src = AT(rand(Float32, (5, 1)))
+            @test_throws Exception copy!(dst, src)
+            @test_throws Exception copy!(src, dst)
+        end
     end
 
     @testset "copyto!" begin


### PR DESCRIPTION
Fixes #695

This method is no longer needed now that Base fallsback to `copyto!` https://github.com/JuliaLang/julia/pull/46161 