### PR TITLE
Avoid scalar indexing in LinearAlgebra.normalize

### DIFF
--- a/src/host/linalg.jl
+++ b/src/host/linalg.jl
@@ -802,6 +802,21 @@ function _normtypes(::Type{T}) where {T}
     return result_type, sum_type, promote_
 end
 
+## normalize
+
+# Avoid `first(a)` scalar indexing in LinearAlgebra.normalize (JuliaGPU/CUDA.jl#3097)
+function LinearAlgebra.normalize(a::AbstractGPUArray, p::Real=2)
+    nrm = norm(a, p)
+    if !isempty(a)
+        T = typeof(zero(eltype(a))/nrm)
+        aa = LinearAlgebra.copymutable_oftype(a, T)
+        return LinearAlgebra.__normalize!(aa, nrm)
+    else
+        T = typeof(zero(eltype(a))/nrm)
+        return T[]
+    end
+end
+
 ## opnorm
 
 function LinearAlgebra.opnorm1(A::AnyGPUArray{T,2}) where {T}

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -533,6 +533,15 @@ end
         @test compare(opnorm, AT, mat, Ref(p))
         @test isrealfloattype(typeof(opnorm(AT(mat), p)))
     end
+    @testset "normalize($T)" for T in eltypes
+        if !in(float(real(T)), eltypes)
+            continue
+        end
+        range = real(T) <: Integer ? (T.(1:10)) : T
+        arr = rand(range, 10)
+        @test compare(normalize, AT, arr)
+        @test compare(normalize, AT, arr, Ref(1))
+    end
 end
 
 @testsuite "linalg/NaN_false" (AT, eltypes)->begin


### PR DESCRIPTION
Override `normalize` for `AbstractGPUArray` to use `zero(eltype(a))` instead of `first(a)` for output type computation, preventing GPU scalar indexing.

Fixes JuliaGPU/CUDA.jl#3097.