### PR TITLE
Let findmax/min work with Complex and real-valued f

### DIFF
--- a/src/host/indexing.jl
+++ b/src/host/indexing.jl
@@ -261,5 +261,5 @@ end
 
 Base.findmax(a::AnyGPUArray; dims=:) = findminmax(Base.isless, identity, a; init=typemin(eltype(a)), dims)
 Base.findmin(a::AnyGPUArray; dims=:) = findminmax(Base.isgreater, identity, a; init=typemax(eltype(a)), dims)
-Base.findmax(f::Function, a::AnyGPUArray; dims=:) = findminmax(Base.isless, f, a; init=typemin(eltype(a)), dims)
-Base.findmin(f::Function, a::AnyGPUArray; dims=:) = findminmax(Base.isgreater, f, a; init=typemax(eltype(a)), dims)
+Base.findmax(f::Function, a::AnyGPUArray; dims=:) = findminmax(Base.isless, f, a; init=typemin(f(zero(eltype(a)))), dims)
+Base.findmin(f::Function, a::AnyGPUArray; dims=:) = findminmax(Base.isgreater, f, a; init=typemax(f(zero(eltype(a)))), dims)

--- a/test/testsuite/indexing.jl
+++ b/test/testsuite/indexing.jl
@@ -276,8 +276,8 @@ end
         end
         # test with Complex elements as long as f outputs a real
         let x = rand(ComplexF32, 100)
-            @test findmax(abs, x) == findmax(abs, AT(x))
-            @test findmax(abs, x; dims=1) == Array.(findmax(abs, AT(x); dims=1))
+            @test findmax(real, x) == findmax(real, AT(x))
+            @test findmax(abs, x; dims=1) ≈ Array.(findmax(abs, AT(x); dims=1))
         end
     end
 

--- a/test/testsuite/indexing.jl
+++ b/test/testsuite/indexing.jl
@@ -274,6 +274,11 @@ end
             @test isequal(findmin(x; dims=2), Array.(findmin(AT(x); dims=2)))
             @test isequal(findmin(x; dims=3), Array.(findmin(AT(x); dims=3)))
         end
+        # test with Complex elements as long as f outputs a real
+        let x = rand(ComplexF32, 100)
+            @test findmax(abs, x) == findmax(abs, AT(x))
+            @test findmax(abs, x; dims=1) == Array.(findmax(abs, AT(x); dims=1))
+        end
     end
 
     @testset "argmax & argmin" begin

--- a/test/testsuite/indexing.jl
+++ b/test/testsuite/indexing.jl
@@ -277,7 +277,9 @@ end
         # test with Complex elements as long as f outputs a real
         let x = rand(ComplexF32, 100)
             @test findmax(real, x) == findmax(real, AT(x))
-            @test findmax(abs, x; dims=1) ≈ Array.(findmax(abs, AT(x); dims=1))
+            @test findmax(real, x; dims=1) == Array.(findmax(real, AT(x); dims=1))
+            @test findmin(real, x) == findmin(real, AT(x))
+            @test findmin(real, x; dims=1) == Array.(findmin(real, AT(x); dims=1))
         end
     end
 


### PR DESCRIPTION
Right now this errors for complex valued arrays because there's no `typemin`/`typemax` defined for complex numbers, even if `f` argument to `findmax`/`findmin` is real valued. 