### PR TITLE
Shrink high-RSS tests in testsuite.

### DIFF
--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -292,7 +292,7 @@ end
 
 @testsuite "linalg/kron" (AT, eltypes) -> begin
     @testset "$T, $opa, $opb" for T in eltypes, opa in (vec, identity, transpose, adjoint), opb in (vec, identity, transpose, adjoint)
-        @test compare(kron, AT, opa(rand(T, 32, 64)), opb(rand(T, 128, 16)))
+        @test compare(kron, AT, opa(rand(T, 16, 32)), opb(rand(T, 64, 8)))
     end
 end
 

--- a/test/testsuite/reductions.jl
+++ b/test/testsuite/reductions.jl
@@ -24,8 +24,8 @@ end
 
         range = ET <: Real ? (ET(1):ET(10)) : ET
         # Reduce larger array sizes to test multiple-element reading in certain implementations
-        for (sz,red) in [(1000000,)=>(1,), (5000,500)=>(1,1), (500,5000)=>(1,1),
-                         (500,5000)=>(500,1), (5000,500)=>(1,500)]
+        for (sz,red) in [(500000,)=>(1,), (1000,500)=>(1,1), (500,1000)=>(1,1),
+                         (500,1000)=>(500,1), (1000,500)=>(1,500)]
             @test compare((A,R)->Base.mapreducedim!(identity, +, R, A), AT, rand(range, sz), zeros(ET, red))
         end
     end


### PR DESCRIPTION
When run against CuArray in CUDA.jl's test suite, two tests dominated GPU RSS without exercising anything the smaller sizes wouldn't:

- linalg/kron: 32x64 * 128x16 produces a 4096x1024 result; halving each operand to 16x32 * 64x8 still covers all opa/opb transpose variants at ~16x less memory.
- reductions/mapreducedim! large: the 5000x500 / 500x5000 / 1000000 sizes were picked to exceed the multi-element-reading threshold (~86k on typical GPUs). 1000x500 / 500x1000 / 500000 still clears that threshold on realistic devices.