### PR TITLE
Reduce testsuite runtime by merging similar reduction testsets

### DIFF
--- a/test/testsuite/reductions.jl
+++ b/test/testsuite/reductions.jl
@@ -1,19 +1,3 @@
-@testsuite "reductions/mapreducedim!" (AT, eltypes)->begin
-    @testset "$ET" for ET in eltypes
-        range = ET <: Real ? (ET(1):ET(10)) : ET
-        for (sz,red) in [(10,)=>(1,), (10,10)=>(1,1), (10,10,10)=>(1,1,1), (10,10,10)=>(10,10,10),
-                         (10,10,10)=>(1,10,10), (10,10,10)=>(10,1,10), (10,10,10)=>(10,10,1),
-                         (0,)=>(1,)]
-            @test compare((A,R)->Base.mapreducedim!(identity, +, R, A), AT, rand(range, sz), zeros(ET, red))
-            @test compare((A,R)->Base.mapreducedim!(identity, *, R, A), AT, rand(range, sz), ones(ET, red))
-            @test compare((A,R)->Base.mapreducedim!(x->x+x, +, R, A), AT, rand(range, sz), zeros(ET, red))
-        end
-
-        # implicit singleton dimensions
-        @test compare((A,R)->Base.mapreducedim!(identity, +, R, A), AT, rand(range, (2,2)), zeros(ET, (2,)))
-        @test compare((A,R)->Base.mapreducedim!(identity, +, R, A), AT, rand(range, (2,3)), zeros(ET, (2,)))
-    end
-end
 
 @testsuite "reductions/mapreducedim!_large" (AT, eltypes)->begin
     @testset "$ET" for ET in eltypes
@@ -31,15 +15,25 @@ end
     end
 end
 
-@testsuite "reductions/reducedim!" (AT, eltypes)->begin
+@testsuite "reductions/mapreducedim!" (AT, eltypes)->begin
     @testset "$ET" for ET in eltypes
         range = ET <: Real ? (ET(1):ET(10)) : ET
         for (sz,red) in [(10,)=>(1,), (10,10)=>(1,1), (10,10,10)=>(1,1,1), (10,10,10)=>(10,10,10),
                          (10,10,10)=>(1,10,10), (10,10,10)=>(10,1,10), (10,10,10)=>(10,10,1),
                          (0,)=>(1,)]
+            # mapreducedim!
+            @test compare((A,R)->Base.mapreducedim!(identity, +, R, A), AT, rand(range, sz), zeros(ET, red))
+            @test compare((A,R)->Base.mapreducedim!(identity, *, R, A), AT, rand(range, sz), ones(ET, red))
+            @test compare((A,R)->Base.mapreducedim!(x->x+x, +, R, A), AT, rand(range, sz), zeros(ET, red))
+
+            # reducedim!
             @test compare((A,R)->Base.reducedim!(+, R, A), AT, rand(range, sz), zeros(ET, red))
             @test compare((A,R)->Base.reducedim!(*, R, A), AT, rand(range, sz), ones(ET, red))
         end
+
+        # implicit singleton dimensions
+        @test compare((A,R)->Base.mapreducedim!(identity, +, R, A), AT, rand(range, (2,2)), zeros(ET, (2,)))
+        @test compare((A,R)->Base.mapreducedim!(identity, +, R, A), AT, rand(range, (2,3)), zeros(ET, (2,)))
     end
 end
 

--- a/test/testsuite/reductions.jl
+++ b/test/testsuite/reductions.jl
@@ -44,9 +44,14 @@ end
                           (10,)=>:, (10,10)=>:, (10,10,10)=>:,
                           (10,10,10)=>[1], (10,10,10)=>[2], (10,10,10)=>[3],
                           (0,)=>[1]]
+            # mapreduce
             @test compare(A->mapreduce(identity, +, A; dims=dims, init=zero(ET)), AT, rand(range, sz))
             @test compare(A->mapreduce(identity, *, A; dims=dims, init=one(ET)), AT, rand(range, sz))
             @test compare(A->mapreduce(x->x+x, +, A; dims=dims, init=zero(ET)), AT, rand(range, sz))
+
+            # reduce
+            @test compare(A->reduce(+, A; dims=dims, init=zero(ET)), AT, rand(range, sz))
+            @test compare(A->reduce(*, A; dims=dims, init=one(ET)), AT, rand(range, sz))
         end
     end
     # Test more corner cases. Tests from AcceleraterKernels.jl
@@ -55,30 +60,6 @@ end
     for dims in [1,2,3,4,[1,2],[1,3],[1,4],[2,3],[2,4],[3,4],[1,2,3],[1,2,4],[1,3,4],[2,3,4],[1,2,3,4]],
         isize in (0, 3), jsize in (0, 3), ksize in (0, 3)
         @test compare(A->mapreduce(x->x+x, +, A; init=zero(Int32), dims), AT, rand(Int32(1):Int32(10), isize, jsize, ksize))
-    end
-end
-
-@testsuite "reductions/reduce" (AT, eltypes)->begin
-    @testset "$ET" for ET in eltypes
-        range = ET <: Real ? (ET(1):ET(10)) : ET
-        for (sz,dims) in [(10,)=>[1], (10,10)=>[1,2], (10,10,10)=>[1,2,3], (10,10,10)=>[],
-                          (10,)=>:, (10,10)=>:, (10,10,10)=>:,
-                          (10,10,10)=>[1], (10,10,10)=>[2], (10,10,10)=>[3],
-                          (0,)=>[1]]
-            @test compare(A->reduce(+, A; dims=dims, init=zero(ET)), AT, rand(range, sz))
-            @test compare(A->reduce(*, A; dims=dims, init=one(ET)), AT, rand(range, sz))
-            if ET <: Integer
-                @test compare(A->reduce(&, A; dims=dims, init=~zero(ET)), AT, rand(range, sz))
-                @test compare(A->reduce(|, A; dims=dims, init=zero(ET)), AT, rand(range, sz))
-                @test compare(A->reduce(⊻, A; dims=dims, init=zero(ET)), AT, rand(range, sz))
-            end
-        end
-    end
-    # Test more corner cases. Tests from AcceleraterKernels.jl
-    # Cover empty (size 0) and non-singleton (size 3) axes; the size-10 loop above
-    # already covers the common non-edge shape.
-    for dims in [1,2,3,4,[1,2],[1,3],[1,4],[2,3],[2,4],[3,4],[1,2,3],[1,2,4],[1,3,4],[2,3,4],[1,2,3,4]],
-        isize in (0, 3), jsize in (0, 3), ksize in (0, 3)
         @test compare(A->reduce(+, A; init=zero(Int32), dims), AT, rand(Int32(1):Int32(10), isize, jsize, ksize))
     end
 end
@@ -114,6 +95,20 @@ end
                 @test compare((A,R)->sum!(R, A), AT, rand(range, sz), rand(ET, red))
                 @test compare((A,R)->prod!(R, A), AT, rand(range, sz), rand(ET, red))
             end
+        end
+    end
+end
+
+@testsuite "reductions/and or xor" (AT, eltypes)->begin
+    @testset "$ET" for ET in filter(x -> x <: Integer, eltypes)
+        range = ET <: Real ? (ET(1):ET(10)) : ET
+        for (sz,dims) in [(10,)=>[1], (10,10)=>[1,2], (10,10,10)=>[1,2,3], (10,10,10)=>[],
+                          (10,)=>:, (10,10)=>:, (10,10,10)=>:,
+                          (10,10,10)=>[1], (10,10,10)=>[2], (10,10,10)=>[3],
+                          (0,)=>[1]]
+            @test compare(A->reduce(&, A; dims=dims, init=~zero(ET)), AT, rand(range, sz))
+            @test compare(A->reduce(|, A; dims=dims, init=zero(ET)), AT, rand(range, sz))
+            @test compare(A->reduce(⊻, A; dims=dims, init=zero(ET)), AT, rand(range, sz))
         end
     end
 end


### PR DESCRIPTION
Merge mapreducedim! and reducedim! testsets.
Also merge mapreduce and reduce testsets while factoring out the `&`, `|`, and `xor` tests to keep Alloc values reasonable.

The result is that 4 testsets that used to take well over a minute each are now 2 testsets that take a few seconds longer than the longest of the 2 and a shorter ~30s testset.

Probably not a huge difference tests are mostly run in parallel, but this feels like a huge amount of time that used to be wasted compiling kernels instead of actually testing.


<details>

<summary>Timing comparison</summary>

Command: `using Pkg; Pkg.test("CUDA|Metal"; test_args=["--jobs=1", "--verbose", "gpuarrays/reductions/mapred", "gpuarrays/reductions/and", "gpuarrays/reductions/red"])`
*I also forced a new worker for every test in runtest.jl's `test_worker` to ensure worst-case scenario

```
# metal before
                                               │   Test   │   Init   │ Compile │ ──────────────── CPU ──────────────── │
Test                                  (Worker) │ time (s) │ time (s) │   (%)   │ GC (s) │ GC % │ Alloc (MB) │ RSS (MB) │
gpuarrays/reductions/mapreduce             (1) │        started at 2026-06-03T16:58:12.697
gpuarrays/reductions/mapreduce             (1) │    80.19 │     7.50 │   76.16 │   2.82 │  3.5 │   22161.98 │  1305.05 │
gpuarrays/reductions/mapreducedim!_large   (2) │        started at 2026-06-03T16:59:40.564
gpuarrays/reductions/mapreducedim!_large   (2) │    28.38 │     7.26 │   73.63 │   1.17 │  4.1 │    7607.99 │  1047.58 │
gpuarrays/reductions/mapreducedim!         (3) │        started at 2026-06-03T17:00:16.234
gpuarrays/reductions/mapreducedim!         (3) │    77.90 │     7.10 │   76.32 │   2.90 │  3.7 │   22157.35 │  1300.23 │
gpuarrays/reductions/reducedim!            (4) │        started at 2026-06-03T17:01:41.759
gpuarrays/reductions/reducedim!            (4) │    56.79 │     7.30 │   79.78 │   2.06 │  3.6 │   15733.63 │  1159.98 │
gpuarrays/reductions/reduce                (5) │        started at 2026-06-03T17:02:46.027
gpuarrays/reductions/reduce                (5) │    78.27 │     7.28 │   76.85 │   2.98 │  3.8 │   22238.45 │  1332.27 │

Test Summary:                                | Pass  Total     Time
  Overall                                    | 1349   1349  6m00.1s

#metal now
                                               │   Test   │   Init   │ Compile │ ──────────────── CPU ──────────────── │
Test                                  (Worker) │ time (s) │ time (s) │   (%)   │ GC (s) │ GC % │ Alloc (MB) │ RSS (MB) │
gpuarrays/reductions/mapreduce             (1) │        started at 2026-06-03T16:53:11.516
gpuarrays/reductions/mapreduce             (1) │    85.43 │     7.34 │   75.85 │   3.18 │  3.7 │   22905.00 │  1405.03 │
gpuarrays/reductions/mapreducedim!         (2) │        started at 2026-06-03T16:54:45.118
gpuarrays/reductions/mapreducedim!         (2) │    87.28 │     7.71 │   76.35 │   3.14 │  3.6 │   22182.17 │  1312.38 │
gpuarrays/reductions/mapreducedim!_large   (3) │        started at 2026-06-03T16:56:20.193
gpuarrays/reductions/mapreducedim!_large   (3) │    30.06 │     7.47 │   74.45 │   1.38 │  4.6 │    7608.21 │  1032.05 │
gpuarrays/reductions/and or xor            (4) │        started at 2026-06-03T16:56:57.955
gpuarrays/reductions/and or xor            (4) │    27.55 │     7.43 │   80.29 │   1.09 │  4.0 │    7121.14 │   918.94 │

Test Summary:                                | Pass  Total     Time
  Overall                                    | 1349   1349  4m22.2s

# CUDA before
                                               │   Test   │   Init   │ Compile │ ──────────── GPU ───────────── │ ──────────────── CPU ──────────────── │
Test                                  (Worker) │ time (s) │ time (s) │   (%)   │ GC (s) │ Alloc (MB) │ RSS (MB) │ GC (s) │ GC % │ Alloc (MB) │ RSS (MB) │
gpuarrays/reductions/reducedim!            (1) │        started at 2026-06-03T17:00:18.658
gpuarrays/reductions/reducedim!            (1) │    84.29 │    13.23 │    0.00 │   0.01 │       1.03 │   150.00 │   2.11 │  2.5 │    8011.49 │  2269.91 │
gpuarrays/reductions/reduce                (2) │        started at 2026-06-03T17:01:57.853
gpuarrays/reductions/reduce                (2) │   102.86 │    12.91 │    0.00 │   0.02 │       1.51 │   150.00 │   2.43 │  2.4 │   10534.54 │  2295.56 │
gpuarrays/reductions/mapreducedim!_large   (3) │        started at 2026-06-03T17:03:55.405
gpuarrays/reductions/mapreducedim!_large   (3) │    39.66 │    12.89 │    0.00 │   0.01 │     186.05 │   182.00 │   1.46 │  3.7 │    4230.51 │  2039.38 │
gpuarrays/reductions/mapreduce             (4) │        started at 2026-06-03T17:04:49.450
gpuarrays/reductions/mapreduce             (4) │   102.99 │    12.76 │    0.00 │   0.02 │       1.81 │   152.00 │   2.44 │  2.4 │   10307.30 │  2305.18 │
gpuarrays/reductions/mapreducedim!         (5) │        started at 2026-06-03T17:06:47.203
gpuarrays/reductions/mapreducedim!         (5) │   104.98 │    12.90 │    0.00 │   0.01 │       1.54 │   152.00 │   2.38 │  2.3 │    9639.75 │  2374.53 │

Test Summary:                                | Pass  Total     Time
  Overall                                    | 1553   1553  8m29.6s

# CUDA now
                                               │   Test   │   Init   │ Compile │ ──────────── GPU ───────────── │ ──────────────── CPU ──────────────── │
Test                                  (Worker) │ time (s) │ time (s) │   (%)   │ GC (s) │ Alloc (MB) │ RSS (MB) │ GC (s) │ GC % │ Alloc (MB) │ RSS (MB) │
gpuarrays/reductions/mapreducedim!         (1) │        started at 2026-06-03T17:15:42.413
gpuarrays/reductions/mapreducedim!         (1) │   105.67 │    13.29 │    0.00 │   0.01 │       2.57 │   152.00 │   2.36 │  2.2 │    9657.06 │  2390.07 │
gpuarrays/reductions/mapreducedim!_large   (2) │        started at 2026-06-03T17:17:42.935
gpuarrays/reductions/mapreducedim!_large   (2) │    39.60 │    12.79 │    0.00 │   0.01 │     186.05 │   182.00 │   1.45 │  3.7 │    4230.55 │  2039.03 │
gpuarrays/reductions/and or xor            (3) │        started at 2026-06-03T17:18:36.990
gpuarrays/reductions/and or xor            (3) │    30.32 │    12.85 │    0.00 │   0.01 │       0.30 │   148.00 │   0.71 │  2.3 │    3126.03 │  1939.61 │
gpuarrays/reductions/mapreduce             (4) │        started at 2026-06-03T17:19:21.736
gpuarrays/reductions/mapreduce             (4) │   105.53 │    12.84 │    0.00 │   0.02 │       3.02 │   152.00 │   2.48 │  2.4 │   10667.96 │  2310.68 │

Test Summary:                                | Pass  Total     Time
  Overall                                    | 1553   1553  5m41.0s

```

</details>