### PR TITLE
Detect contiguous views with mixed unit-range indices

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -65,7 +65,8 @@ steps:
           version: "{{matrix.julia}}"
       - JuliaCI/julia-coverage#v1:
           codecov: true
-    command: |
+    commands: |
+      unset LD_LIBRARY_PATH
       julia -e 'using Pkg
 
                 gpuarrays = pwd()

--- a/src/host/base.jl
+++ b/src/host/base.jl
@@ -313,6 +313,7 @@ end
 ## views
 
 struct Contiguous end
+struct MaybeContiguous end
 struct NonContiguous end
 
 # NOTE: this covers more cases than the I<:... in Base.FastContiguousSubArray
@@ -324,6 +325,18 @@ GPUIndexStyle(::Base.Slice, ::Union{Base.ScalarIndex, CartesianIndex}...) = Cont
 GPUIndexStyle(::AbstractUnitRange, ::Union{Base.ScalarIndex, CartesianIndex}...) = Contiguous()
 GPUIndexStyle(::Colon, I...) = GPUIndexStyle(I...)
 GPUIndexStyle(::Base.Slice, I...) = GPUIndexStyle(I...)
+# Two or more adjacent AbstractUnitRange indices can't be classified statically;
+# whether the view is contiguous depends on the lengths of the ranges (e.g.
+# `view(A, 1:1, 1:1)` is contiguous, but `view(A, 1:2, 1:2)` is not). Defer
+# those cases to a runtime stride check.
+GPUIndexStyle(::AbstractUnitRange, ::AbstractUnitRange,
+              ::Vararg{Union{AbstractUnitRange, Base.ScalarIndex, CartesianIndex}}) =
+    MaybeContiguous()
+# Disambiguate the above from the recursive `Base.Slice` rule: a leading Slice
+# covers a full dimension and should be stripped, regardless of what follows.
+GPUIndexStyle(::Base.Slice, i2::AbstractUnitRange,
+              I::Vararg{Union{AbstractUnitRange, Base.ScalarIndex, CartesianIndex}}) =
+    GPUIndexStyle(i2, I...)
 
 viewlength() = ()
 @inline viewlength(::Real, I...) = viewlength(I...) # skip scalar
@@ -360,4 +373,37 @@ end
 
 @inline function unsafe_view(A, I, ::NonContiguous)
     Base.unsafe_view(Base._maybe_reshape_parent(A, Base.index_ndims(I...)), I...)
+end
+
+@inline function unsafe_view(A, I, ::MaybeContiguous)
+    P = Base._maybe_reshape_parent(A, Base.index_ndims(I...))
+    if iscontiguous_indices(P, I)
+        unsafe_contiguous_view(P, I, viewlength(I...))
+    else
+        Base.unsafe_view(P, I...)
+    end
+end
+
+# Determine at runtime whether the view `I` into `A` covers a contiguous
+# stretch of memory. Length-1 range indices (and scalars) don't affect the
+# traversal stride; each longer range index must sit at the expected parent
+# stride and advances it by its length.
+@inline iscontiguous_indices(A, I::Tuple) = _iscontiguous_indices(strides(A), I, 1, 1)
+@inline _iscontiguous_indices(::Tuple, ::Tuple{}, dim::Int, expected::Int) = true
+@inline function _iscontiguous_indices(st::Tuple, I::Tuple, dim::Int, expected::Int)
+    idx = I[1]
+    rest = Base.tail(I)
+    if idx isa AbstractUnitRange
+        len = Base.length(idx)
+        if len == 1
+            _iscontiguous_indices(st, rest, dim+1, expected)
+        else
+            @inbounds st[dim] == expected || return false
+            @inbounds _iscontiguous_indices(st, rest, dim+1, st[dim] * len)
+        end
+    elseif idx isa CartesianIndex
+        _iscontiguous_indices(st, rest, dim+length(idx), expected)
+    else # Base.ScalarIndex
+        _iscontiguous_indices(st, rest, dim+1, expected)
+    end
 end

--- a/test/testsuite/base.jl
+++ b/test/testsuite/base.jl
@@ -424,44 +424,49 @@ end
 
       # mixed AbstractUnitRange indices: contiguity must be determined at
       # runtime since the type `UnitRange` doesn't encode length (#2653).
-      @testset "mixed range contiguity" begin
-        A = AT(rand(Float32, 5, 4))
-        B = AT(rand(Float32, 5, 4, 3))
+      # GPU-only: the "contiguous view collapses to AT" behavior is provided by
+      # GPUArrays' `unsafe_contiguous_view`; `Base.view` on a plain `Array`
+      # always returns a `SubArray`.
+      if AT <: AbstractGPUArray
+        @testset "mixed range contiguity" begin
+          A = AT(rand(Float32, 5, 4))
+          B = AT(rand(Float32, 5, 4, 3))
 
-        # contiguous cases: should collapse to the array type itself
-        @test view(A, 1:1, 1:1) isa AT
-        @test view(A, 1:2, 1:1) isa AT
-        @test view(A, 1:5, 1:2) isa AT
-        @test view(A, 1:5, 2:3) isa AT
-        @test view(B, 1:1, 1:1, 1:1) isa AT
-        @test view(B, 1:5, 1:4, 1:1) isa AT
-        @test view(B, 1:5, 2:3, 1:1) isa AT
-        @test view(B, 1:5, 2:3, 2:2) isa AT
-        @test view(B, 1:5, 2:3, 2)   isa AT
-        @test view(B, 1:5, 1:4, 2:3) isa AT
+          # contiguous cases: should collapse to the array type itself
+          @test view(A, 1:1, 1:1) isa AT
+          @test view(A, 1:2, 1:1) isa AT
+          @test view(A, 1:5, 1:2) isa AT
+          @test view(A, 1:5, 2:3) isa AT
+          @test view(B, 1:1, 1:1, 1:1) isa AT
+          @test view(B, 1:5, 1:4, 1:1) isa AT
+          @test view(B, 1:5, 2:3, 1:1) isa AT
+          @test view(B, 1:5, 2:3, 2:2) isa AT
+          @test view(B, 1:5, 2:3, 2)   isa AT
+          @test view(B, 1:5, 1:4, 2:3) isa AT
 
-        # non-contiguous cases: must stay as SubArray
-        @test view(A, 1:2, 1:2)      isa SubArray
-        @test view(A, 1:1, 2:3)      isa SubArray
-        @test view(B, 1:5, 1:1, 1:2) isa SubArray
-        @test view(B, 1:5, 1:2, 1:2) isa SubArray
-        @test view(B, 1:2, 1:2, 1:1) isa SubArray
+          # non-contiguous cases: must stay as SubArray
+          @test view(A, 1:2, 1:2)      isa SubArray
+          @test view(A, 1:1, 2:3)      isa SubArray
+          @test view(B, 1:5, 1:1, 1:2) isa SubArray
+          @test view(B, 1:5, 1:2, 1:2) isa SubArray
+          @test view(B, 1:2, 1:2, 1:1) isa SubArray
 
-        # values must match in all cases
-        Acpu = Array(A); Bcpu = Array(B)
-        for idx in [(1:1,1:1), (1:4,1:2), (1:5,2:3), (1:2,1:2), (1:1,2:3)]
-            @test Array(view(A, idx...)) == view(Acpu, idx...)
-        end
-        for idx in [(1:5,2:3,1:1), (1:5,2:3,2), (1:5,1:4,2:3),
-                    (1:5,1:1,1:2), (1:5,1:2,1:2), (1:2,1:2,1:1)]
-            @test Array(view(B, idx...)) == view(Bcpu, idx...)
-        end
+          # values must match in all cases
+          Acpu = Array(A); Bcpu = Array(B)
+          for idx in [(1:1,1:1), (1:4,1:2), (1:5,2:3), (1:2,1:2), (1:1,2:3)]
+              @test Array(view(A, idx...)) == view(Acpu, idx...)
+          end
+          for idx in [(1:5,2:3,1:1), (1:5,2:3,2), (1:5,1:4,2:3),
+                      (1:5,1:1,1:2), (1:5,1:2,1:2), (1:2,1:2,1:1)]
+              @test Array(view(B, idx...)) == view(Bcpu, idx...)
+          end
 
-        # reshape of a 1-element view (original report in #2653)
-        let C = AT(rand(ComplexF32, 4, 5))
-            v = @view C[1:1, 1:1]
-            @test v isa AT
-            @test reshape(v, (1, 1)) isa AT
+          # reshape of a 1-element view (original report in #2653)
+          let C = AT(rand(ComplexF32, 4, 5))
+              v = @view C[1:1, 1:1]
+              @test v isa AT
+              @test reshape(v, (1, 1)) isa AT
+          end
         end
       end
     end

--- a/test/testsuite/base.jl
+++ b/test/testsuite/base.jl
@@ -421,6 +421,49 @@ end
           @test compare(view, AT, a, i)
           @test compare(view, AT, a, view(i, 2:2))
       end
+
+      # mixed AbstractUnitRange indices: contiguity must be determined at
+      # runtime since the type `UnitRange` doesn't encode length (#2653).
+      @testset "mixed range contiguity" begin
+        A = AT(rand(Float32, 5, 4))
+        B = AT(rand(Float32, 5, 4, 3))
+
+        # contiguous cases: should collapse to the array type itself
+        @test view(A, 1:1, 1:1) isa AT
+        @test view(A, 1:2, 1:1) isa AT
+        @test view(A, 1:5, 1:2) isa AT
+        @test view(A, 1:5, 2:3) isa AT
+        @test view(B, 1:1, 1:1, 1:1) isa AT
+        @test view(B, 1:5, 1:4, 1:1) isa AT
+        @test view(B, 1:5, 2:3, 1:1) isa AT
+        @test view(B, 1:5, 2:3, 2:2) isa AT
+        @test view(B, 1:5, 2:3, 2)   isa AT
+        @test view(B, 1:5, 1:4, 2:3) isa AT
+
+        # non-contiguous cases: must stay as SubArray
+        @test view(A, 1:2, 1:2)      isa SubArray
+        @test view(A, 1:1, 2:3)      isa SubArray
+        @test view(B, 1:5, 1:1, 1:2) isa SubArray
+        @test view(B, 1:5, 1:2, 1:2) isa SubArray
+        @test view(B, 1:2, 1:2, 1:1) isa SubArray
+
+        # values must match in all cases
+        Acpu = Array(A); Bcpu = Array(B)
+        for idx in [(1:1,1:1), (1:4,1:2), (1:5,2:3), (1:2,1:2), (1:1,2:3)]
+            @test Array(view(A, idx...)) == view(Acpu, idx...)
+        end
+        for idx in [(1:5,2:3,1:1), (1:5,2:3,2), (1:5,1:4,2:3),
+                    (1:5,1:1,1:2), (1:5,1:2,1:2), (1:2,1:2,1:1)]
+            @test Array(view(B, idx...)) == view(Bcpu, idx...)
+        end
+
+        # reshape of a 1-element view (original report in #2653)
+        let C = AT(rand(ComplexF32, 4, 5))
+            v = @view C[1:1, 1:1]
+            @test v isa AT
+            @test reshape(v, (1, 1)) isa AT
+        end
+      end
     end
 
     @testset "reshape" begin


### PR DESCRIPTION
The static `GPUIndexStyle` dispatch couldn't recognize index tuples like `(1:1, 1:1)` or `(1:5, 2:3, 1:1)` as contiguous because the lengths of `UnitRange{Int}` aren't visible at the type level. Add a `MaybeContiguous` tag for `(::AbstractUnitRange, ::AbstractUnitRange, ...)` patterns and a runtime stride check that decides whether to take the contiguous fast path. Makes things type-unstable, but views being contiguous is much more important, I think.

Fixes JuliaGPU/CUDA.jl#2653. cc @kshyatt 