### PR TITLE
[CI] Minor testsuite improvements

### DIFF
--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -454,6 +454,43 @@ end
     @testset "$T, $opa, $opb" for T in eltypes, opa in (vec, identity, transpose, adjoint), opb in (vec, identity, transpose, adjoint)
         @test compare(kron, AT, opa(rand(T, 16, 32)), opb(rand(T, 64, 8)))
     end
+
+    # Diagonal
+    @testset "$T" for T in filter(T -> T == Float32 || T == Float64, eltypes)
+        n, m = 16, 8
+        a, b = rand(T, n), rand(T, m)
+
+        # Diagonal*Diagonal
+        R = kron(Diagonal(adapt(AT, a)), Diagonal(adapt(AT, b)))
+        @test R isa Diagonal
+        @test Array(R.diag) ≈ kron(a, b)
+
+        # Diagonal*Dense
+        B = rand(T, m, m)
+        R2 = kron(Diagonal(adapt(AT, a)), adapt(AT, B))
+        @test Array(R2) ≈ kron(Matrix(Diagonal(a)), B)
+
+        # Dense*Diagonal
+        A = rand(T, n, n)
+        R3 = kron(adapt(AT, A), Diagonal(adapt(AT, b)))
+        @test Array(R3) ≈ kron(A, Matrix(Diagonal(b)))
+
+        # kron! Diagonal*Diagonal
+        C1 = Diagonal(adapt(AT, zeros(T, n * m)))
+        kron!(C1, Diagonal(adapt(AT, a)), Diagonal(adapt(AT, b)))
+        @test C1 isa Diagonal
+        @test Array(C1.diag) ≈ kron(a, b)
+
+        # kron! Diagonal*Dense
+        C2 = adapt(AT, zeros(T, n * m, n * m))
+        kron!(C2, Diagonal(adapt(AT, a)), adapt(AT, B))
+        @test Array(C2) ≈ kron(Matrix(Diagonal(a)), B)
+
+        # kron! Dense*Diagonal
+        C3 = adapt(AT, zeros(T, n * m, n * m))
+        kron!(C3, adapt(AT, A), Diagonal(adapt(AT, b)))
+        @test Array(C3) ≈ kron(A, Matrix(Diagonal(b)))
+    end
 end
 
 @testsuite "linalg/diagonal" (AT, eltypes) -> begin
@@ -871,43 +908,5 @@ end
             y = invoke(GPUArrays.generic_matmatmul!, Tuple{AbstractArray, AbstractArray, AbstractArray, Number, Number}, adapt(AT, fill(NaN_T(T), 3, 3)), adapt(AT, fill(NaN_T(T), 3, 3)), adapt(AT, fill(NaN_T(T), 3, 3)), false, false)
             @test !any(isnan, collect(y))
         end
-    end
-end
-
-@testsuite "linalg/kron_diagonal" (AT, eltypes) -> begin
-    for T in filter(T -> T == Float32 || T == Float64, eltypes)
-        n, m = 16, 8
-        a, b = rand(T, n), rand(T, m)
-
-        # Diagonal*Diagonal
-        R = kron(Diagonal(adapt(AT, a)), Diagonal(adapt(AT, b)))
-        @test R isa Diagonal
-        @test Array(R.diag) ≈ kron(a, b)
-
-        # Diagonal*Dense
-        B = rand(T, m, m)
-        R2 = kron(Diagonal(adapt(AT, a)), adapt(AT, B))
-        @test Array(R2) ≈ kron(Matrix(Diagonal(a)), B)
-
-        # Dense*Diagonal
-        A = rand(T, n, n)
-        R3 = kron(adapt(AT, A), Diagonal(adapt(AT, b)))
-        @test Array(R3) ≈ kron(A, Matrix(Diagonal(b)))
-
-        # kron! Diagonal*Diagonal
-        C1 = Diagonal(adapt(AT, zeros(T, n * m)))
-        kron!(C1, Diagonal(adapt(AT, a)), Diagonal(adapt(AT, b)))
-        @test C1 isa Diagonal
-        @test Array(C1.diag) ≈ kron(a, b)
-
-        # kron! Diagonal*Dense
-        C2 = adapt(AT, zeros(T, n * m, n * m))
-        kron!(C2, Diagonal(adapt(AT, a)), adapt(AT, B))
-        @test Array(C2) ≈ kron(Matrix(Diagonal(a)), B)
-
-        # kron! Dense*Diagonal
-        C3 = adapt(AT, zeros(T, n * m, n * m))
-        kron!(C3, adapt(AT, A), Diagonal(adapt(AT, b)))
-        @test Array(C3) ≈ kron(A, Matrix(Diagonal(b)))
     end
 end

--- a/test/testsuite/linalg.jl
+++ b/test/testsuite/linalg.jl
@@ -659,7 +659,8 @@ end
     end
 end
 
-@testsuite "linalg/mul!/vector-matrix" (AT, eltypes)->begin
+@testsuite "linalg/mul!/gemm" (AT, eltypes)->begin
+    # vector-matrix
     @testset "$T gemv y := $f(A) * x * a + y * b" for f in (identity, transpose, adjoint), T in eltypes
         y, A, x = rand(T, 4), rand(T, 4, 4), rand(T, 4)
 
@@ -675,9 +676,8 @@ end
             @test compare(mul!, AT, rand(T, 2,2), rand(T, 2,1), f(rand(T, 2)))
         end
     end
-end
 
-@testsuite "linalg/mul!/matrix-matrix" (AT, eltypes)->begin
+    # matrix-matrix
     @testset "$T gemm C := $f(A) * $g(B) * a + C * b" for f in (identity, transpose, adjoint), g in (identity, transpose, adjoint), T in eltypes
         A, B, C = rand(T, 4, 4), rand(T, 4, 4), rand(T, 4, 4)
 

--- a/test/testsuite/math.jl
+++ b/test/testsuite/math.jl
@@ -16,7 +16,7 @@
 
     # power
     for ET in eltypes
-        for p in 0:5
+        for p in [0,1,2,5]
             @test compare(x->x^p, AT, rand(ET, 2,2))
         end
     end

--- a/test/testsuite/math.jl
+++ b/test/testsuite/math.jl
@@ -1,4 +1,5 @@
-@testsuite "math/intrinsics" (AT, eltypes)->begin
+@testsuite "math" (AT, eltypes)->begin
+    # clamp
     for ET in filter(!iscomplextype, eltypes)
         T = AT{ET}
         @testset "$ET" begin
@@ -12,9 +13,8 @@
             end
         end
     end
-end
 
-@testsuite "math/power" (AT, eltypes)->begin
+    # power
     for ET in eltypes
         for p in 0:5
             @test compare(x->x^p, AT, rand(ET, 2,2))


### PR DESCRIPTION
Combines a few testsets and reduces number of power tests.

Combining the vector-matrix and matrix-matrix tests helps to reduce duplicated compilation, while the rest only save on (minimal) launch overhead but they were 2 smaller testsets