### PR TITLE
test that elementwise ops on mismatched sizes throw DimensionMismatch

### DIFF
--- a/test/testsuite/broadcasting.jl
+++ b/test/testsuite/broadcasting.jl
@@ -132,6 +132,14 @@ function broadcasting(AT, eltypes)
             @test compare(A -> A .* ET(10), AT, rand(ET, 40, 40))
             @test compare((A, B) -> A .* B, AT, rand(ET, 40, 40), rand(ET, 40, 40))
             @test compare((A, B) -> A .* B .+ ET(10), AT, rand(ET, 40, 40), rand(ET, 40, 40))
+
+            @testset "mismatched sizes" begin
+                a = AT(rand(ET, 10, 1))
+                b = AT(rand(ET, 3, 1))
+                @test_throws DimensionMismatch a + b
+                @test_throws DimensionMismatch b + a
+                @test_throws DimensionMismatch a .+ b
+            end
         end
 
         @testset "map! $ET" begin


### PR DESCRIPTION
Add a guard so mismatched GPU array sizes throw `DimensionMismatch` instead of truncating. Shapes `(10, 1)` and `(3, 1)`, both orders of `+`, plus `.+`.

On CUDA, `+` for a `CuMatrix` is not broadcast. It is cuBLAS `geam`, and `geam!` checks the bounds. `.+` is the `promote_shape` path. CPU backends take `promote_shape` for `+` as well. Same exception either way. See CUDA.jl#2812.

Shared suite, every backend. CUDA.jl#3275 is in, and that broadcasting run was 536/536 with this test included.
