### PR TITLE
broadcast: split ComposedFunction on AbstractGPUArrayStyle

### DIFF
--- a/src/host/broadcast.jl
+++ b/src/host/broadcast.jl
@@ -4,6 +4,16 @@ using Base.Broadcast
 
 using Base.Broadcast: BroadcastStyle, Broadcasted, AbstractArrayStyle, instantiate
 
+# Rewrite `(f ∘ g).(args...)` as `f.(g.(args...))` whenever the broadcast style is
+# a GPU style. The fused `Broadcasted` tree is identical in semantics, but the
+# kernel closure no longer has to call `ComposedFunction`'s `(c)(args...; kw...)`
+# entry — which forces a kwsorter dispatch GPUCompiler cannot resolve statically
+# when the inner function has a non-trivial body (e.g. `NNlib.tanh_fast`'s
+# polynomial+sign branch produces an `InvalidIRError` on CUDA). The CPU
+# broadcast path is unaffected because dispatch is gated on `AbstractGPUArrayStyle`.
+@inline Broadcast.broadcasted(S::AbstractGPUArrayStyle, c::ComposedFunction, args...) =
+    Broadcast.broadcasted(S, c.outer, Broadcast.broadcasted(S, c.inner, args...))
+
 # but make sure we don't dispatch to the optimized copy method that directly indexes
 function Broadcast.copy(bc::Broadcasted{<:AbstractGPUArrayStyle{0}})
     ElType = Broadcast.combine_eltypes(bc.f, bc.args)

--- a/src/host/broadcast.jl
+++ b/src/host/broadcast.jl
@@ -4,13 +4,8 @@ using Base.Broadcast
 
 using Base.Broadcast: BroadcastStyle, Broadcasted, AbstractArrayStyle, instantiate
 
-# Rewrite `(f ∘ g).(args...)` as `f.(g.(args...))` whenever the broadcast style is
-# a GPU style. The fused `Broadcasted` tree is identical in semantics, but the
-# kernel closure no longer has to call `ComposedFunction`'s `(c)(args...; kw...)`
-# entry — which forces a kwsorter dispatch GPUCompiler cannot resolve statically
-# when the inner function has a non-trivial body (e.g. `NNlib.tanh_fast`'s
-# polynomial+sign branch produces an `InvalidIRError` on CUDA). The CPU
-# broadcast path is unaffected because dispatch is gated on `AbstractGPUArrayStyle`.
+# split `ComposedFunction` so the kernel closure doesn't hit its kwarg-accepting
+# call, whose kwsorter dispatch GPUCompiler can't resolve statically.
 @inline Broadcast.broadcasted(S::AbstractGPUArrayStyle, c::ComposedFunction, args...) =
     Broadcast.broadcasted(S, c.outer, Broadcast.broadcasted(S, c.inner, args...))
 

--- a/test/testsuite/broadcasting.jl
+++ b/test/testsuite/broadcasting.jl
@@ -230,10 +230,6 @@ function unknown_wrapper(AT, eltypes)
     end
 end
 
-# `(f ∘ g).(args...)` is rewritten to `f.(g.(args...))` for AbstractGPUArrayStyle so
-# that the kernel closure never carries a `ComposedFunction` value — the latter
-# forces a kwsorter dispatch that GPUCompiler cannot resolve when the inner body
-# has non-trivial control flow (e.g. NNlib.tanh_fast). On CPU this is a no-op.
 function composed_function(AT, eltypes)
     sq(x) = x*x
     for ET in eltypes

--- a/test/testsuite/broadcasting.jl
+++ b/test/testsuite/broadcasting.jl
@@ -2,6 +2,7 @@
     broadcasting(AT, eltypes)
     vec3(AT, eltypes)
     unknown_wrapper(AT, eltypes)
+    composed_function(AT, eltypes)
 end
 
 test_idx(idx, A::AbstractArray{T}) where T = A[idx] * T(2)
@@ -225,6 +226,28 @@ function unknown_wrapper(AT, eltypes)
             # test for dispatch with dest's BroadcastStyle.
             WA .= ET(1)
             @test all(isequal(ET(1)), Array(A))
+        end
+    end
+end
+
+# `(f ∘ g).(args...)` is rewritten to `f.(g.(args...))` for AbstractGPUArrayStyle so
+# that the kernel closure never carries a `ComposedFunction` value — the latter
+# forces a kwsorter dispatch that GPUCompiler cannot resolve when the inner body
+# has non-trivial control flow (e.g. NNlib.tanh_fast). On CPU this is a no-op.
+function composed_function(AT, eltypes)
+    sq(x) = x*x
+    for ET in eltypes
+        @testset "ComposedFunction $ET" begin
+            a = AT(rand(ET, 8))
+            b = AT(rand(ET, 8))
+            ca, cb = Array(a), Array(b)
+
+            @test Array(broadcast(sq ∘ (+), a, b))   ≈ (ca .+ cb).^2
+            @test Array((sq ∘ (+)).(a, b))           ≈ (ca .+ cb).^2
+            @test Array((sq ∘ sq ∘ (+)).(a, b))      ≈ ((ca .+ cb).^2).^2
+            @test Array((sq ∘ identity).(a))         ≈ ca.^2
+            @test Array((sq ∘ (+)).(a, Ref(ET(2))))  ≈ (ca .+ ET(2)).^2
+            @test Array((identity ∘ (-)).(a, b))     ≈ ca .- cb
         end
     end
 end


### PR DESCRIPTION
## Summary

Specialize `Broadcast.broadcasted` on `AbstractGPUArrayStyle` and `ComposedFunction` to rewrite `(f ∘ g).(args...)` into `f.(g.(args...))`. Broadcast fusion produces an identical kernel per-element, but the closure carried into the GPU kernel no longer holds a `ComposedFunction` value — so its `(c)(args...; kw...)` entry never has to be resolved by the GPU compiler.

## Motivation

The kwsorter dispatch on `ComposedFunction` is what fails in practice. When the inner function has non-trivial control flow (the canonical example is `NNlib.tanh_fast`'s polynomial branch with `sign`/`ifelse`), GPUCompiler cannot statically resolve `var"#_#NN"(kw, c, args...)` and emits:

```
InvalidIRError: ... unsupported dynamic function invocation
  (call to var"#_#113"(kw::Base.Pairs{...}, c::ComposedFunction, x...) @ Base operators.jl:1050)
```

Reproducer (pre-fix, on `CUDA.rand` arrays):

```julia
using CUDA, NNlib
a = CUDA.rand(Float32, 5); b = CUDA.rand(Float32, 5)

broadcast(NNlib.tanh_fast ∘ (+), a, b)   # ❌ InvalidIRError
broadcast(tanh ∘ (+), a, b)              # ✅ OK
NNlib.tanh_fast.(a .+ b)                 # ✅ OK (already-split form)
```

This has been seen in the wild on:
- CUDA: SciML/HighDimPDE.jl#141 (the trigger for this PR)
- Metal: FluxML/Flux.jl#2633, JuliaGPU/Metal.jl#673

The Metal incarnation was patched in [NNlib v0.9.32 / FluxML/NNlib.jl#666](https://github.com/FluxML/NNlib.jl/pull/666) with a per-function `NNlibMetalExt`:

```julia
@device_override NNlib.tanh_fast(x) = Base.FastMath.tanh_fast(x)
```

That works but only covers `tanh_fast`. There is no equivalent CUDA override upstream, and the same pattern would re-surface for any future fast-activation function that has a similar body (`sigmoid_fast` is currently fine because its body inlines, but the contract is fragile).

## Why fix it here, not in NNlib (or Base)

- **Per-function `@device_override` in NNlibCUDAExt** — bounded but only patches one function per backend; doesn't help user-defined `f ∘ g`. Every fast activation needs its own override on every backend.
- **Add a positional-only `(c::ComposedFunction)(args...) = c.outer(c.inner(args...))` to Base** — would fix the root cause everywhere, but Base needs to keep the existing kwarg-accepting method for API compatibility, and even if Base accepted such a patch the fix wouldn't reach existing Julia versions.
- **At the broadcast layer in GPUArrays** (this PR) — fixes every `f ∘ g`, every depth (right-associative recursion handles `f ∘ g ∘ h` automatically), every GPU backend, in one line. The CPU path is untouched because dispatch is gated on `AbstractGPUArrayStyle`. Not type-piracy: `BroadcastStyle` and `AbstractGPUArrayStyle` are owned here.

## Validation

- 920/920 tests pass on JLArray + Array backends locally (`runtests.jl JLArray/broadcasting Array/broadcasting`).
- Original failing MWE compiles and matches CPU output on H100 (CUDA 13.2, NNlib 0.9.34, Julia 1.11.9).
- Verified non-regression for `Flux.Dense(_, _, tanh_fast)`-style `tanh_fast.(W*x .+ b)` patterns.
- Verified preserved semantics for nested composition, scalar `Ref` args, unary composition, user-defined `ComposedFunction`s.

## Test plan

- [x] `JLArray/broadcasting` testsuite (CPU-style coverage via JLArrays)
- [x] `Array/broadcasting` testsuite (CPU non-regression)
- [x] H100 CUDA validation of the original failing MWE
- [ ] CI green on the buildkite GPU runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)