### PR TITLE
[JLArrays] Revert a couple changes to unbreak downstream CI

### DIFF
--- a/lib/JLArrays/Project.toml
+++ b/lib/JLArrays/Project.toml
@@ -1,7 +1,7 @@
 name = "JLArrays"
 uuid = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
-authors = ["Tim Besard <tim.besard@gmail.com>"]
 version = "0.3.2"
+authors = ["Tim Besard <tim.besard@gmail.com>"]
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
@@ -14,7 +14,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 [compat]
 Adapt = "2.0, 3.0, 4.0"
 GPUArrays = "11.1"
-KernelAbstractions = "0.9, 0.10"
+KernelAbstractions = "0.9"
 LinearAlgebra = "1"
 Random = "1"
 SparseArrays = "1"

--- a/lib/JLArrays/Project.toml
+++ b/lib/JLArrays/Project.toml
@@ -1,6 +1,6 @@
 name = "JLArrays"
 uuid = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Tim Besard <tim.besard@gmail.com>"]
 
 [deps]

--- a/lib/JLArrays/src/JLArrays.jl
+++ b/lib/JLArrays/src/JLArrays.jl
@@ -323,11 +323,9 @@ StridedJLVector{T} = StridedJLArray{T,1}
 StridedJLMatrix{T} = StridedJLArray{T,2}
 StridedJLVecOrMat{T} = Union{StridedJLVector{T}, StridedJLMatrix{T}}
 
-# Pointer access is only available for callers that explicitly want a pointer.
-Base.pointer(x::JLArray{T}) where {T} =
-    convert(Ptr{T}, pointer(x.data[])) + x.offset
-@inline function Base.pointer(x::JLArray{T}, i::Integer) where T
-    pointer(x) + (i - 1) * sizeof(T)
+Base.pointer(x::StridedJLArray{T}) where {T} = Base.unsafe_convert(Ptr{T}, x)
+@inline function Base.pointer(x::StridedJLArray{T}, i::Integer) where T
+    Base.unsafe_convert(Ptr{T}, x) + Base._memory_offset(x, i)
 end
 
 # anything that's (secretly) backed by a JLArray
@@ -344,10 +342,8 @@ Base.elsize(::Type{<:JLArray{T}}) where {T} = sizeof(T)
 Base.size(x::JLArray) = x.dims
 Base.sizeof(x::JLArray) = Base.elsize(x) * length(x)
 
-# Reject implicit conversions to a pointer, i.e., by passing to a CPU ccall.
-function Base.unsafe_convert(::Type{Ptr{T}}, x::JLArray{T}) where {T}
-    error("Illegal conversion of a JLArray to a Ptr")
-end
+Base.unsafe_convert(::Type{Ptr{T}}, x::JLArray{T}) where {T} =
+    convert(Ptr{T}, pointer(x.data[])) + x.offset
 
 
 ## interop with Julia arrays


### PR DESCRIPTION
The KA 0.10 interface has changed so it's no longer true. Also revert the pointer change to be reapplied in a breaking release of JLArrays

Unlike the real GPU backends, JLArrays support for KernelInterface will depend on KA 0.10 since it'll rely on the new POCLBackend

Should wait for https://github.com/JuliaRegistries/General/pull/165667 before merging/registering

Close #757