### PR TITLE
Inline the strided-view mul! routing and return C explicitly

### DIFF
--- a/src/host/linalg.jl
+++ b/src/host/linalg.jl
@@ -551,7 +551,7 @@ has_strided_gpu_view(As...) =
 # signatures also cover view-free products to avoid overlapping methods for each possible view
 # position; those calls are sent back through LinearAlgebra's original implementation.
 @static if VERSION < v"1.11"
-function LinearAlgebra.mul!(C::AnyStridedGPUVector, A::AnyStridedGPUMatrixOperand,
+@inline function LinearAlgebra.mul!(C::AnyStridedGPUVector, A::AnyStridedGPUMatrixOperand,
                             B::AnyStridedGPUVector, a::Number, b::Number)
     if has_strided_gpu_view(C, A, B)
         return generic_matmatmul!(C, A, B, a, b)
@@ -559,9 +559,10 @@ function LinearAlgebra.mul!(C::AnyStridedGPUVector, A::AnyStridedGPUMatrixOperan
     invoke(LinearAlgebra.mul!,
            Tuple{AbstractVector,LinearAlgebra.AbstractVecOrMat,AbstractVector,Number,Number},
            C, A, B, a, b)
+    return C
 end
 
-function LinearAlgebra.mul!(C::AnyStridedGPUMatrix, A::AnyStridedGPUVecOrMatOperand,
+@inline function LinearAlgebra.mul!(C::AnyStridedGPUMatrix, A::AnyStridedGPUVecOrMatOperand,
                             B::AnyStridedGPUVecOrMatOperand, a::Number, b::Number)
     if has_strided_gpu_view(C, A, B)
         return generic_matmatmul!(C, A, B, a, b)
@@ -570,9 +571,10 @@ function LinearAlgebra.mul!(C::AnyStridedGPUMatrix, A::AnyStridedGPUVecOrMatOper
            Tuple{AbstractMatrix,LinearAlgebra.AbstractVecOrMat,
                  LinearAlgebra.AbstractVecOrMat,Number,Number},
            C, A, B, a, b)
+    return C
 end
 else
-function LinearAlgebra._mul!(C::AnyStridedGPUVector, A::AnyStridedGPUMatrixOperand,
+@inline function LinearAlgebra._mul!(C::AnyStridedGPUVector, A::AnyStridedGPUMatrixOperand,
                              B::AnyStridedGPUVector, a::Number, b::Number)
     if has_strided_gpu_view(C, A, B)
         return generic_matmatmul!(C, A, B, a, b)
@@ -580,9 +582,10 @@ function LinearAlgebra._mul!(C::AnyStridedGPUVector, A::AnyStridedGPUMatrixOpera
     invoke(LinearAlgebra._mul!,
            Tuple{AbstractVector,LinearAlgebra.AbstractVecOrMat,AbstractVector,Number,Number},
            C, A, B, a, b)
+    return C
 end
 
-function LinearAlgebra._mul!(C::AnyStridedGPUMatrix, A::AnyStridedGPUVecOrMatOperand,
+@inline function LinearAlgebra._mul!(C::AnyStridedGPUMatrix, A::AnyStridedGPUVecOrMatOperand,
                              B::AnyStridedGPUVecOrMatOperand, a::Number, b::Number)
     if has_strided_gpu_view(C, A, B)
         return generic_matmatmul!(C, A, B, a, b)
@@ -591,6 +594,7 @@ function LinearAlgebra._mul!(C::AnyStridedGPUMatrix, A::AnyStridedGPUVecOrMatOpe
            Tuple{AbstractMatrix,LinearAlgebra.AbstractVecOrMat,
                  LinearAlgebra.AbstractVecOrMat,Number,Number},
            C, A, B, a, b)
+    return C
 end
 end
 


### PR DESCRIPTION
AI-generated fix for GPUArrays on Enzyme which was slightly broken due to the recent mul! change [cc @kshyatt @rsenne ]

Follow-up to #760.

## Problem

The routing methods from #760 sit in front of every GPU `mul!`, and in the common no-view case forward via `invoke` back to LinearAlgebra's original implementation. That `invoke` edge is specialized on the abstract invoke signature, which severs **constant propagation** of `α`/`β`.

Concretely, for plain 3-arg `mul!` the `(true, false)` constants previously const-folded `MulAddMul(α, β)` into a concrete type, so `generic_matmatmul!` devirtualized. With the wrapper in between, the inlined generic body union-splits the `MulAddMul` constructor into its 4 concrete types, the φ-merge widens them back to the abstract `MulAddMul{ais1, bis0}` UnionAll (union limit is 3), and the `generic_matmatmul!` call becomes a **dynamic dispatch on every 3-arg GPU matmul** (Julia ≤ 1.11; on 1.12+ the equivalent precision loss happens above `generic_matmatmul_wrapper!`):

```julia
23 ┄ %41 = φ (#18 => %31, #19 => %33, #21 => %37, #22 => %39)::LinearAlgebra.MulAddMul{ais1, bis0, Bool, Bool} where {ais1, bis0}
│    %42 = LinearAlgebra.generic_matmatmul!(C, 'N', 'N', A, B, %41)::JLArray{Float64, 2}   # dynamic
```

Besides the dispatch overhead, this broke Enzyme's custom-rule interception, which relies on that call devirtualizing so the rule applies with correct activity info: every Enzyme.jl CI run fails since v11.5.11 (see EnzymeAD/Enzyme.jl#3468 for the downstream analysis).

## Fix

Mark the four routing wrappers `@inline` and `return C` explicitly:

- **`@inline`**: the routing check inlines into the caller, the `invoke` then sees the constant scalars at its own call site, invoke-level constant propagation fires, and `MulAddMul` folds concrete again — `generic_matmatmul!` devirtualizes exactly as before #760. It also removes an extra non-inlined call from the hot path of every GPU `mul!`.
- **`return C`**: makes the wrapper's return value independent of inference precision on the invoke edge, rather than relying on the abstract-signature `invoke` inferring a concrete result.

## Validation

With JLArrays on Julia 1.10 and 1.11 (both sides of the version gate):

- strided-view routing unchanged: `mul!` on `view`s of JLArrays still routes to the generic kernels and produces correct results (3- and 5-arg);
- the `generic_matmatmul!` call in the 3-arg chain is static again (verified via Enzyme, whose static rule interception depends on it: its full GPUArrays-linalg test suite passes 28/28 against this branch with unmodified Enzyme, where v11.5.11 fails).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WgVTTES3ytMLYhZGyvQvf8