### PR TITLE
[Testsuite] Add option to test subset of types

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -235,7 +235,7 @@ steps:
                 println("--- :julia: Installing Metal.jl")
                 withenv("JULIA_PKG_PRECOMPILE_AUTO" => 0,
                         "JULIA_PKG_DEVDIR" => devdir) do
-                  Pkg.develop("Metal")
+                  Pkg.add(url="https://github.com/JuliaGPU/Metal.jl", rev="testsubset")
                   Pkg.activate(package)
 
                   try

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,217 +1,217 @@
 steps:
   # Julia 1.10 doesn't support [sources] in Project.toml,
   # so we need to manually dev CUDA.jl's workspace packages.
-  - label: "CUDA.jl -- Julia 1.10"
-    plugins:
-      - JuliaCI/julia#v1:
-          version: "1.10"
-      - JuliaCI/julia-coverage#v1:
-          codecov: true
-    commands: |
-      unset LD_LIBRARY_PATH
-      julia -e 'using Pkg
+  # - label: "CUDA.jl -- Julia 1.10"
+  #   plugins:
+  #     - JuliaCI/julia#v1:
+  #         version: "1.10"
+  #     - JuliaCI/julia-coverage#v1:
+  #         codecov: true
+  #   commands: |
+  #     unset LD_LIBRARY_PATH
+  #     julia -e 'using Pkg
 
-                gpuarrays = pwd()
-                gpuarrayscore = joinpath(gpuarrays, "lib", "GPUArraysCore")
-                devdir = mktempdir()
-                package = joinpath(devdir, "CUDA")
+  #               gpuarrays = pwd()
+  #               gpuarrayscore = joinpath(gpuarrays, "lib", "GPUArraysCore")
+  #               devdir = mktempdir()
+  #               package = joinpath(devdir, "CUDA")
 
-                println("--- :julia: Installing TestEnv")
-                Pkg.activate(; temp=true)
-                Pkg.add("TestEnv")
-                using TestEnv
+  #               println("--- :julia: Installing TestEnv")
+  #               Pkg.activate(; temp=true)
+  #               Pkg.add("TestEnv")
+  #               using TestEnv
 
-                println("--- :julia: Installing CUDA.jl")
-                withenv("JULIA_PKG_PRECOMPILE_AUTO" => 0,
-                        "JULIA_PKG_DEVDIR" => devdir) do
-                  Pkg.develop("CUDA")
-                  Pkg.activate(package)
+  #               println("--- :julia: Installing CUDA.jl")
+  #               withenv("JULIA_PKG_PRECOMPILE_AUTO" => 0,
+  #                       "JULIA_PKG_DEVDIR" => devdir) do
+  #                 Pkg.develop("CUDA")
+  #                 Pkg.activate(package)
 
-                  try
-                    Pkg.develop([
-                      PackageSpec(path=gpuarrays), PackageSpec(path=gpuarrayscore),
-                      PackageSpec(path=joinpath(package, "CUDACore")),
-                      PackageSpec(path=joinpath(package, "CUDATools")),
-                      PackageSpec(path=joinpath(package, "lib", "cupti")),
-                      PackageSpec(path=joinpath(package, "lib", "nvml")),
-                      PackageSpec(path=joinpath(package, "lib", "cublas")),
-                      PackageSpec(path=joinpath(package, "lib", "cusparse")),
-                      PackageSpec(path=joinpath(package, "lib", "cusolver")),
-                      PackageSpec(path=joinpath(package, "lib", "cufft")),
-                      PackageSpec(path=joinpath(package, "lib", "curand")),
-                    ])
-                    TestEnv.activate()
-                  catch err
-                    @error "Could not install CUDA.jl" exception=(err,catch_backtrace())
-                    exit(3)
-                  finally
-                    Pkg.activate(package)
-                  end
-                end
+  #                 try
+  #                   Pkg.develop([
+  #                     PackageSpec(path=gpuarrays), PackageSpec(path=gpuarrayscore),
+  #                     PackageSpec(path=joinpath(package, "CUDACore")),
+  #                     PackageSpec(path=joinpath(package, "CUDATools")),
+  #                     PackageSpec(path=joinpath(package, "lib", "cupti")),
+  #                     PackageSpec(path=joinpath(package, "lib", "nvml")),
+  #                     PackageSpec(path=joinpath(package, "lib", "cublas")),
+  #                     PackageSpec(path=joinpath(package, "lib", "cusparse")),
+  #                     PackageSpec(path=joinpath(package, "lib", "cusolver")),
+  #                     PackageSpec(path=joinpath(package, "lib", "cufft")),
+  #                     PackageSpec(path=joinpath(package, "lib", "curand")),
+  #                   ])
+  #                   TestEnv.activate()
+  #                 catch err
+  #                   @error "Could not install CUDA.jl" exception=(err,catch_backtrace())
+  #                   exit(3)
+  #                 finally
+  #                   Pkg.activate(package)
+  #                 end
+  #               end
 
-                println("+++ :julia: Running tests")
-                Pkg.test(; coverage=true)'
-    agents:
-      queue: "cuda"
-    if: build.message !~ /\[skip tests\]/
-    timeout_in_minutes: 120
-    soft_fail:
-      - exit_status: 3
+  #               println("+++ :julia: Running tests")
+  #               Pkg.test(; coverage=true)'
+  #   agents:
+  #     queue: "cuda"
+  #   if: build.message !~ /\[skip tests\]/
+  #   timeout_in_minutes: 120
+  #   soft_fail:
+  #     - exit_status: 3
 
-  - label: "CUDA.jl -- Julia {{matrix.julia}}"
-    plugins:
-      - JuliaCI/julia#v1:
-          version: "{{matrix.julia}}"
-      - JuliaCI/julia-coverage#v1:
-          codecov: true
-    commands: |
-      unset LD_LIBRARY_PATH
-      julia -e 'using Pkg
+  # - label: "CUDA.jl -- Julia {{matrix.julia}}"
+  #   plugins:
+  #     - JuliaCI/julia#v1:
+  #         version: "{{matrix.julia}}"
+  #     - JuliaCI/julia-coverage#v1:
+  #         codecov: true
+  #   commands: |
+  #     unset LD_LIBRARY_PATH
+  #     julia -e 'using Pkg
 
-                gpuarrays = pwd()
-                gpuarrayscore = joinpath(gpuarrays, "lib", "GPUArraysCore")
-                devdir = mktempdir()
-                package = joinpath(devdir, "CUDA")
+  #               gpuarrays = pwd()
+  #               gpuarrayscore = joinpath(gpuarrays, "lib", "GPUArraysCore")
+  #               devdir = mktempdir()
+  #               package = joinpath(devdir, "CUDA")
 
-                println("--- :julia: Installing TestEnv")
-                Pkg.activate(; temp=true)
-                Pkg.add("TestEnv")
-                using TestEnv
+  #               println("--- :julia: Installing TestEnv")
+  #               Pkg.activate(; temp=true)
+  #               Pkg.add("TestEnv")
+  #               using TestEnv
 
-                println("--- :julia: Installing CUDA.jl")
-                withenv("JULIA_PKG_PRECOMPILE_AUTO" => 0,
-                        "JULIA_PKG_DEVDIR" => devdir) do
-                  Pkg.develop("CUDA")
-                  Pkg.activate(package)
+  #               println("--- :julia: Installing CUDA.jl")
+  #               withenv("JULIA_PKG_PRECOMPILE_AUTO" => 0,
+  #                       "JULIA_PKG_DEVDIR" => devdir) do
+  #                 Pkg.develop("CUDA")
+  #                 Pkg.activate(package)
 
-                  try
-                    Pkg.develop([PackageSpec(path=gpuarrays), PackageSpec(path=gpuarrayscore)])
-                    TestEnv.activate()
-                  catch err
-                    @error "Could not install CUDA.jl" exception=(err,catch_backtrace())
-                    exit(3)
-                  finally
-                    Pkg.activate(package)
-                  end
-                end
+  #                 try
+  #                   Pkg.develop([PackageSpec(path=gpuarrays), PackageSpec(path=gpuarrayscore)])
+  #                   TestEnv.activate()
+  #                 catch err
+  #                   @error "Could not install CUDA.jl" exception=(err,catch_backtrace())
+  #                   exit(3)
+  #                 finally
+  #                   Pkg.activate(package)
+  #                 end
+  #               end
 
-                println("+++ :julia: Running tests")
-                Pkg.test(; coverage=true)'
-    agents:
-      queue: "cuda"
-    if: build.message !~ /\[skip tests\]/
-    timeout_in_minutes: 120
-    matrix:
-      setup:
-        julia:
-          - "1.11"
-          - "1.12"
-    soft_fail:
-      - exit_status: 3
+  #               println("+++ :julia: Running tests")
+  #               Pkg.test(; coverage=true)'
+  #   agents:
+  #     queue: "cuda"
+  #   if: build.message !~ /\[skip tests\]/
+  #   timeout_in_minutes: 120
+  #   matrix:
+  #     setup:
+  #       julia:
+  #         - "1.11"
+  #         - "1.12"
+  #   soft_fail:
+  #     - exit_status: 3
 
-  - label: "AMDGPU.jl -- Julia {{matrix.julia}}"
-    plugins:
-      - JuliaCI/julia#v1:
-          version: "{{matrix.julia}}"
-      - JuliaCI/julia-coverage#v1:
-          codecov: true
-    command: |
-      julia -e 'using Pkg
+  # - label: "AMDGPU.jl -- Julia {{matrix.julia}}"
+  #   plugins:
+  #     - JuliaCI/julia#v1:
+  #         version: "{{matrix.julia}}"
+  #     - JuliaCI/julia-coverage#v1:
+  #         codecov: true
+  #   command: |
+  #     julia -e 'using Pkg
 
-                gpuarrays = pwd()
-                gpuarrayscore = joinpath(gpuarrays, "lib", "GPUArraysCore")
-                devdir = mktempdir()
-                package = joinpath(devdir, "AMDGPU")
+  #               gpuarrays = pwd()
+  #               gpuarrayscore = joinpath(gpuarrays, "lib", "GPUArraysCore")
+  #               devdir = mktempdir()
+  #               package = joinpath(devdir, "AMDGPU")
 
-                println("--- :julia: Installing TestEnv")
-                Pkg.activate(; temp=true)
-                Pkg.add("TestEnv")
-                using TestEnv
+  #               println("--- :julia: Installing TestEnv")
+  #               Pkg.activate(; temp=true)
+  #               Pkg.add("TestEnv")
+  #               using TestEnv
 
-                println("--- :julia: Installing AMDGPU.jl")
-                withenv("JULIA_PKG_PRECOMPILE_AUTO" => 0,
-                        "JULIA_PKG_DEVDIR" => devdir) do
-                  Pkg.develop("AMDGPU")
-                  Pkg.activate(package)
+  #               println("--- :julia: Installing AMDGPU.jl")
+  #               withenv("JULIA_PKG_PRECOMPILE_AUTO" => 0,
+  #                       "JULIA_PKG_DEVDIR" => devdir) do
+  #                 Pkg.develop("AMDGPU")
+  #                 Pkg.activate(package)
 
-                  try
-                    Pkg.develop([PackageSpec(path=gpuarrays), PackageSpec(path=gpuarrayscore)])
-                    TestEnv.activate()
-                  catch err
-                    @error "Could not install AMDGPU.jl" exception=(err,catch_backtrace())
-                    exit(3)
-                  finally
-                    Pkg.activate(package)
-                  end
-                end
+  #                 try
+  #                   Pkg.develop([PackageSpec(path=gpuarrays), PackageSpec(path=gpuarrayscore)])
+  #                   TestEnv.activate()
+  #                 catch err
+  #                   @error "Could not install AMDGPU.jl" exception=(err,catch_backtrace())
+  #                   exit(3)
+  #                 finally
+  #                   Pkg.activate(package)
+  #                 end
+  #               end
 
-                println("+++ :julia: Running tests")
-                Pkg.test(; coverage=true)'
-    agents:
-      queue: "rocm"
-      rocmgpu: "*"
-    if: build.message !~ /\[skip tests\]/
-    timeout_in_minutes: 120
-    matrix:
-      setup:
-        julia:
-          - "1.10"
-          - "1.11"
-          - "1.12"
-    soft_fail:
-      - exit_status: 3
+  #               println("+++ :julia: Running tests")
+  #               Pkg.test(; coverage=true)'
+  #   agents:
+  #     queue: "rocm"
+  #     rocmgpu: "*"
+  #   if: build.message !~ /\[skip tests\]/
+  #   timeout_in_minutes: 120
+  #   matrix:
+  #     setup:
+  #       julia:
+  #         - "1.10"
+  #         - "1.11"
+  #         - "1.12"
+  #   soft_fail:
+  #     - exit_status: 3
 
-  - label: "oneAPI.jl -- Julia {{matrix.julia}}"
-    plugins:
-      - JuliaCI/julia#v1:
-          version: "{{matrix.julia}}"
-      - JuliaCI/julia-coverage#v1:
-          codecov: true
-    command: |
-      julia -e 'using Pkg
+  # - label: "oneAPI.jl -- Julia {{matrix.julia}}"
+  #   plugins:
+  #     - JuliaCI/julia#v1:
+  #         version: "{{matrix.julia}}"
+  #     - JuliaCI/julia-coverage#v1:
+  #         codecov: true
+  #   command: |
+  #     julia -e 'using Pkg
 
-                gpuarrays = pwd()
-                gpuarrayscore = joinpath(gpuarrays, "lib", "GPUArraysCore")
-                devdir = mktempdir()
-                package = joinpath(devdir, "oneAPI")
+  #               gpuarrays = pwd()
+  #               gpuarrayscore = joinpath(gpuarrays, "lib", "GPUArraysCore")
+  #               devdir = mktempdir()
+  #               package = joinpath(devdir, "oneAPI")
 
-                println("--- :julia: Installing TestEnv")
-                Pkg.activate(; temp=true)
-                Pkg.add("TestEnv")
-                using TestEnv
+  #               println("--- :julia: Installing TestEnv")
+  #               Pkg.activate(; temp=true)
+  #               Pkg.add("TestEnv")
+  #               using TestEnv
 
-                println("--- :julia: Installing oneAPI.jl")
-                withenv("JULIA_PKG_PRECOMPILE_AUTO" => 0,
-                        "JULIA_PKG_DEVDIR" => devdir) do
-                  Pkg.develop("oneAPI")
-                  include(joinpath(package, "deps", "build_ci.jl"))
-                  Pkg.activate(package)
+  #               println("--- :julia: Installing oneAPI.jl")
+  #               withenv("JULIA_PKG_PRECOMPILE_AUTO" => 0,
+  #                       "JULIA_PKG_DEVDIR" => devdir) do
+  #                 Pkg.develop("oneAPI")
+  #                 include(joinpath(package, "deps", "build_ci.jl"))
+  #                 Pkg.activate(package)
 
-                  try
-                    Pkg.develop([PackageSpec(path=gpuarrays), PackageSpec(path=gpuarrayscore)])
-                    TestEnv.activate()
-                  catch err
-                    @error "Could not install oneAPI.jl" exception=(err,catch_backtrace())
-                    exit(3)
-                  finally
-                    Pkg.activate(package)
-                  end
-                end
+  #                 try
+  #                   Pkg.develop([PackageSpec(path=gpuarrays), PackageSpec(path=gpuarrayscore)])
+  #                   TestEnv.activate()
+  #                 catch err
+  #                   @error "Could not install oneAPI.jl" exception=(err,catch_backtrace())
+  #                   exit(3)
+  #                 finally
+  #                   Pkg.activate(package)
+  #                 end
+  #               end
 
-                println("+++ :julia: Running tests")
-                Pkg.test(; coverage=true)'
-    agents:
-      queue: "oneapi"
-    if: build.message !~ /\[skip tests\]/
-    timeout_in_minutes: 60
-    matrix:
-      setup:
-        julia:
-          - "1.10"
-          - "1.11"
-          - "1.12"
-    soft_fail:
-      - exit_status: 3
+  #               println("+++ :julia: Running tests")
+  #               Pkg.test(; coverage=true)'
+  #   agents:
+  #     queue: "oneapi"
+  #   if: build.message !~ /\[skip tests\]/
+  #   timeout_in_minutes: 60
+  #   matrix:
+  #     setup:
+  #       julia:
+  #         - "1.10"
+  #         - "1.11"
+  #         - "1.12"
+  #   soft_fail:
+  #     - exit_status: 3
 
   - label: "Metal.jl -- Julia {{matrix.julia}}"
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -251,7 +251,7 @@ steps:
                 end
 
                 println("+++ :julia: Running tests")
-                Pkg.test(; coverage=true, test_args=`--verbose --all --all-eltypes`)'
+                Pkg.test(; coverage=true, test_args=`--verbose --all`)'
     agents:
       queue: "metal"
     if: build.message !~ /\[skip tests\]/

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -250,7 +250,7 @@ steps:
                 end
 
                 println("+++ :julia: Running tests")
-                Pkg.test(; coverage=true, test_args=`--all`)'
+                Pkg.test(; coverage=true, test_args=`--verbose --all`)'
     agents:
       queue: "metal"
     if: build.message !~ /\[skip tests\]/

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -235,7 +235,8 @@ steps:
                 println("--- :julia: Installing Metal.jl")
                 withenv("JULIA_PKG_PRECOMPILE_AUTO" => 0,
                         "JULIA_PKG_DEVDIR" => devdir) do
-                  Pkg.add(url="https://github.com/JuliaGPU/Metal.jl", rev="testsubset")
+                  run(Cmd(["git", "clone", "--depth=1", "--branch", "testsubset",
+                           "https://github.com/JuliaGPU/Metal.jl", package]))
                   Pkg.activate(package)
 
                   try

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -251,7 +251,7 @@ steps:
                 end
 
                 println("+++ :julia: Running tests")
-                Pkg.test(; coverage=true, test_args=`--verbose --all`)'
+                Pkg.test(; coverage=true, test_args=`--verbose --all --all-eltypes`)'
     agents:
       queue: "metal"
     if: build.message !~ /\[skip tests\]/

--- a/test/testsuite.jl
+++ b/test/testsuite.jl
@@ -95,7 +95,9 @@ function trim_eltypes(eltypes, testall)
         isempty(matched) || push!(trimmed, rand(matched))
         remaining = filter(!category, remaining)
     end
-    return vcat(trimmed, remaining)
+    types_to_use = vcat(trimmed, remaining)
+    @show types_to_use
+    return types_to_use
 end
 
 # derived sparse container types that are supported by the array type

--- a/test/testsuite.jl
+++ b/test/testsuite.jl
@@ -76,6 +76,28 @@ supported_eltypes() = (Int16, Int32, Int64,
                        ComplexF16, ComplexF32, ComplexF64,
                        Complex{Int16}, Complex{Int32}, Complex{Int64})
 
+# Bin eltypes to reduce tests while keeping coverage: keep one randomly-chosen
+# eltype per category, plus any eltypes that don't fit a category.
+function trim_eltypes(eltypes, testall)
+    categories = (
+        T -> T <: Integer && sizeof(T) < 4 && T != Bool, # small ints not Bool
+        T -> T <: Integer && sizeof(T) >= 4,             # big ints
+        T -> T == Float32,                               # float32
+        T -> T <: AbstractFloat && T != Float32,         # other floats
+        T -> T <: Complex{<:AbstractFloat},              # Complex float
+        T -> T <: Complex{<:Integer},                    # Complex int
+    )
+    remaining = unique(eltypes)
+    testall && return remaining
+    trimmed = Type[]
+    for category in categories
+        matched = filter(category, remaining)
+        isempty(matched) || push!(trimmed, rand(matched))
+        remaining = filter(!category, remaining)
+    end
+    return vcat(trimmed, remaining)
+end
+
 # derived sparse container types that are supported by the array type
 sparse_types(::Type{AT}) where {AT} = ()
 
@@ -95,7 +117,7 @@ macro testsuite(name, ex)
     quote
         # the supported element types can be overrided by passing in a different set,
         # or by specializing the `supported_eltypes` function on the array type and test.
-        $(esc(fn))(AT; eltypes=supported_eltypes(AT, $(esc(fn)))) = $(esc(ex))(AT, eltypes)
+        $(esc(fn))(AT; eltypes=supported_eltypes(AT, $(esc(fn))), testall=true) = $(esc(ex))(AT, $(trim_eltypes)(eltypes, testall))
 
         @assert !haskey(tests, $name)
         tests[$name] = $fn


### PR DESCRIPTION
Sorts out supported eltypes into biins and only picks one per bin to run tests on.

Current questions:
- Bins make sense?
- Need to be more reproducible or is it fine to have someone run the full testuite to reproduce?
- If a backend implements it, testsuite won't be able to run on older GPUArrays testsuites

Locally on Metal.jl I went from 8 minutes to 6