### PR TITLE
[testsuite] Don't let `sprand` generate stored zeros.

### DIFF
--- a/test/testsuite/sparse.jl
+++ b/test/testsuite/sparse.jl
@@ -20,6 +20,15 @@ end
 using SparseArrays
 using SparseArrays: nonzeroinds, nonzeros, rowvals
 
+# `sprand`/`sprandn` can produce *stored* zeros: with a coarse element type like Float16,
+# `rand` returns an exact zero about once every 2048 draws, so roughly one in 60 vectors
+# here contains one. That's a valid sparse array, but CPU and GPU implementations
+# legitimately disagree on what to do with it -- `x .* 1` drops stored zeros on the CPU
+# while our kernels preserve the structure -- so the structural comparisons below fail at
+# random. Keep the inputs canonical instead.
+sprand_nozeros(args...) = dropzeros!(sprand(args...))
+sprandn_nozeros(args...) = dropzeros!(sprandn(args...))
+
 function vector(AT, eltypes)
     dense_AT = GPUArrays.dense_array_type(AT)
     @testset "Sparse vector properties" begin
@@ -29,7 +38,7 @@ function vector(AT, eltypes)
             k = 10
             p = 5
             blockdim = 5
-            x   = sprand(ET,m,0.2)
+            x   = sprand_nozeros(ET,m,0.2)
             d_x = AT(x)
             @test length(d_x) == m
             @test size(d_x)   == (m,)
@@ -66,7 +75,7 @@ function vector_construction(AT, eltypes)
         k = 10
         p = 5
         blockdim = 5
-        x = sprand(ET, m, 0.2)
+        x = sprand_nozeros(ET, m, 0.2)
         d_x = AT(x)
         @test collect(d_x) == collect(x)
         @test similar(d_x) isa AT{ET}
@@ -83,10 +92,10 @@ function matrix(AT, eltypes)
             k = 10
             p = 5
             blockdim = 5
-            x    = sprand(ET, m, 0.2)
+            x    = sprand_nozeros(ET, m, 0.2)
             d_x  = AT(x)
             @test size(d_x) == (m, 1)
-            x    = sprand(ET, m, n, 0.2)
+            x    = sprand_nozeros(ET, m, n, 0.2)
             d_x  = AT(x)
             d_tx = AT(transpose(x))
             d_ax = AT(adjoint(x))
@@ -139,7 +148,7 @@ function matrix_construction(AT, eltypes)
         k = 10
         p = 5
         blockdim = 5
-        x = sprand(ET, m, n, 0.2)
+        x = sprand_nozeros(ET, m, n, 0.2)
         d_x = AT(x)
         @test collect(d_x) == collect(x)
         @test similar(d_x) isa AT{ET}
@@ -157,7 +166,7 @@ function broadcasting_vector(AT, eltypes)
         @testset "$ET" for ET in eltypes
             m  = 64
             p  = 0.5
-            x  = sprand(ET, m, p)
+            x  = sprand_nozeros(ET, m, p)
             dx = AT(x)
 
             # zero-preserving
@@ -184,7 +193,7 @@ function broadcasting_vector(AT, eltypes)
 
             # sparse to sparse
             dx = AT(x)
-            y  = sprand(ET, m, p)
+            y  = sprand_nozeros(ET, m, p)
             dy = AT(y)
             z  = x  .* y
             dz = dx .* dy
@@ -192,8 +201,8 @@ function broadcasting_vector(AT, eltypes)
             @test z ≈ SparseVector(dz)
 
             # multiple inputs
-            y  = sprand(ET, m, p)
-            w  = sprand(ET, m, p)
+            y  = sprand_nozeros(ET, m, p)
+            w  = sprand_nozeros(ET, m, p)
             dy = AT(y)
             dx = AT(x)
             dw = AT(w)
@@ -202,8 +211,8 @@ function broadcasting_vector(AT, eltypes)
             @test dz isa AT{ET}
             @test z ≈ SparseVector(dz)
 
-            y = sprand(ET, m, p)
-            w = sprand(ET, m, p)
+            y = sprand_nozeros(ET, m, p)
+            w = sprand_nozeros(ET, m, p)
             dense_arr   = rand(ET, m)
             d_dense_arr = dense_AT(dense_arr)
             dy = AT(y)
@@ -213,7 +222,7 @@ function broadcasting_vector(AT, eltypes)
             @test dz isa dense_AT{ET}
             @test Array(z) ≈ Array(dz)
 
-            y  = sprand(ET, m, p)
+            y  = sprand_nozeros(ET, m, p)
             dy = AT(y)
             dx = AT(x)
             z  = x  .* y  .* ET(2)
@@ -246,7 +255,7 @@ function broadcasting_matrix(AT, eltypes)
         @testset "$ET" for ET in eltypes
             m, n = 5, 6
             p   = 0.5
-            x   = sprand(ET, m, n, p)
+            x   = sprand_nozeros(ET, m, n, p)
             dx  = AT(x)
             # zero-preserving
             y  = x  .* ET(1)
@@ -269,7 +278,7 @@ function broadcasting_matrix(AT, eltypes)
             @test Array(y) == Array(dy)
 
             # multiple inputs
-            y  = sprand(ET, m, n, p)
+            y  = sprand_nozeros(ET, m, n, p)
             dy = AT(y)
             z  = x  .* y  .* ET(2)
             dz = dx .* dy .* ET(2)
@@ -277,7 +286,7 @@ function broadcasting_matrix(AT, eltypes)
             @test z ≈ SparseMatrixCSC(dz)
 
             # multiple inputs
-            w  = sprand(ET, m, n, p)
+            w  = sprand_nozeros(ET, m, n, p)
             dw = AT(w)
             z  = x  .* y  .* w
             dz = dx .* dy .* dw
@@ -306,7 +315,7 @@ function mapreduce_matrix(AT, eltypes)
         @testset "$ET" for ET in eltypes
             m,n = 5,6
             p = 0.5
-            x = sprand(ET, m, n, p)
+            x = sprand_nozeros(ET, m, n, p)
             dx = AT(x)
 
             # dim=:
@@ -359,8 +368,8 @@ function linalg(AT, eltypes)
         # sprandn doesn't work nicely with these...
         @testset "$ET" for ET in filter(T -> !(T <: Union{Int16, Int32, Int64, Complex{Int16}, Complex{Int32}, Complex{Int64}}), eltypes)
             m = 10
-            A  = sprandn(ET, m, m, 0.2)
-            B  = sprandn(ET, m, m, 0.3)
+            A  = sprandn_nozeros(ET, m, m, 0.2)
+            B  = sprandn_nozeros(ET, m, m, 0.3)
             ZA = spzeros(ET, m, m)
             C  = I(div(m, 2))
             dA = AT(A)
@@ -381,9 +390,9 @@ function iszero_vector(AT, eltypes)
             m = 25
 
             # Test non-zero sparse vector
-            x = sprand(ET, m, 0.5)
+            x = sprand_nozeros(ET, m, 0.5)
             while iszero(x)
-                x = sprand(ET, m, 0.5)
+                x = sprand_nozeros(ET, m, 0.5)
             end
             d_x = AT(x)
             @test iszero(d_x) == iszero(x)
@@ -411,9 +420,9 @@ function iszero_matrix(AT, eltypes)
             m, n = 10, 10
 
             # Test non-zero sparse matrix
-            A = sprand(ET, m, n, 0.5)
+            A = sprand_nozeros(ET, m, n, 0.5)
             while iszero(A)
-                A = sprand(ET, m, n, 0.5)
+                A = sprand_nozeros(ET, m, n, 0.5)
             end
             dA = AT(A)
             @test iszero(dA) == iszero(A)


### PR DESCRIPTION
`sprand`/`sprandn` draw their values with `rand`, which for a coarse element type like Float16 returns an exact zero about once every 2048 draws -- roughly one in 60 of the vectors generated here contains one.

Such an array is valid, but CPU and GPU implementations legitimately disagree on what to do with it: `x .* 1` drops stored zeros on the CPU while our kernels preserve the structure. The `nonzeroinds`/`nonzeros` comparisons in the broadcasting tests then fail, at random, on whichever side happens to be the reference. Keep the inputs canonical instead.

Measured over 20000 draws of `sprand(Float16, 64, 0.5)`: 285 structural mismatches before, 0 after.