### PR TITLE
Define LU factorization for JLArray

### DIFF
--- a/lib/JLArrays/src/JLArrays.jl
+++ b/lib/JLArrays/src/JLArrays.jl
@@ -349,6 +349,31 @@ function Base.unsafe_convert(::Type{Ptr{T}}, x::JLArray{T}) where {T}
     error("Illegal conversion of a JLArray to a Ptr")
 end
 
+"""
+    lu(A::JLArray, args...; kwargs...)
+
+Compute an LU factorization using the host representation of `A`.
+"""
+function LinearAlgebra.lu(A::JLArray{T, 2}, args...; kwargs...) where {T}
+    return LinearAlgebra.lu(Array(A), args...; kwargs...)
+end
+
+function LinearAlgebra.ldiv!(
+        F::LinearAlgebra.LU{T, <:StridedMatrix{T}}, B::JLArray{T, N}
+    ) where {T <: LinearAlgebra.BlasFloat, N}
+    B_cpu = Array(B)
+    LinearAlgebra.ldiv!(F, B_cpu)
+    copyto!(B, B_cpu)
+    return B
+end
+
+function LinearAlgebra.ldiv!(Y::JLArray, F::LinearAlgebra.LU, B::JLArray)
+    B_cpu = Array(B)
+    LinearAlgebra.ldiv!(F, B_cpu)
+    copyto!(Y, B_cpu)
+    return Y
+end
+
 
 ## interop with Julia arrays
 

--- a/test/jlarrays_lu.jl
+++ b/test/jlarrays_lu.jl
@@ -1,0 +1,16 @@
+using Test, JLArrays, LinearAlgebra
+
+@testset "JLArray LU" begin
+    A = jl([2.0 1.0; 1.0 3.0])
+    F = lu(A; check = false)
+
+    @test F isa LU{Float64, Matrix{Float64}, Vector{Int}}
+
+    b = jl([1.0, 2.0])
+    ldiv!(F, b)
+    @test Array(b) ≈ [0.2, 0.6]
+
+    y = similar(b)
+    ldiv!(y, F, jl([1.0, 2.0]))
+    @test Array(y) ≈ [0.2, 0.6]
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using ParallelTestRunner: runtests, parse_args
 import GPUArrays
 
+include("jlarrays_lu.jl")
+
 include("testsuite.jl")
 
 const init_worker_code = quote


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary

JLArrays now defines LinearAlgebra.lu for JLArray matrices by explicitly copying to the host representation before calling host LU. Matching ldiv! methods copy right-hand sides through host memory so the returned factorization can be used by solver code without triggering JLArray to Ptr conversion.

This addresses the regression described in https://github.com/SciML/OrdinaryDiffEq.jl/issues/4179. JLArrays 0.3.2 intentionally rejects implicit CPU pointer conversion, while the generic LinearAlgebra LU path still reaches LAPACK with a JLArray.

## Verification

Before the fix, on the unmodified branch:

    julia --project=test --startup-file=no -e 'using JLArrays, LinearAlgebra; A = jl([2.0 1.0; 1.0 3.0]); lu(A; check = false)'

failed with:

    ERROR: Illegal conversion of a JLArray to a Ptr
    [3] getrf!(A::JLArray{Float64, 2}, ipiv::JLArray{Int64, 1}; check::Bool)
        @ LinearAlgebra.LAPACK .../LinearAlgebra/src/lapack.jl:587

With this patch:

    julia --project=test --startup-file=no test/jlarrays_lu.jl

passed:

    Test Summary: | Pass  Total  Time
    JLArray LU    |    3      3  1.3s

The OrdinaryDiffEq reproduction also passed for both TRBDF2 and Rodas5P:

    (SciMLBase.ReturnCode.Success, SciMLBase.ReturnCode.Success, [0.04713496106370036, 0.04713496106370036, 0.04713496106370036])

The full GPUArrays suite passed:

    Test Summary: |  Pass  Total      Time
      Overall     | 21022  21022  16m23.0s
       SUCCESS
        Testing GPUArrays tests passed

Also ran typos on the changed files and git diff --check. GPU-specific backends and downstream packages were not tested.
