### PR TITLE
Handle Nothing in TestSuite.compare

### DIFF
--- a/test/testsuite.jl
+++ b/test/testsuite.jl
@@ -17,6 +17,9 @@ using Test
 using Adapt
 
 test_result(@nospecialize(a), @nospecialize(b); kwargs...) = a == b
+test_result(::Nothing, ::Nothing; kwargs...) = true
+test_result(::Nothing, @nospecialize(b); kwargs...) = false
+test_result(@nospecialize(a), ::Nothing; kwargs...) = false
 test_result(a::Number, b::Number; kwargs...) = ≈(a, b; kwargs...)
 test_result(a::Missing, b::Missing; kwargs...) = true
 test_result(a::Number, b::Missing; kwargs...) = false

--- a/test/testsuite/indexing.jl
+++ b/test/testsuite/indexing.jl
@@ -159,6 +159,7 @@ end
         # 1D
         @test compare(findfirst, AT, rand(Bool, 100))
         @test compare(x->findfirst(>(0.5f0), x), AT, rand(Float32, 100))
+        @test compare(findfirst, AT, fill(false, 10))
         let x = fill(false, 10)
             @test findfirst(x) == findfirst(AT(x))
         end


### PR DESCRIPTION
## Summary

Fixes `TestSuite.compare` for cases where the tested function returns `nothing`, which currently trips the array comparison path and fails on `collect(::Nothing)`.

## Why

`findfirst` can legitimately return `nothing` for arrays with no match. The current test suite expects these CPU/GPU results to compare cleanly, but `TestSuite.compare` did not have explicit `Nothing` handling.

This patch adds a small regression test for `findfirst(fill(false, 10))` and teaches `test_result` how to compare `Nothing` safely.

## Validation

I verified the code change and regression test locally. Julia is not installed in this environment, so I could not run the package test suite end-to-end here.
