### PR TITLE
Align the generic matmul kernels with LinearAlgebra.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GPUArrays"
 uuid = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
-version = "11.5.9"
+version = "11.5.10"
 
 [workspace]
 projects = ["lib/GPUArraysCore", "lib/JLArrays", "test", "docs"]

--- a/src/host/linalg.jl
+++ b/src/host/linalg.jl
@@ -459,10 +459,9 @@ function generic_matmatmul!(C::AbstractArray{R}, A::AbstractArray{T}, B::Abstrac
 
         @inbounds if i <= size(A,1) && j <= size(B,2)
             z2 = zero(A[i, 1]*B[1, j] + A[i, 1]*B[1, j])
-            Tacc = promote_type(R, typeof(z2))
-            Cij = convert(Tacc, z2)
+            Cij = convert(promote_type(R, typeof(z2)), z2)
             for k in 1:size(A,2)
-                Cij += convert(Tacc, A[i, k]) * convert(Tacc, B[k, j])
+                Cij = muladd(A[i, k], B[k, j], Cij)
             end
             C[i,j] = add(Cij, C[i,j])
         end
@@ -512,11 +511,10 @@ function _triangular_matmatmul!(C::AbstractGPUVecOrMat{R}, A::AbstractTriangular
 
         @inbounds if i <= l && j <= n
             z2 = zero(A[i, 1]*B[1, j] + A[i, 1]*B[1, j])
-            Tacc = promote_type(R, typeof(z2))
-            Cij = convert(Tacc, z2)
-            Cij += convert(Tacc, A[i,i]) * convert(Tacc, B[i,j])
+            Cij = convert(promote_type(R, typeof(z2)), z2)
+            Cij = muladd(A[i,i], B[i,j], Cij)
             for k in (upperA ? (i + 1) : 1):(upperA ? m : (i - 1))
-                Cij += convert(Tacc, A[i,k]) * convert(Tacc, B[k,j])
+                Cij = muladd(A[i,k], B[k,j], Cij)
             end
             # treat C as write-only when beta is zero (it may hold NaN/Inf)
             C[i,j] = iszero(beta) ? alpha * Cij : alpha * Cij + beta * C[i,j]
@@ -598,11 +596,10 @@ function generic_trimatmul!(C::AbstractGPUVecOrMat{R}, uploc, isunitc, tfun::Fun
 
         @inbounds if i <= l && j <= n
             z2 = zero(A[i,1] * B[1,j] + A[i,1] * B[1,j])
-            Tacc = promote_type(R, typeof(z2))
-            Cij = convert(Tacc, z2)
-            Cij += (unit ? one(Cij) : convert(Tacc, A[i,i])) * convert(Tacc, B[i,j])
+            Cij = convert(promote_type(R, typeof(z2)), z2)
+            Cij = muladd(unit ? one(Cij) : A[i,i], B[i,j], Cij)
             for k in (upper ? (i + 1) : 1):(upper ? m : (i - 1))
-                Cij += convert(Tacc, A[i,k]) * convert(Tacc, B[k,j])
+                Cij = muladd(A[i,k], B[k,j], Cij)
             end
             C[i,j] += Cij
         end
@@ -616,11 +613,10 @@ function generic_trimatmul!(C::AbstractGPUVecOrMat{R}, uploc, isunitc, tfun::Fun
 
         @inbounds if i <= l && j <= n
             z2 = zero(A[i,1] * B[1,j] + A[i,1] * B[1,j])
-            Tacc = promote_type(R, typeof(z2))
-            Cij = convert(Tacc, z2)
-            Cij += (unit ? one(Cij) : transpose(convert(Tacc, A[i,i]))) * convert(Tacc, B[i,j])
+            Cij = convert(promote_type(R, typeof(z2)), z2)
+            Cij = muladd(unit ? one(Cij) : transpose(A[i,i]), B[i,j], Cij)
             for k in (upper ? (i + 1) : 1):(upper ? m : (i - 1))
-                Cij += transpose(convert(Tacc, A[k,i])) * convert(Tacc, B[k,j])
+                Cij = muladd(transpose(A[k,i]), B[k,j], Cij)
             end
             C[i,j] += Cij
         end
@@ -634,11 +630,10 @@ function generic_trimatmul!(C::AbstractGPUVecOrMat{R}, uploc, isunitc, tfun::Fun
 
         @inbounds if i <= l && j <= n
             z2 = zero(A[i,1] * B[1,j] + A[i,1] * B[1,j])
-            Tacc = promote_type(R, typeof(z2))
-            Cij = convert(Tacc, z2)
-            Cij += (unit ? one(Cij) : adjoint(convert(Tacc, A[i,i]))) * convert(Tacc, B[i,j])
+            Cij = convert(promote_type(R, typeof(z2)), z2)
+            Cij = muladd(unit ? one(Cij) : adjoint(A[i,i]), B[i,j], Cij)
             for k in (upper ? (i + 1) : 1):(upper ? m : (i - 1))
-                Cij += adjoint(convert(Tacc, A[k,i])) * convert(Tacc, B[k,j])
+                Cij = muladd(adjoint(A[k,i]), B[k,j], Cij)
             end
             C[i,j] += Cij
         end
@@ -679,11 +674,10 @@ function generic_mattrimul!(C::AbstractGPUVecOrMat{R}, uploc, isunitc, tfun::Fun
 
         @inbounds if i <= l && j <= n
             z2 = zero(A[i,1] * B[1,j] + A[i,1] * B[1,j])
-            Tacc = promote_type(R, typeof(z2))
-            Cij = convert(Tacc, z2)
-            Cij += convert(Tacc, A[i,j]) * (unit ? one(Cij) : convert(Tacc, B[j,j]))
+            Cij = convert(promote_type(R, typeof(z2)), z2)
+            Cij = muladd(A[i,j], unit ? one(Cij) : B[j,j], Cij)
             for k in (upper ? 1 : (j + 1)):(upper ? (j - 1) : m)
-                Cij += convert(Tacc, A[i,k]) * convert(Tacc, B[k,j])
+                Cij = muladd(A[i,k], B[k,j], Cij)
             end
             C[i,j] += Cij
         end
@@ -697,11 +691,10 @@ function generic_mattrimul!(C::AbstractGPUVecOrMat{R}, uploc, isunitc, tfun::Fun
 
         @inbounds if i <= l && j <= n
             z2 = zero(A[i,1] * B[1,j] + A[i,1] * B[1,j])
-            Tacc = promote_type(R, typeof(z2))
-            Cij = convert(Tacc, z2)
-            Cij += convert(Tacc, A[i,j]) * (unit ? one(Cij) : transpose(convert(Tacc, B[j,j])))
+            Cij = convert(promote_type(R, typeof(z2)), z2)
+            Cij = muladd(A[i,j], unit ? one(Cij) : transpose(B[j,j]), Cij)
             for k in (upper ? 1 : (j + 1) ):(upper ? (j - 1) : m)
-                Cij += convert(Tacc, A[i,k]) * transpose(convert(Tacc, B[j,k]))
+                Cij = muladd(A[i,k], transpose(B[j,k]), Cij)
             end
             C[i,j] += Cij
         end
@@ -715,11 +708,10 @@ function generic_mattrimul!(C::AbstractGPUVecOrMat{R}, uploc, isunitc, tfun::Fun
 
         @inbounds if i <= l && j <= n
             z2 = zero(A[i,1] * B[1,j] + A[i,1] * B[1,j])
-            Tacc = promote_type(R, typeof(z2))
-            Cij = convert(Tacc, z2)
-            Cij += convert(Tacc, A[i,j]) * (unit ? one(Cij) : adjoint(convert(Tacc, B[j,j])))
+            Cij = convert(promote_type(R, typeof(z2)), z2)
+            Cij = muladd(A[i,j], unit ? one(Cij) : adjoint(B[j,j]), Cij)
             for k in (upper ? 1 : (j + 1)):(upper ? (j - 1) : m)
-                Cij += convert(Tacc, A[i,k]) * adjoint(convert(Tacc, B[j,k]))
+                Cij = muladd(A[i,k], adjoint(B[j,k]), Cij)
             end
             C[i,j] += Cij
         end

--- a/src/host/linalg.jl
+++ b/src/host/linalg.jl
@@ -587,6 +587,7 @@ function generic_trimatmul!(C::AbstractGPUVecOrMat{R}, uploc, isunitc, tfun::Fun
 
     upper = tfun === identity ? uploc == 'U' :  uploc != 'U'
     unit  = isunitc == 'U'
+    oA = oneunit(eltype(A))
 
     @kernel function trimatmul(C, A, B)
         idx = @index(Global, Linear)
@@ -597,11 +598,11 @@ function generic_trimatmul!(C::AbstractGPUVecOrMat{R}, uploc, isunitc, tfun::Fun
         @inbounds if i <= l && j <= n
             z2 = zero(A[i,1] * B[1,j] + A[i,1] * B[1,j])
             Cij = convert(promote_type(R, typeof(z2)), z2)
-            Cij = muladd(unit ? one(Cij) : A[i,i], B[i,j], Cij)
+            Cij = muladd(unit ? oA : A[i,i], B[i,j], Cij)
             for k in (upper ? (i + 1) : 1):(upper ? m : (i - 1))
                 Cij = muladd(A[i,k], B[k,j], Cij)
             end
-            C[i,j] += Cij
+            C[i,j] = Cij
         end
     end
 
@@ -614,11 +615,11 @@ function generic_trimatmul!(C::AbstractGPUVecOrMat{R}, uploc, isunitc, tfun::Fun
         @inbounds if i <= l && j <= n
             z2 = zero(A[i,1] * B[1,j] + A[i,1] * B[1,j])
             Cij = convert(promote_type(R, typeof(z2)), z2)
-            Cij = muladd(unit ? one(Cij) : transpose(A[i,i]), B[i,j], Cij)
+            Cij = muladd(unit ? oA : transpose(A[i,i]), B[i,j], Cij)
             for k in (upper ? (i + 1) : 1):(upper ? m : (i - 1))
                 Cij = muladd(transpose(A[k,i]), B[k,j], Cij)
             end
-            C[i,j] += Cij
+            C[i,j] = Cij
         end
     end
 
@@ -631,11 +632,11 @@ function generic_trimatmul!(C::AbstractGPUVecOrMat{R}, uploc, isunitc, tfun::Fun
         @inbounds if i <= l && j <= n
             z2 = zero(A[i,1] * B[1,j] + A[i,1] * B[1,j])
             Cij = convert(promote_type(R, typeof(z2)), z2)
-            Cij = muladd(unit ? one(Cij) : adjoint(A[i,i]), B[i,j], Cij)
+            Cij = muladd(unit ? oA : adjoint(A[i,i]), B[i,j], Cij)
             for k in (upper ? (i + 1) : 1):(upper ? m : (i - 1))
                 Cij = muladd(adjoint(A[k,i]), B[k,j], Cij)
             end
-            C[i,j] += Cij
+            C[i,j] = Cij
         end
     end
 
@@ -665,6 +666,7 @@ function generic_mattrimul!(C::AbstractGPUVecOrMat{R}, uploc, isunitc, tfun::Fun
 
     upper = tfun === identity ? uploc == 'U' :  uploc != 'U'
     unit  = isunitc == 'U'
+    oB = oneunit(eltype(B))
 
     @kernel function mattrimul(C, A, B)
         idx = @index(Global, Linear)
@@ -675,11 +677,11 @@ function generic_mattrimul!(C::AbstractGPUVecOrMat{R}, uploc, isunitc, tfun::Fun
         @inbounds if i <= l && j <= n
             z2 = zero(A[i,1] * B[1,j] + A[i,1] * B[1,j])
             Cij = convert(promote_type(R, typeof(z2)), z2)
-            Cij = muladd(A[i,j], unit ? one(Cij) : B[j,j], Cij)
+            Cij = muladd(A[i,j], unit ? oB : B[j,j], Cij)
             for k in (upper ? 1 : (j + 1)):(upper ? (j - 1) : m)
                 Cij = muladd(A[i,k], B[k,j], Cij)
             end
-            C[i,j] += Cij
+            C[i,j] = Cij
         end
     end
 
@@ -692,11 +694,11 @@ function generic_mattrimul!(C::AbstractGPUVecOrMat{R}, uploc, isunitc, tfun::Fun
         @inbounds if i <= l && j <= n
             z2 = zero(A[i,1] * B[1,j] + A[i,1] * B[1,j])
             Cij = convert(promote_type(R, typeof(z2)), z2)
-            Cij = muladd(A[i,j], unit ? one(Cij) : transpose(B[j,j]), Cij)
+            Cij = muladd(A[i,j], unit ? oB : transpose(B[j,j]), Cij)
             for k in (upper ? 1 : (j + 1) ):(upper ? (j - 1) : m)
                 Cij = muladd(A[i,k], transpose(B[j,k]), Cij)
             end
-            C[i,j] += Cij
+            C[i,j] = Cij
         end
     end
 
@@ -709,11 +711,11 @@ function generic_mattrimul!(C::AbstractGPUVecOrMat{R}, uploc, isunitc, tfun::Fun
         @inbounds if i <= l && j <= n
             z2 = zero(A[i,1] * B[1,j] + A[i,1] * B[1,j])
             Cij = convert(promote_type(R, typeof(z2)), z2)
-            Cij = muladd(A[i,j], unit ? one(Cij) : adjoint(B[j,j]), Cij)
+            Cij = muladd(A[i,j], unit ? oB : adjoint(B[j,j]), Cij)
             for k in (upper ? 1 : (j + 1)):(upper ? (j - 1) : m)
                 Cij = muladd(A[i,k], adjoint(B[j,k]), Cij)
             end
-            C[i,j] += Cij
+            C[i,j] = Cij
         end
     end
 

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -158,15 +158,15 @@
                 n = 128
                 A = AT(rand(T, n,n))
                 b = AT(rand(T, n))
-                Ct = AT(zeros(T, n))
-                C = zeros(T, n)
+                Ct = AT(fill(T(NaN), n))
+                C = fill(T(NaN), n)
                 mul!(Ct, f(TR(A)), b)
                 mul!(C, f(TR(collect(A))), collect(b))
                 @test collect(Ct) ≈ C
 
                 B = AT(rand(T, n, n))
-                Ct = AT(zeros(T, n, n))
-                C = zeros(T, n, n)
+                Ct = AT(fill(T(NaN), n, n))
+                C = fill(T(NaN), n, n)
                 mul!(Ct, f(TR(A)), B)
                 mul!(C, f(TR(collect(A))), collect(B))
                 @test collect(Ct) ≈ C
@@ -179,8 +179,8 @@
                 n = 128
                 A = AT(rand(T, n,n))
                 B = AT(rand(T, n, n))
-                Ct = AT(zeros(T, n, n))
-                C = zeros(T, n, n)
+                Ct = AT(fill(T(NaN), n, n))
+                C = fill(T(NaN), n, n)
                 mul!(Ct, A, f(TR(B)))
                 mul!(C, collect(A), f(TR(collect(B))))
                 @test collect(Ct) ≈ C
@@ -621,6 +621,12 @@ Base.:(*)(x::Number, y::Duo) = Duo(x * y.a, x * y.b)
 
         @test Array(AT(A) * AT(B)) == A * B
         @test Array(AT(B) * AT(A)) == B * A
+
+        @testset "$W" for W in (UpperTriangular, LowerTriangular,
+                                UnitUpperTriangular, UnitLowerTriangular)
+            @test Array(W(AT(B)) * AT(A)) == W(B) * A
+            @test Array(AT(A) * W(AT(B))) == A * W(B)
+        end
     end
 end
 

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -601,6 +601,29 @@ end
     end
 end
 
+# a container-like element type that doesn't promote with its own scalars
+struct Duo{T}
+    a::T
+    b::T
+end
+Base.zero(::Type{Duo{T}}) where {T} = Duo(zero(T), zero(T))
+Base.zero(x::Duo) = zero(typeof(x))
+Base.:(+)(x::Duo, y::Duo) = Duo(x.a + y.a, x.b + y.b)
+Base.:(*)(x::Duo, y::Number) = Duo(x.a * y, x.b * y)
+Base.:(*)(x::Number, y::Duo) = Duo(x * y.a, x * y.b)
+
+@testsuite "linalg/mul!/mixed-eltype" (AT, eltypes)->begin
+    # mixed element types that have no common promotion type
+    @testset "Duo{$T} * $T" for T in filter(isfloattype, eltypes)
+        n = 4
+        A = [Duo(T(i), T(2i)) for i in 1:n, _ in 1:n]
+        B = T.(reshape(1:n^2, n, n))
+
+        @test Array(AT(A) * AT(B)) == A * B
+        @test Array(AT(B) * AT(A)) == B * A
+    end
+end
+
 @testsuite "linalg/norm" (AT, eltypes)->begin
     @testset "$p-norm($sz x $T)" for sz in [(2,), (2,0), (2,2,2)],
                                      p in Any[0, 0.5, 1, 1.5, 2, Inf, -Inf],


### PR DESCRIPTION
#746 widened both factors to the accumulator type to avoid narrow-integer
overflow, but that type isn't a valid conversion target for mixed element
types: `CuMatrix{SVector{2,Float32}} * CuMatrix{Float32}` gives
`Tacc == SVector{2,Float32}`, and `convert(SVector{2,Float32}, ::Float32)`
doesn't exist. Unreachable on the host, a `jl_f_throw_methoderror` call in
device IR. Blocks CUDA.jl CI since 11.5.9 (JuliaGPU/CUDA.jl#3225).

LinearAlgebra doesn't hand-roll this — it accumulates with `muladd`, which
promotes `Number` factors to the accumulator's type (the overflow fix) and
falls back to `x*y + z` for anything else (no conversion attempted). So the
first commit just uses `muladd` and drops `Tacc`.

Testing that turned up two pre-existing bugs in the triangular kernels,
both also a divergence from the stdlib:

- The unit diagonal used `one(Cij)` instead of `oneunit(eltype(A))`, so
  `UpperTriangular(::CuMatrix{Float32}) * ::CuMatrix{SVector{2,Float32}}`
  failed on the missing `one(::SVector)`.
- `C[i,j] += Cij` accumulated into an un-zeroed destination. This one hits
  plain `Float32`: `mul!(JLArray(fill(NaN32,3,3)), UpperTriangular(A), B)`
  returns all NaN. The tests missed it by pre-filling with `zeros`; they
  now use `fill(T(NaN), ...)`.

New `linalg/mul!/mixed-eltype` testsuite entry, using a small
container-like element type so downstream backends need no new dependency.
Full `linalg/*` on `JLArray` and `Array`: 4945 pass, the 16
`Symmetric`/`Hermitian` `uplo=L` failures also fail unmodified. Verified on
a GPU against CUDA.jl.