### PR TITLE
Restore CPU-RNG to GPU-array fallback for rand!/randn!.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GPUArrays"
 uuid = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
-version = "11.5.0"
+version = "11.5.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/host/random.jl
+++ b/src/host/random.jl
@@ -464,6 +464,18 @@ function Random.randn!(rng::RNG{AT}, A::AbstractArray{T}) where {AT, T}
 end
 
 
+## CPU RNG → GPU array: generate on CPU, copyto! the destination.
+#
+# Without this, `rand!(::Random.TaskLocalRNG, ::CuArray)` hits Random's stdlib
+# scalar path and iterates the GPU array one element at a time.
+
+Random.rand!(rng::AbstractRNG, A::AnyGPUArray) =
+    copyto!(A, rand(rng, eltype(A), size(A)...))
+Random.randn!(rng::AbstractRNG, A::AnyGPUArray{T}) where {T<:Union{AbstractFloat,
+                                                                   Complex{<:AbstractFloat}}} =
+    copyto!(A, randn(rng, eltype(A), size(A)...))
+
+
 ## Out-of-place rand / randn — construct an AT array and fill it.
 
 Random.rand(rng::RNG{AT}, ::Type{T}, dims::Dims) where {AT, T} =

--- a/test/testsuite/random.jl
+++ b/test/testsuite/random.jl
@@ -77,4 +77,15 @@
             end
         end
     end
+
+    # a CPU RNG into a GPU array should route through a CPU generate + copyto!,
+    # not the stdlib scalar setindex! fallback
+    if AT <: AbstractGPUArray && Float32 in eltypes
+        @testset "CPU RNG → GPU array" begin
+            cpu_rng = MersenneTwister(1)
+            A = AT{Float32}(undef, 16)
+            @test (rand!(cpu_rng, A); true)
+            @test (randn!(cpu_rng, A); true)
+        end
+    end
 end


### PR DESCRIPTION
Without this, e.g. `randn!(Random.TaskLocalRNG(), ::CuArray)` falls through to the stdlib scalar setindex! path. Regression from #707.