### PR TITLE
Add test for `findfirst` with no results

### DIFF
--- a/test/testsuite.jl
+++ b/test/testsuite.jl
@@ -17,6 +17,9 @@ using Test
 using Adapt
 
 test_result(@nospecialize(a), @nospecialize(b); kwargs...) = a == b
+test_result(::Nothing, ::Nothing; kwargs...) = true
+test_result(::Nothing, @nospecialize(b); kwargs...) = false
+test_result(@nospecialize(a), ::Nothing; kwargs...) = false
 test_result(a::Number, b::Number; kwargs...) = ≈(a, b; kwargs...)
 test_result(a::Missing, b::Missing; kwargs...) = true
 test_result(a::Number, b::Missing; kwargs...) = false

--- a/test/testsuite/indexing.jl
+++ b/test/testsuite/indexing.jl
@@ -159,6 +159,7 @@ end
         # 1D
         @test compare(findfirst, AT, rand(Bool, 100))
         @test compare(x->findfirst(>(0.5f0), x), AT, rand(Float32, 100))
+        @test compare(findfirst, AT, fill(false, 10))
         let x = fill(false, 10)
             @test findfirst(x) == findfirst(AT(x))
         end


### PR DESCRIPTION
Fixes the `Nothing` handling gap in `TestSuite.compare` that causes the regression reported in the issue branch.

The fix is intentionally small and focused on the comparison helper and its regression test, so the behavior is covered at the boundary where `Nothing` was previously dropping through.

Validation:
- reviewed the helper and test changes directly
- no local Julia runtime was available in this environment, so I validated by code inspection only