### PR TITLE
Fix triangular solves on backends without a vendor BLAS

### DIFF
--- a/src/host/linalg.jl
+++ b/src/host/linalg.jl
@@ -264,6 +264,24 @@ function LinearAlgebra.istril(A::AbstractGPUMatrix, k::Integer = 0)
     mapreduce(mapper, reducer, A, eachindex(IndexCartesian(), A); init=true)
 end
 
+# istriu/istril of triangular wrappers of the opposite triangularity: the generic
+# fallbacks in LinearAlgebra scan the wrapper element-by-element, which requires scalar
+# indexing. forwarding to the parent ends up in the mapreduce-based methods above, also
+# for lazily wrapped parents (via LinearAlgebra's Adjoint/Transpose forwards). needed by
+# e.g. 2-arg ldiv!/rdiv! on Julia 1.11.2+, which consult istriu/istril to select the
+# solver; LinearAlgebra provides equivalent methods on Julia 1.13+
+# (JuliaLang/LinearAlgebra.jl#1265), making these redundant there.
+@static if VERSION < v"1.13.0-"
+LinearAlgebra.istriu(A::LowerTriangular{<:Any, <:AnyGPUMatrix}, k::Integer = 0) =
+    istriu(parent(A), min(k, 1))
+LinearAlgebra.istriu(A::UnitLowerTriangular{<:Any, <:AnyGPUMatrix}, k::Integer = 0) =
+    k <= 0 && istriu(parent(A), k)
+LinearAlgebra.istril(A::UpperTriangular{<:Any, <:AnyGPUMatrix}, k::Integer = 0) =
+    istril(parent(A), max(k, -1))
+LinearAlgebra.istril(A::UnitUpperTriangular{<:Any, <:AnyGPUMatrix}, k::Integer = 0) =
+    k >= 0 && istril(parent(A), k)
+end
+
 ## uniformscaling
 
 function LinearAlgebra.mul!(out::AnyGPUMatrix{T}, a::Number, B::LinearAlgebra.UniformScaling, α::Number, β::Number) where {T}

--- a/src/host/linalg.jl
+++ b/src/host/linalg.jl
@@ -888,11 +888,92 @@ function generic_mattrimul!(C::AbstractGPUVecOrMat{R}, uploc, isunitc, tfun::Fun
     C
 end
 
+# triangular solves parallelize only across right-hand sides; each one is a sequential
+# forward/backward substitution. backends with a vendor BLAS override these with native
+# trsm calls, so these fallbacks mainly serve backends without one. unlike LinearAlgebra's
+# generic implementation, a zero diagonal element does not throw a SingularException but
+# yields Infs/NaNs, like vendor BLAS libraries.
+function generic_trimatdiv!(C::AbstractGPUVecOrMat{R}, uploc, isunitc, tfun::Function, A::AbstractGPUMatrix{T}, B::AbstractGPUVecOrMat{S}) where {T,S,R}
+    if size(A,2) != size(B,1)
+        throw(DimensionMismatch(lazy"matrix A has dimensions $(size(A)), right hand side B has dimensions $(size(B))"))
+    end
+    if size(C) != size(B)
+        throw(DimensionMismatch(lazy"result C has dimensions $(size(C)), needs $(size(B))"))
+    end
+    isempty(B) && return C
+
+    upper = tfun === identity ? uploc == 'U' : uploc != 'U'
+    unit  = isunitc == 'U'
+
+    # C = tfun(A) \ B; safe for C === B, as B[i,j] is read before C[i,j] is written
+    @kernel function trimatdiv(C, A, B, tf)
+        j = @index(Global, Linear)
+        m, n = size(C, 1), size(C, 2)
+
+        @inbounds if j <= n
+            for ii in 1:m
+                i = upper ? m - ii + 1 : ii
+                Cij = convert(promote_type(R, S), B[i,j])
+                for k in (upper ? (i + 1) : 1):(upper ? m : (i - 1))
+                    Aik = tf === identity ? A[i,k] : tf(A[k,i])
+                    Cij -= Aik * C[k,j]
+                end
+                C[i,j] = unit ? Cij : tf(A[i,i]) \ Cij
+            end
+        end
+    end
+
+    trimatdiv(get_backend(C))(C, A, B, tfun; ndrange = size(C, 2))
+
+    C
+end
+
+function generic_mattridiv!(C::AbstractGPUMatrix{R}, uploc, isunitc, tfun::Function, A::AbstractGPUMatrix{T}, B::AbstractGPUMatrix{S}) where {T,S,R}
+    if size(A,2) != size(B,1)
+        throw(DimensionMismatch(lazy"left hand side A has dimensions $(size(A)), matrix B has dimensions $(size(B))"))
+    end
+    if size(C) != size(A)
+        throw(DimensionMismatch(lazy"result C has dimensions $(size(C)), needs $(size(A))"))
+    end
+    isempty(A) && return C
+
+    upper = tfun === identity ? uploc == 'U' : uploc != 'U'
+    unit  = isunitc == 'U'
+
+    # C = A / tfun(B); safe for C === A, as A[i,j] is read before C[i,j] is written
+    @kernel function mattridiv(C, A, B, tf)
+        i = @index(Global, Linear)
+        m, n = size(C, 1), size(C, 2)
+
+        @inbounds if i <= m
+            for jj in 1:n
+                j = upper ? jj : n - jj + 1
+                Cij = convert(promote_type(R, T), A[i,j])
+                for k in (upper ? 1 : (j + 1)):(upper ? (j - 1) : n)
+                    Bkj = tf === identity ? B[k,j] : tf(B[j,k])
+                    Cij -= C[i,k] * Bkj
+                end
+                C[i,j] = unit ? Cij : Cij / tf(B[j,j])
+            end
+        end
+    end
+
+    mattridiv(get_backend(C))(C, A, B, tfun; ndrange = size(C, 1))
+
+    C
+end
+
 function LinearAlgebra.generic_trimatmul!(C::AbstractGPUVecOrMat, uploc, isunitc, tfun::Function, A::AbstractGPUMatrix, B::AbstractGPUVecOrMat)
     generic_trimatmul!(C, uploc, isunitc, tfun, A, B)
 end
 function LinearAlgebra.generic_mattrimul!(C::AbstractGPUMatrix, uploc, isunitc, tfun::Function, A::AbstractGPUMatrix, B::AbstractGPUMatrix)
     generic_mattrimul!(C, uploc, isunitc, tfun, A, B)
+end
+function LinearAlgebra.generic_trimatdiv!(C::AbstractGPUVecOrMat, uploc, isunitc, tfun::Function, A::AbstractGPUMatrix, B::AbstractGPUVecOrMat)
+    generic_trimatdiv!(C, uploc, isunitc, tfun, A, B)
+end
+function LinearAlgebra.generic_mattridiv!(C::AbstractGPUMatrix, uploc, isunitc, tfun::Function, A::AbstractGPUMatrix, B::AbstractGPUMatrix)
+    generic_mattridiv!(C, uploc, isunitc, tfun, A, B)
 end
 
 function generic_rmul!(X::AbstractArray, s::Number)

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -236,6 +236,49 @@
             end
         end
 
+        @testset "ldiv!/rdiv! + Triangular" begin
+            @testset "trimatdiv ($TR \\ $T, $f)" for T in (Float32, ComplexF32), TR in (UpperTriangular, LowerTriangular, UnitUpperTriangular, UnitLowerTriangular), f in (identity, transpose, adjoint)
+                if !(T in eltypes)
+                    continue
+                end
+                n = 32
+                # strictly diagonally dominant, so the solve is well-conditioned
+                # (also keeps the unit-diagonal wrappers well-conditioned)
+                A = rand(T, n, n) / n + I
+                b = rand(T, n)
+                B = rand(T, n, 4)
+                Ad, bd, Bd = AT(A), AT(b), AT(B)
+
+                @test collect(f(TR(Ad)) \ bd) ≈ f(TR(A)) \ b
+                @test collect(f(TR(Ad)) \ Bd) ≈ f(TR(A)) \ B
+
+                Cd = ldiv!(AT(fill(T(NaN), n)), f(TR(Ad)), bd)
+                C = ldiv!(fill(T(NaN), n), f(TR(A)), b)
+                @test collect(Cd) ≈ C
+
+                # 2-arg form overwrites the right hand side
+                Cd = ldiv!(f(TR(Ad)), copy(Bd))
+                C = ldiv!(f(TR(A)), copy(B))
+                @test collect(Cd) ≈ C
+            end
+
+            @testset "mattridiv ($T / $TR, $f)" for T in (Float32, ComplexF32), TR in (UpperTriangular, LowerTriangular, UnitUpperTriangular, UnitLowerTriangular), f in (identity, transpose, adjoint)
+                if !(T in eltypes)
+                    continue
+                end
+                n = 32
+                A = rand(T, n, n) / n + I
+                B = rand(T, 4, n)
+                Ad, Bd = AT(A), AT(B)
+
+                @test collect(Bd / f(TR(Ad))) ≈ B / f(TR(A))
+
+                Cd = rdiv!(copy(Bd), f(TR(Ad)))
+                C = rdiv!(copy(B), f(TR(A)))
+                @test collect(Cd) ≈ C
+            end
+        end
+
         @testset "mul! + Symmetric/Hermitian" begin
             # with BLAS eltypes these dispatch through generic_matmatmul_wrapper!'s
             # SymmHemmGeneric path, which must not end up in BLAS.symm!/hemm!

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -150,6 +150,22 @@
             end
         end
 
+        @testset "istril/istriu of triangular wrappers" begin
+            n = 4
+            parents = (triu(rand(Float32, n, n)), tril(rand(Float32, n, n)),
+                       Float32.(diagm(0 => rand(n))), Float32.(diagm(1 => rand(n-1))),
+                       Float32.(diagm(-1 => rand(n-1))), zeros(Float32, n, n))
+            for A in parents, k in -2:2, f in (identity, transpose, adjoint)
+                B = AT(A)
+                # querying the opposite triangularity used to scan the wrapper with
+                # scalar indexing; these hit e.g. 2-arg ldiv!/rdiv! solver selection
+                @test istriu(LowerTriangular(f(B)), k) == istriu(LowerTriangular(f(A)), k)
+                @test istriu(UnitLowerTriangular(f(B)), k) == istriu(UnitLowerTriangular(f(A)), k)
+                @test istril(UpperTriangular(f(B)), k) == istril(UpperTriangular(f(A)), k)
+                @test istril(UnitUpperTriangular(f(B)), k) == istril(UnitUpperTriangular(f(A)), k)
+            end
+        end
+
         @testset "mul! + Triangular" begin
             @testset "trimatmul! ($TR x $T, $f)" for T in (Float32, ComplexF32), TR in (UpperTriangular, LowerTriangular, UnitUpperTriangular, UnitLowerTriangular), f in (identity, transpose, adjoint)
                 if !(T in eltypes)


### PR DESCRIPTION
This seems to fix the issue for Metal. ~Not sure Fable's method ambiguity concern is valid.~ Edit: It is

<details>

<summary>🤖 Slop</summary>

Triangular solves (`\`, `/`, `ldiv!`, `rdiv!`) currently only work on backends that pair GPUArrays with a vendor linear algebra library (CUBLAS, rocBLAS, oneMKL, MPS). Everywhere else they die with scalar-indexing errors — twice over. This PR fixes both layers, so e.g. `transpose(UpperTriangular(A)) \ b` now works on OpenCL and JLArrays, and fixes a Julia 1.12.7 regression that broke it even on backends *with* a vendor library.

## 1. `istriu`/`istril` of opposite-triangularity wrappers scalar-index

`istriu(::LowerTriangular{...})` and friends have no structural method in LinearAlgebra ≤ 1.12, so they fall back to a generic element-by-element band scan of the wrapper.

This became load-bearing in **Julia 1.12.7**: JuliaLang/LinearAlgebra.jl#1561 (backported in 1.12.7) routes triangular `\`/`/` for BlasFloat eltypes through 2-arg `ldiv!`/`rdiv!`, which consult `istriu`/`istril` to select the solver. As a result, `transpose(UpperTriangular(A)) \ b` regressed from working (1.12.6) to a scalar-indexing error on Metal/oneAPI/OpenCL/JLArrays. CUDA was unaffected only because it carries a local workaround with hardcoded constants (`lib/cublas/src/linalg.jl`, added for JuliaLang/julia#55547).

The fix mirrors JuliaLang/LinearAlgebra.jl#1265 (present in Julia 1.13+, never backported to 1.12): forward the query to the parent with an adjusted band offset, terminating in GPUArrays' existing mapreduce-based `istriu`/`istril` kernels. Restricted to `AnyGPUMatrix` parents, so it's not piracy, and it also covers lazily wrapped parents.

The methods are guarded to `VERSION < v"1.13.0-"`, since LinearAlgebra ships equivalent (structurally identical) methods from 1.13 — verified that the testsuite passes on 1.13.0-rc3 with the guard active, going through LinearAlgebra's own forwards. There is deliberately no lower bound at 1.11.2: julia#55547 is only when 2-arg `ldiv!`/`rdiv!` started *consulting* these predicates, but a direct `istriu(LowerTriangular(gpu_A))` query scalar-indexes on every version before 1.13, including 1.10, and the new tests exercise those direct queries on all supported versions.

## 2. No generic implementation of the triangular solve family

GPUArrays has KA kernels for the triangular *multiply* family (`generic_trimatmul!`/`generic_mattrimul!`) but never implemented the *solve* family, so past the `istriu` check, backends without a vendor BLAS fell through to LinearAlgebra's scalar-indexing `generic_trimatdiv!`/`generic_mattridiv!`.

This adds substitution kernels for both, parallelizing across right-hand sides (each solve is inherently sequential). Notes:

- Backend methods (CUBLAS `trsm!`, MPS `solve_triangular`, …) are strictly more specific and keep winning dispatch — verified via `which` and by running the testsuite against Metal.jl, where the fallback also picks up eltypes the vendor library doesn't support (e.g. ComplexF32 on MPS).
- Aliasing-safe for the 2-arg `ldiv!(A, B)`/`rdiv!(A, B)` forms (`C === B` resp. `C === A`), which read each RHS element before overwriting it.
- A zero diagonal yields Infs/NaNs instead of a `SingularException` (can't throw from a kernel), matching vendor BLAS/`trsm` behavior.
- On Julia ≤ 1.12, LinearAlgebra still has BLAS-specialized `generic_trimatdiv!(C::StridedVecOrMat{T}, ...)` methods that GPU arrays match (via `AbstractGPUArray <: DenseArray`); the new methods empirically win dispatch on 1.10–1.13 with no ambiguity errors.

## Tests

The testsuite had no triangular-solve coverage at all (only Diagonal `ldiv!`), which is why this gap was never caught by JLArrays CI — backends only test their own vendor paths downstream. Added:

- `istril`/`istriu` of all four wrappers × identity/transpose/adjoint × `k ∈ -2:2` × 6 parent band structures, against CPU ground truth.
- `ldiv!`/`rdiv!`/`\`/`/` for all four wrappers × identity/transpose/adjoint × Float32/ComplexF32, vector and matrix RHS, including the aliasing 2-arg forms, against CPU ground truth.

Verified locally: JLArray + Array on Julia 1.10, 1.12.7, and 1.13.0-rc3 (full pass); Metal.jl testsuite with Metal's `supported_eltypes` set (full pass, 1062/1062); OpenCL.jl via POCL (previously broken on *every* Julia version, now all 24 wrapper/transform solve combinations pass).

## ⚠️ CUDA.jl coordination needed before release

CUDA.jl's `istriu`/`istril` workaround (`lib/cublas/src/linalg.jl:308-317`) is dispatch-ambiguous with the new wrapper methods (each is more specific in a different position), so e.g. `istriu(LowerTriangular(cu(A)))` would throw a `MethodError` at runtime. CUDA.jl should drop that workaround and bump its GPUArrays compat in lockstep; I can open that PR. (The new methods are also exact where CUDA's constants are subtly wrong for banded parents, e.g. wrappers of diagonal-valued matrices.) Happy to hold off on a release/version bump until that's sorted.

Non-goals: the bare `istriu(::AbstractGPUMatrix)` kernels deliberately stay un-loosened (widening to `AnyGPUMatrix` would shadow LinearAlgebra's O(1) structural answers for triangular wrappers and create ambiguities), and same-triangularity queries with `k > 0` on lazily-wrapped parents still hit a separate pre-existing scalar path in LinearAlgebra's `_istriu`.

A backport request of JuliaLang/LinearAlgebra.jl#1265 to `release-1.12` may still be worthwhile independently of this PR, since #1561 made these predicates load-bearing for `\`.

<\details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
