### PR TITLE
Fixing Base.show for sparse device COO format matrices

### DIFF
--- a/src/device/sparse.jl
+++ b/src/device/sparse.jl
@@ -156,7 +156,7 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", A::GPUSparseDeviceMatrixCOO)
     println(io, "$(length(A))-element device sparse matrix COO at:")
-    println(io, "  rowPtr: $(A.rowPtr)")
+    println(io, "  rowInd: $(A.rowInd)")
     println(io, "  colInd: $(A.colInd)")
     print(io,   "  nzVal:  $(A.nzVal)")
 end


### PR DESCRIPTION
I ran into this while working on #694 and I thought it was best to address it on a different PR